### PR TITLE
Jump to slide if layout changes

### DIFF
--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -100,6 +100,11 @@ impl Presentation {
         self.current_slide_mut().jump_chunk(chunk_index);
     }
 
+    /// Get the current slide's chunk.
+    pub(crate) fn current_chunk(&self) -> usize {
+        self.current_slide().current_chunk()
+    }
+
     /// Render all widgets in this slide.
     pub(crate) fn render_slide_widgets(&mut self) -> bool {
         let slide = self.current_slide_mut();
@@ -168,6 +173,10 @@ impl Slide {
 
     fn jump_chunk(&mut self, chunk_index: usize) {
         self.visible_chunks = (chunk_index + 1).min(self.chunks.len());
+    }
+
+    fn current_chunk(&self) -> usize {
+        self.visible_chunks.saturating_sub(1)
     }
 
     fn show_first_chunk(&mut self) {

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -157,6 +157,9 @@ impl<'a> Presenter<'a> {
                 if let Some(modification) = PresentationDiffer::find_first_modification(current, &presentation) {
                     presentation.jump_slide(modification.slide_index);
                     presentation.jump_chunk(modification.chunk_index);
+                } else {
+                    presentation.jump_slide(current.current_slide_index());
+                    presentation.jump_chunk(current.current_chunk());
                 }
                 self.state = PresenterState::Presenting(presentation)
             }


### PR DESCRIPTION
This includes layout operations in the list of operations that are considered to change the content of a slide. This means hot reloading now jumps to a slide if the layout has changed (either column number, column width, or the column itself changes).

Fixes #22