### PR TITLE
feat(release): Use github actions to release binaries

### DIFF
--- a/.github/releaser.sh
+++ b/.github/releaser.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# Trigger release action on new release
+
+if [ -z "$1" ]; then
+    echo "Please provide a version number."
+    echo "Usages: $0 v[X.Y.Z]"
+    exit 1
+fi
+
+version=$1
+
+git tag "v$version"
+git push origin "v$version"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,93 @@
+name: Continuous Deployment
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  publish-github:
+    name: Publish on GitHub
+    runs-on: ${{ matrix.config.OS }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - { OS: ubuntu-latest, TARGET: "x86_64-unknown-linux-gnu" }
+          - { OS: ubuntu-latest, TARGET: "x86_64-unknown-linux-musl" }
+          - { OS: ubuntu-latest, TARGET: "i686-unknown-linux-gnu" }
+          - { OS: ubuntu-latest, TARGET: "i686-unknown-linux-musl" }
+          - { OS: ubuntu-latest, TARGET: "armv5te-unknown-linux-gnueabi" }
+          - { OS: ubuntu-latest, TARGET: "armv7-unknown-linux-gnueabihf" }
+          - { OS: ubuntu-latest, TARGET: "aarch64-unknown-linux-gnu" }
+          - { OS: ubuntu-latest, TARGET: "aarch64-unknown-linux-musl" }
+          - { OS: macos-latest, TARGET: "x86_64-apple-darwin" }
+          - { OS: macos-latest, TARGET: "aarch64-apple-darwin" }
+          - { OS: windows-latest, TARGET: "x86_64-pc-windows-msvc" }
+          - { OS: windows-latest, TARGET: "i686-pc-windows-msvc" }
+
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+
+      - name: Set the release version
+        shell: bash
+        run: echo "RELEASE_VERSION=${GITHUB_REF:11}" >> $GITHUB_ENV
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.config.TARGET }}
+          override: true
+
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: --release --locked --target ${{ matrix.config.TARGET }}
+
+      - name: Prepare release assets
+        shell: bash
+        run: |
+          mkdir release/
+          cp {LICENSE,README.md} release/
+          cp target/${{ matrix.config.TARGET }}/release/presenterm release/
+          mv release/ presenterm-${{ env.RELEASE_VERSION }}/
+
+      - name: Create release artifacts
+        shell: bash
+        run: |
+          if [ "${{ matrix.config.OS }}" = "windows-latest" ]; then
+            7z a -tzip "presenterm-${{ env.RELEASE_VERSION }}-${{ matrix.config.TARGET }}.zip" \
+              presenterm-${{ env.RELEASE_VERSION }}
+          else
+            tar -czvf presenterm-${{ env.RELEASE_VERSION }}-${{ matrix.config.TARGET }}.tar.gz \
+              presenterm-${{ env.RELEASE_VERSION }}/
+            shasum -a 512 presenterm-${{ env.RELEASE_VERSION }}-${{ matrix.config.TARGET }}.tar.gz \
+              > presenterm-${{ env.RELEASE_VERSION }}-${{ matrix.config.TARGET }}.tar.gz.sha512
+          fi
+
+      - name: Upload the release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: presenterm-${{ env.RELEASE_VERSION }}-${{ matrix.config.TARGET }}.*
+          file_glob: true
+          overwrite: true
+          tag: ${{ github.ref }}
+
+  publish-crates-io:
+    name: Publish on crates.io
+    needs: publish-github
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+
+      - name: Publish
+        uses: actions-rs/cargo@v1
+        with:
+          command: publish
+          args: --locked --token ${{ secrets.CARGO_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,6 +231,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "colored"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2674ec482fbc38012cf31e6c42ba0177b431a0cb6f15fe40efa5aab1bda516f6"
+dependencies = [
+ "is-terminal",
+ "lazy_static",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "comrak"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -720,6 +731,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+dependencies = [
+ "hermit-abi",
+ "rustix",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1009,6 +1031,7 @@ name = "presenterm"
 version = "0.2.0"
 dependencies = [
  "clap",
+ "colored",
  "comrak",
  "crossterm",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ strum = { version = "0.25", features = ["derive"] }
 thiserror = "1"
 unicode-width = "0.1"
 viuer = "0.7.1"
+colored = "2.0.4"
 
 [dev-dependencies]
 rstest = { version = "0.18", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,23 @@ rstest = { version = "0.18", default-features = false }
 [features]
 default = []
 sixel = ["viuer/sixel"]
+
+[profile.dev]
+opt-level = 0
+debug = true
+panic = "abort"
+
+[profile.test]
+opt-level = 0
+debug = true
+
+[profile.release]
+opt-level = 3
+debug = false
+panic = "unwind"
+lto = true
+codegen-units = 1
+
+[profile.bench]
+opt-level = 3
+debug = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.2.0"
 edition = "2021"
 
 [dependencies]
-clap = { version = "4.4", features = ["derive"] }
+clap = { version = "4.4", features = ["derive", "string"] }
 comrak = { version = "0.19", default-features = false }
 crossterm = { version = "0.27", features = ["serde"] }
 hex = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,3 +12,4 @@ pub mod render;
 pub mod resource;
 pub mod style;
 pub mod theme;
+pub mod splash;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,12 +6,15 @@ use presenterm::{
     presenter::{PresentMode, Presenter},
     render::highlighting::CodeHighlighter,
     resource::Resources,
+    splash::show_splashes,
     theme::PresentationTheme,
 };
 use std::path::{Path, PathBuf};
 
 /// Run slideshows from your terminal.
 #[derive(Parser)]
+#[command()]
+#[command(author, version, about = show_splashes(), long_about = show_splashes(), arg_required_else_help = true)]
 struct Cli {
     /// The path to the markdown file that contains the presentation.
     path: PathBuf,

--- a/src/splash.rs
+++ b/src/splash.rs
@@ -1,0 +1,19 @@
+use colored::Colorize;
+
+pub fn show_splashes() -> String {
+    let crate_version = env!("CARGO_PKG_VERSION");
+
+    let logo = format!(
+        r#"
+  ┌─┐┬─┐┌─┐┌─┐┌─┐┌┐┌┌┬┐┌─┐┬─┐┌┬┐
+  ├─┘├┬┘├┤ └─┐├┤ │││ │ ├┤ ├┬┘│││
+  ┴  ┴└─└─┘└─┘└─┘┘└┘ ┴ └─┘┴└─┴ ┴ v{}
+    A terminal slideshow tool 
+                    @mfontanini/presenterm
+"#,
+        crate_version,
+    )
+    .bold()
+    .purple();
+    format!("{logo}")
+}


### PR DESCRIPTION
HelloW,  You got a really nice project there. Congrats on that :clinking_glasses: 

This pr will allow you to use github actions and release binaries of `presenterm` .

Few notes :

1. Don't forget to add `CARGO_TOKEN` as secret before merge for [`crates.io`](https://crates.io) releases
2. Consider adding a `CHANGELOG.md`, You can use [`git-cliff`](https://git-cliff.org) for that. I'm not super familiar with this but still you can get some idea from my [`repos`](https://github.com/pwnwriter)

3. Allow github actions to publish 

----

Image -> 

![screenshot_2023-10-18_10-57-01](https://github.com/mfontanini/presenterm/assets/90331517/cb91f34c-e4e2-474c-9983-bc45cbf221cb)

---- 

The process would go like this . Tested [`here`](https://github.com/pwnwriter/presenterm/releases)

![screenshot_2023-10-18_11-06-01](https://github.com/mfontanini/presenterm/assets/90331517/33bfcd17-eb63-4a34-8d82-f24c75c9d696)

4. I added `cargo` profiles for `release,bench,test,dev`. It was helping me a lot to minimize the binary size and test with minimal efforts. 

Feel free to make changes <3 


