### PR TITLE
Include real line number on command parse error

### DIFF
--- a/src/markdown/elements.rs
+++ b/src/markdown/elements.rs
@@ -39,10 +39,15 @@ pub(crate) enum MarkdownElement {
     ThematicBreak,
 
     /// An HTML comment.
-    Comment(String),
+    Comment { comment: String, source_position: SourcePosition },
 
     /// A quote.
     BlockQuote(Vec<String>),
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct SourcePosition {
+    pub(crate) line: usize,
 }
 
 /// The components that make up a paragraph.

--- a/src/markdown/parse.rs
+++ b/src/markdown/parse.rs
@@ -1,3 +1,4 @@
+use super::elements::SourcePosition;
 use crate::{
     markdown::elements::{
         Code, CodeFlags, CodeLanguage, ListItem, ListItemType, MarkdownElement, ParagraphElement, StyledText, Table,
@@ -97,7 +98,10 @@ impl<'a> MarkdownParser<'a> {
         }
         let block = &block[start_tag.len()..];
         let block = &block[0..block.len() - end_tag.len()];
-        Ok(MarkdownElement::Comment(block.into()))
+        Ok(MarkdownElement::Comment {
+            comment: block.into(),
+            source_position: SourcePosition { line: sourcepos.start.line },
+        })
     }
 
     fn parse_block_quote(node: &'a AstNode<'a>) -> ParseResult<MarkdownElement> {
@@ -705,8 +709,8 @@ echo hi mom
 <!-- foo -->
 ",
         );
-        let MarkdownElement::Comment(text) = parsed else { panic!("not a comment: {parsed:?}") };
-        assert_eq!(text, " foo ");
+        let MarkdownElement::Comment { comment, .. } = parsed else { panic!("not a comment: {parsed:?}") };
+        assert_eq!(comment, " foo ");
     }
 
     #[test]


### PR DESCRIPTION
This includes the real line number when parsing commands fails rather than the bogus "line 1 column 0" you get from `serde_yaml`.

Fixes #26