### PR TITLE
Don't remove newlines after every list + pause

### DIFF
--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -223,6 +223,10 @@ impl SlideChunk {
     pub(crate) fn iter_operations(&self) -> impl Iterator<Item = &RenderOperation> + Clone {
         self.0.iter()
     }
+
+    pub(crate) fn pop_last(&mut self) -> Option<RenderOperation> {
+        self.0.pop()
+    }
 }
 
 /// The metadata for a presentation.


### PR DESCRIPTION
This makes it so that a list + pause combo doesn't always pop the newline as this only should be the behavior if the thing right after is a list.

Fixes #32.