### PR TITLE
Only run push checks on master

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -1,4 +1,8 @@
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 name: Merge checks
 


### PR DESCRIPTION
This prevents having duplicate jobs.