### PR TITLE
feat(install): Arch user repository pkgbuilds // installation guide

### DIFF
--- a/.github/PKGBUILDS/presenterm-bin/.SRCINFO
+++ b/.github/PKGBUILDS/presenterm-bin/.SRCINFO
@@ -1,0 +1,11 @@
+pkgbase = presenterm-bin
+	pkgdesc = A terminal slideshow tool
+	pkgver = 0.2.1
+	pkgrel = 1
+	url = https://github.com/mfontanini/presenterm
+	arch = x86_64
+	license = BSD 2-Clause
+	source = presenterm-bin-0.2.1.tar.gz::https://github.com/mfontanini/presenterm/releases/download/v0.2.1/presenterm-0.2.1-x86_64-unknown-linux-gnu.tar.gz
+	sha512sums = 6f1f76b208b2586aee6ef6884699866ca8f22fc242a7cc83b767fff3e3d8fc22bfebd2fd25151e87faf88fe352758c4877823726dc41ce8390e481038dfa56e5
+
+pkgname = presenterm-bin

--- a/.github/PKGBUILDS/presenterm-bin/PKGBUILD
+++ b/.github/PKGBUILDS/presenterm-bin/PKGBUILD
@@ -1,0 +1,23 @@
+# Maintainer: pwnwriter < hey@pwnwriter.xyz >
+
+pkgname=presenterm-bin
+pkgver=0.2.1
+pkgrel=1
+pkgdesc="A terminal slideshow tool"
+arch=('x86_64')
+url="https://github.com/mfontanini/presenterm"
+license=('BSD 2-Clause')
+source=("$pkgname-$pkgver.tar.gz::$url/releases/download/v$pkgver/presenterm-$pkgver-x86_64-unknown-linux-gnu.tar.gz")
+sha512sums=('6f1f76b208b2586aee6ef6884699866ca8f22fc242a7cc83b767fff3e3d8fc22bfebd2fd25151e87faf88fe352758c4877823726dc41ce8390e481038dfa56e5')
+
+build() {
+  # Nothing to do here for a binary package
+  return 0
+}
+
+package() {
+  cd "${pkgname%-bin}-$pkgver"
+  install -Dm 755 "${pkgname%-bin}" -t "${pkgdir}/usr/bin"
+  install -Dm 644 "README.md" "$pkgdir/usr/share/doc/$pkgname/README.md"
+  install -Dm 644 "LICENSE" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}

--- a/.github/PKGBUILDS/presenterm-git/.SRCINFO
+++ b/.github/PKGBUILDS/presenterm-git/.SRCINFO
@@ -1,0 +1,15 @@
+pkgbase = presenterm-git
+	pkgdesc = A terminal slideshow tool
+	pkgver = 0.2.1.r1.g0f901be
+	pkgrel = 1
+	url = https://github.com/mfontanini/presenterm
+	arch = x86_64
+	license = BSD 2-Clause
+	makedepends = cargo
+	makedepends = git
+	provides = presenterm
+	conflicts = presenterm
+	source = git+https://github.com/mfontanini/presenterm
+	sha512sums = SKIP
+
+pkgname = presenterm-git

--- a/.github/PKGBUILDS/presenterm-git/PKGBUILD
+++ b/.github/PKGBUILDS/presenterm-git/PKGBUILD
@@ -1,0 +1,41 @@
+# Maintainer: PwnWriter <hey@pwnwriter.xyz>
+
+pkgname=presenterm-git
+pkgver=0.2.1.r1.g0f901be
+pkgrel=1
+pkgdesc="A terminal slideshow tool"
+arch=('x86_64')
+url="https://github.com/mfontanini/presenterm"
+license=('BSD 2-Clause')
+makedepends=('cargo' 'git')
+conflicts=("${pkgname%-git}")
+provides=("${pkgname%-git}")
+source=("git+${url}")
+sha512sums=('SKIP')
+
+pkgver() {
+  cd "${pkgname%-git}"
+  git describe --long --tags | sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g'
+}
+
+prepare() {
+  cd "${pkgname%-git}"
+  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
+}
+
+build() {
+  cd "${pkgname%-git}"
+  cargo build --release --frozen
+}
+
+check() {
+  cd "${pkgname%-git}"
+  cargo test --frozen
+}
+
+package() {
+  cd "${pkgname%-git}"
+  install -Dm 755 "target/release/${pkgname%-git}" -t "${pkgdir}/usr/bin"
+  install -Dm 644 README.md -t "$pkgdir/usr/share/doc/$pkgname"
+  install -Dm 644 LICENSE -t "$pkgdir/usr/share/licenses/$pkgname"
+}

--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ cargo build --release
 
 The output binary will be in `./target/release/presenterm`.
 
+## Arch user repository
+presenterm is in the aur as well, So if you have any AUR helpers like paru/yay. You can install it as follows
+
+```bash
+paru/yay -S presenterm-bin # for binary
+paru/yay -S presenterm-git # for Building from source
+```
+
 # Features
 
 * Define your presentation in a single markdown file.


### PR DESCRIPTION
I just packaged `presenterm` for [**aur**](https://aur.archlinux.org/). Any arch or based user can install it using aur helpers like yay/paru. 