### PR TITLE
Don't reset ordered list number after pause

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -67,12 +67,8 @@ impl ContentDiff for RenderOperation {
 
         match (self, other) {
             (SetColors(original), SetColors(updated)) if original != updated => false,
-            (RenderTextLine { line: original, .. }, RenderTextLine { line: updated, .. }) if original != updated => {
-                true
-            }
-            (RenderTextLine { alignment: original, .. }, RenderTextLine { alignment: updated, .. })
-                if original != updated =>
-            {
+            (RenderText { line: original, .. }, RenderText { line: updated, .. }) if original != updated => true,
+            (RenderText { alignment: original, .. }, RenderText { alignment: updated, .. }) if original != updated => {
                 false
             }
             (RenderImage(original), RenderImage(updated)) if original != updated => true,
@@ -130,7 +126,7 @@ mod test {
     #[case(RenderOperation::JumpToBottom)]
     #[case(RenderOperation::RenderLineBreak)]
     #[case(RenderOperation::SetColors(Colors{background: None, foreground: None}))]
-    #[case(RenderOperation::RenderTextLine{line: String::from("asd").into(), alignment: Default::default()})]
+    #[case(RenderOperation::RenderText{line: String::from("asd").into(), alignment: Default::default()})]
     #[case(RenderOperation::RenderPreformattedLine(
         PreformattedLine{
             text: "asd".into(),
@@ -147,18 +143,18 @@ mod test {
 
     #[test]
     fn different_text() {
-        let lhs = RenderOperation::RenderTextLine { line: String::from("foo").into(), alignment: Default::default() };
-        let rhs = RenderOperation::RenderTextLine { line: String::from("bar").into(), alignment: Default::default() };
+        let lhs = RenderOperation::RenderText { line: String::from("foo").into(), alignment: Default::default() };
+        let rhs = RenderOperation::RenderText { line: String::from("bar").into(), alignment: Default::default() };
         assert!(lhs.is_content_different(&rhs));
     }
 
     #[test]
     fn different_text_alignment() {
-        let lhs = RenderOperation::RenderTextLine {
+        let lhs = RenderOperation::RenderText {
             line: String::from("foo").into(),
             alignment: Alignment::Left { margin: Margin::Fixed(42) },
         };
-        let rhs = RenderOperation::RenderTextLine {
+        let rhs = RenderOperation::RenderText {
             line: String::from("foo").into(),
             alignment: Alignment::Left { margin: Margin::Fixed(1337) },
         };

--- a/src/markdown/elements.rs
+++ b/src/markdown/elements.rs
@@ -138,10 +138,10 @@ pub(crate) enum ListItemType {
     Unordered,
 
     /// A list item for an ordered list that uses parenthesis after the list item number.
-    OrderedParens(u16),
+    OrderedParens,
 
     /// A list item for an ordered list that uses a period after the list item number.
-    OrderedPeriod(u16),
+    OrderedPeriod,
 }
 
 /// A piece of code.

--- a/src/markdown/parse.rs
+++ b/src/markdown/parse.rs
@@ -213,12 +213,11 @@ impl<'a> MarkdownParser<'a> {
 
     fn parse_list(root: &'a AstNode<'a>, depth: u8) -> ParseResult<Vec<ListItem>> {
         let mut elements = Vec::new();
-        for (index, node) in root.children().enumerate() {
-            let number = (index + 1) as u16;
+        for node in root.children() {
             let data = node.data.borrow();
             match &data.value {
                 NodeValue::Item(item) => {
-                    elements.extend(Self::parse_list_item(item, node, depth, number)?);
+                    elements.extend(Self::parse_list_item(item, node, depth)?);
                 }
                 other => {
                     return Err(ParseErrorKind::UnsupportedStructure {
@@ -232,11 +231,11 @@ impl<'a> MarkdownParser<'a> {
         Ok(elements)
     }
 
-    fn parse_list_item(item: &NodeList, root: &'a AstNode<'a>, depth: u8, number: u16) -> ParseResult<Vec<ListItem>> {
+    fn parse_list_item(item: &NodeList, root: &'a AstNode<'a>, depth: u8) -> ParseResult<Vec<ListItem>> {
         let item_type = match (item.list_type, item.delimiter) {
             (ListType::Bullet, _) => ListItemType::Unordered,
-            (ListType::Ordered, ListDelimType::Paren) => ListItemType::OrderedParens(number),
-            (ListType::Ordered, ListDelimType::Period) => ListItemType::OrderedPeriod(number),
+            (ListType::Ordered, ListDelimType::Paren) => ListItemType::OrderedParens,
+            (ListType::Ordered, ListDelimType::Period) => ListItemType::OrderedPeriod,
         };
         let mut elements = Vec::new();
         for node in root.children() {

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -278,8 +278,8 @@ pub(crate) enum RenderOperation {
     /// Jumps to the last row in the slide.
     JumpToBottom,
 
-    /// Render a line of text.
-    RenderTextLine { line: WeightedLine, alignment: Alignment },
+    /// Render text.
+    RenderText { line: WeightedLine, alignment: Alignment },
 
     /// Render a line break.
     RenderLineBreak,

--- a/src/render/draw.rs
+++ b/src/render/draw.rs
@@ -55,10 +55,10 @@ where
                 background: Some(Color::new(0, 0, 0)),
             }),
             RenderOperation::JumpToVerticalCenter,
-            RenderOperation::RenderTextLine { line: WeightedLine::from(heading), alignment: alignment.clone() },
+            RenderOperation::RenderText { line: WeightedLine::from(heading), alignment: alignment.clone() },
             RenderOperation::RenderLineBreak,
             RenderOperation::RenderLineBreak,
-            RenderOperation::RenderTextLine { line: WeightedLine::from(error), alignment: alignment.clone() },
+            RenderOperation::RenderText { line: WeightedLine::from(error), alignment: alignment.clone() },
         ];
         let operator = RenderOperator::new(&mut self.terminal, dimensions);
         operator.render(operations.iter())?;

--- a/src/render/operator.rs
+++ b/src/render/operator.rs
@@ -52,7 +52,7 @@ where
             RenderOperation::SetColors(colors) => self.set_colors(colors),
             RenderOperation::JumpToVerticalCenter => self.jump_to_vertical_center(),
             RenderOperation::JumpToBottom => self.jump_to_bottom(),
-            RenderOperation::RenderTextLine { line: texts, alignment } => self.render_text(texts, alignment),
+            RenderOperation::RenderText { line: texts, alignment } => self.render_text(texts, alignment),
             RenderOperation::RenderLineBreak => self.render_line_break(),
             RenderOperation::RenderImage(image) => self.render_image(image),
             RenderOperation::RenderPreformattedLine(operation) => self.render_preformatted_line(operation),


### PR DESCRIPTION
This makes pauses not break the numbering in ordered lists. This is a bit convoluted because from the markdown's perspective, an ordered list with a pause in between is 2 ordered lists. So the logic to realize there was a list before the pause and that we should pick up from the last index is done when constructing the presentation.

This does not work for lists of depth > 0 (e.g. a nested ordered list) because that's not valid markdown. I don't think comrak gives enough information when parsing lists to even get around this so it probably can't be fixed.

Fixes #15