### PR TITLE
Don't crash if terminal window size can't be found

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,13 +112,15 @@ _presenterm_ with the `sixel` feature flag, which is disabled by default. You ca
 cargo build --release --features sixel
 ```
 
-> **Note**: this feature flag is only needed if your terminal emulator only supports sixel. many terminals support the kitty or iterm2 protocols so this isn't necessary.
+> **Note**: this feature flag is only needed if your terminal emulator only supports sixel. Many terminals support the kitty or iterm2 protocols so this isn't necessary.
 
 Images are rendered **in their default size**. This means if your terminal window is 100 pixels wide and your image is 
 50 pixels wide, it will take up 50% of the width. If an image does not fit in the screen, it will be scaled down to fit 
 it.
 
 ![](assets/demo-image.png)
+
+> **Note**: image rendering is currently not supported on Windows.
 
 ## Themes
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -101,11 +101,7 @@ impl<'a> PresentationBuilder<'a> {
         }
         self.needs_enter_column = false;
         let last_valid = matches!(last, RenderOperation::EnterColumn { .. } | RenderOperation::ExitLayout);
-        if last_valid {
-            Ok(())
-        } else {
-            Err(BuildError::NotInsideColumn)
-        }
+        if last_valid { Ok(()) } else { Err(BuildError::NotInsideColumn) }
     }
 
     fn push_slide_prelude(&mut self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,6 @@ pub mod presentation;
 pub mod presenter;
 pub mod render;
 pub mod resource;
+pub mod splash;
 pub mod style;
 pub mod theme;
-pub mod splash;

--- a/src/render/layout.rs
+++ b/src/render/layout.rs
@@ -161,7 +161,7 @@ mod test {
         Positioning{ max_line_length: 60, start_column: 20 }
     )]
     fn layout(#[case] alignment: Alignment, #[case] length: u16, #[case] expected: Positioning) {
-        let dimensions = WindowSize { rows: 0, columns: 100, width: 0, height: 0 };
+        let dimensions = WindowSize { rows: 0, columns: 100, width: 0, height: 0, has_pixels: true };
         let positioning = Layout::new(alignment).compute(&dimensions, length);
         assert_eq!(positioning, expected);
     }

--- a/src/render/media.rs
+++ b/src/render/media.rs
@@ -44,6 +44,9 @@ impl MediaRender {
         position: CursorPosition,
         dimensions: &WindowSize,
     ) -> Result<(), RenderImageError> {
+        if !dimensions.has_pixels {
+            return Err(RenderImageError::NoWindowSize);
+        }
         let image = &image.0;
 
         // Compute the image's width in columns by translating pixels -> columns.
@@ -97,4 +100,7 @@ pub enum RenderImageError {
 
     #[error("invalid image: {0}")]
     InvalidImage(#[from] InvalidImage),
+
+    #[error("no window size support in terminal")]
+    NoWindowSize,
 }

--- a/src/render/terminal.rs
+++ b/src/render/terminal.rs
@@ -94,6 +94,7 @@ where
     fn drop(&mut self) {
         let _ = self.writer.queue(terminal::LeaveAlternateScreen);
         let _ = self.writer.queue(cursor::Show);
+        let _ = self.writer.flush();
         let _ = terminal::disable_raw_mode();
     }
 }


### PR DESCRIPTION
This patches the issue brought up in #13. Images can't be rendered on windows (and this will lead to an error running the presentation) but at least the rest of the operations should work.