### PR TITLE
Add keybinding to refresh images and themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ Besides this:
 * Jumping to the last slide: `G`.
 * Jumping to a specific slide: `<slide-number>G`.
 * Exit the presentation: `<ctrl>c`.
+* Refresh images: `<ctrl>r`.
 
 # Docs
 

--- a/src/input/user.rs
+++ b/src/input/user.rs
@@ -1,3 +1,4 @@
+use super::source::Command;
 use crossterm::event::{poll, read, Event, KeyCode, KeyEvent, KeyModifiers};
 use std::{io, mem, time::Duration};
 
@@ -9,38 +10,36 @@ pub(crate) struct UserInput {
 
 impl UserInput {
     /// Polls for the next input command coming from the keyboard.
-    pub(crate) fn poll_next_command(&mut self, timeout: Duration) -> io::Result<Option<UserCommand>> {
+    pub(crate) fn poll_next_command(&mut self, timeout: Duration) -> io::Result<Option<Command>> {
         if poll(timeout)? { self.next_command() } else { Ok(None) }
     }
 
     /// Blocks waiting for the next command.
-    pub(crate) fn next_command(&mut self) -> io::Result<Option<UserCommand>> {
+    pub(crate) fn next_command(&mut self) -> io::Result<Option<Command>> {
         let current_state = mem::take(&mut self.state);
         let (command, next_state) = match read()? {
             Event::Key(event) => Self::apply_key_event(event, current_state),
-            Event::Resize(..) => (Some(UserCommand::Redraw), current_state),
+            Event::Resize(..) => (Some(Command::Redraw), current_state),
             _ => (None, current_state),
         };
         self.state = next_state;
         Ok(command)
     }
 
-    fn apply_key_event(event: KeyEvent, state: InputState) -> (Option<UserCommand>, InputState) {
+    fn apply_key_event(event: KeyEvent, state: InputState) -> (Option<Command>, InputState) {
         match event.code {
             KeyCode::Char('h') | KeyCode::Char('k') | KeyCode::Left | KeyCode::PageUp | KeyCode::Up => {
-                (Some(UserCommand::JumpPreviousSlide), InputState::Empty)
+                (Some(Command::JumpPreviousSlide), InputState::Empty)
             }
             KeyCode::Char('l')
             | KeyCode::Char('j')
             | KeyCode::Right
             | KeyCode::PageDown
             | KeyCode::Down
-            | KeyCode::Char(' ') => (Some(UserCommand::JumpNextSlide), InputState::Empty),
-            KeyCode::Char('c') if event.modifiers == KeyModifiers::CONTROL => {
-                (Some(UserCommand::Exit), InputState::Empty)
-            }
+            | KeyCode::Char(' ') => (Some(Command::JumpNextSlide), InputState::Empty),
+            KeyCode::Char('c') if event.modifiers == KeyModifiers::CONTROL => (Some(Command::Exit), InputState::Empty),
             KeyCode::Char('e') if event.modifiers == KeyModifiers::CONTROL => {
-                (Some(UserCommand::RenderWidgets), InputState::Empty)
+                (Some(Command::RenderWidgets), InputState::Empty)
             }
             KeyCode::Char('G') => Self::apply_uppercase_g(state),
             KeyCode::Char('g') => Self::apply_lowercase_g(state),
@@ -48,22 +47,25 @@ impl UserInput {
                 let number = number.to_digit(10).expect("not a digit");
                 (None, Self::apply_number(number, state))
             }
+            KeyCode::Char('r') if event.modifiers == KeyModifiers::CONTROL => {
+                (Some(Command::HardReload), InputState::Empty)
+            }
             _ => (None, InputState::Empty),
         }
     }
 
-    fn apply_lowercase_g(state: InputState) -> (Option<UserCommand>, InputState) {
+    fn apply_lowercase_g(state: InputState) -> (Option<Command>, InputState) {
         match state {
-            InputState::PendingG => (Some(UserCommand::JumpFirstSlide), InputState::Empty),
+            InputState::PendingG => (Some(Command::JumpFirstSlide), InputState::Empty),
             InputState::Empty => (None, InputState::PendingG),
             _ => (None, InputState::Empty),
         }
     }
 
-    fn apply_uppercase_g(state: InputState) -> (Option<UserCommand>, InputState) {
+    fn apply_uppercase_g(state: InputState) -> (Option<Command>, InputState) {
         match state {
-            InputState::Empty => (Some(UserCommand::JumpLastSlide), InputState::Empty),
-            InputState::PendingNumber(number) => (Some(UserCommand::JumpSlide(number)), InputState::Empty),
+            InputState::Empty => (Some(Command::JumpLastSlide), InputState::Empty),
+            InputState::PendingNumber(number) => (Some(Command::JumpSlide(number)), InputState::Empty),
             _ => (None, InputState::Empty),
         }
     }
@@ -83,36 +85,6 @@ impl UserInput {
             None => InputState::OverflowedNumber,
         }
     }
-}
-
-/// A command from the user.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) enum UserCommand {
-    /// Redraw the presentation.
-    ///
-    /// This can happen on terminal resize.
-    Redraw,
-
-    /// Jump to the next slide.
-    JumpNextSlide,
-
-    /// Jump to the previous slide.
-    JumpPreviousSlide,
-
-    /// Jump to the first slide.
-    JumpFirstSlide,
-
-    /// Jump to the last slide.
-    JumpLastSlide,
-
-    /// Jump to one particular slide.
-    JumpSlide(u32),
-
-    /// Render any widgets in the currently visible slide.
-    RenderWidgets,
-
-    /// Exit the presentation.
-    Exit,
 }
 
 #[derive(Default, Debug, PartialEq, Eq)]
@@ -135,7 +107,7 @@ mod test {
         assert!(command.is_none());
 
         let (command, state) = UserInput::apply_key_event(KeyCode::Char('g').into(), state);
-        assert_eq!(command, Some(UserCommand::JumpFirstSlide));
+        assert_eq!(command, Some(Command::JumpFirstSlide));
         assert_eq!(state, InputState::Empty);
     }
 
@@ -143,7 +115,7 @@ mod test {
     fn uppercase_g() {
         let state = InputState::Empty;
         let (command, state) = UserInput::apply_key_event(KeyCode::Char('G').into(), state);
-        assert_eq!(command, Some(UserCommand::JumpLastSlide));
+        assert_eq!(command, Some(Command::JumpLastSlide));
         assert_eq!(state, InputState::Empty);
     }
 
@@ -159,7 +131,7 @@ mod test {
         assert_eq!(state, InputState::PendingNumber(12));
 
         let (command, state) = UserInput::apply_key_event(KeyCode::Char('G').into(), state);
-        assert_eq!(command, Some(UserCommand::JumpSlide(12)));
+        assert_eq!(command, Some(Command::JumpSlide(12)));
         assert_eq!(state, InputState::Empty);
     }
 }

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -50,6 +50,12 @@ impl Resources {
         self.themes.insert(path, theme.clone());
         Ok(theme)
     }
+
+    /// Clears all resources.
+    pub(crate) fn clear(&mut self) {
+        self.images.clear();
+        self.themes.clear();
+    }
 }
 
 /// An error loading an image.


### PR DESCRIPTION
This makes it so that `<C-r>` refreshes the resources, namely images and resources, while in development mode.

Fixes #33.