### PR TITLE
Position template style footer one row above bottom

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -127,7 +127,7 @@ mod test {
     #[rstest]
     #[case(RenderOperation::ClearScreen)]
     #[case(RenderOperation::JumpToVerticalCenter)]
-    #[case(RenderOperation::JumpToBottom)]
+    #[case(RenderOperation::JumpToBottomRow{ index: 0 })]
     #[case(RenderOperation::RenderLineBreak)]
     #[case(RenderOperation::SetColors(Colors{background: None, foreground: None}))]
     #[case(RenderOperation::RenderText{line: String::from("asd").into(), alignment: Default::default()})]
@@ -192,9 +192,9 @@ mod test {
     #[test]
     fn no_slide_changes() {
         let presentation = Presentation::new(vec![
-            Slide::from(vec![RenderOperation::JumpToBottom]),
-            Slide::from(vec![RenderOperation::JumpToBottom]),
-            Slide::from(vec![RenderOperation::JumpToBottom]),
+            Slide::from(vec![RenderOperation::ClearScreen]),
+            Slide::from(vec![RenderOperation::ClearScreen]),
+            Slide::from(vec![RenderOperation::ClearScreen]),
         ]);
         assert_eq!(PresentationDiffer::find_first_modification(&presentation, &presentation), None);
     }
@@ -202,10 +202,10 @@ mod test {
     #[test]
     fn slides_truncated() {
         let lhs = Presentation::new(vec![
-            Slide::from(vec![RenderOperation::JumpToBottom]),
-            Slide::from(vec![RenderOperation::JumpToBottom]),
+            Slide::from(vec![RenderOperation::ClearScreen]),
+            Slide::from(vec![RenderOperation::ClearScreen]),
         ]);
-        let rhs = Presentation::new(vec![Slide::from(vec![RenderOperation::JumpToBottom])]);
+        let rhs = Presentation::new(vec![Slide::from(vec![RenderOperation::ClearScreen])]);
 
         assert_eq!(
             PresentationDiffer::find_first_modification(&lhs, &rhs),
@@ -215,10 +215,10 @@ mod test {
 
     #[test]
     fn slides_added() {
-        let lhs = Presentation::new(vec![Slide::from(vec![RenderOperation::JumpToBottom])]);
+        let lhs = Presentation::new(vec![Slide::from(vec![RenderOperation::ClearScreen])]);
         let rhs = Presentation::new(vec![
-            Slide::from(vec![RenderOperation::JumpToBottom]),
-            Slide::from(vec![RenderOperation::JumpToBottom]),
+            Slide::from(vec![RenderOperation::ClearScreen]),
+            Slide::from(vec![RenderOperation::ClearScreen]),
         ]);
 
         assert_eq!(
@@ -230,14 +230,14 @@ mod test {
     #[test]
     fn second_slide_content_changed() {
         let lhs = Presentation::new(vec![
-            Slide::from(vec![RenderOperation::JumpToBottom]),
-            Slide::from(vec![RenderOperation::JumpToBottom]),
-            Slide::from(vec![RenderOperation::JumpToBottom]),
+            Slide::from(vec![RenderOperation::ClearScreen]),
+            Slide::from(vec![RenderOperation::ClearScreen]),
+            Slide::from(vec![RenderOperation::ClearScreen]),
         ]);
         let rhs = Presentation::new(vec![
-            Slide::from(vec![RenderOperation::JumpToBottom]),
+            Slide::from(vec![RenderOperation::ClearScreen]),
             Slide::from(vec![RenderOperation::JumpToVerticalCenter]),
-            Slide::from(vec![RenderOperation::JumpToBottom]),
+            Slide::from(vec![RenderOperation::ClearScreen]),
         ]);
 
         assert_eq!(
@@ -263,15 +263,15 @@ mod test {
     #[test]
     fn chunk_change() {
         let lhs = Presentation::new(vec![
-            Slide::from(vec![RenderOperation::JumpToBottom]),
-            Slide::new(vec![SlideChunk::default(), SlideChunk::new(vec![RenderOperation::JumpToBottom])], vec![]),
+            Slide::from(vec![RenderOperation::ClearScreen]),
+            Slide::new(vec![SlideChunk::default(), SlideChunk::new(vec![RenderOperation::ClearScreen])], vec![]),
         ]);
         let rhs = Presentation::new(vec![
-            Slide::from(vec![RenderOperation::JumpToBottom]),
+            Slide::from(vec![RenderOperation::ClearScreen]),
             Slide::new(
                 vec![
                     SlideChunk::default(),
-                    SlideChunk::new(vec![RenderOperation::JumpToBottom, RenderOperation::JumpToBottom]),
+                    SlideChunk::new(vec![RenderOperation::ClearScreen, RenderOperation::ClearScreen]),
                 ],
                 vec![],
             ),

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -288,8 +288,10 @@ pub(crate) enum RenderOperation {
     /// Jump the draw cursor into the vertical center, that is, at `screen_height / 2`.
     JumpToVerticalCenter,
 
-    /// Jumps to the last row in the slide.
-    JumpToBottom,
+    /// Jumps to the N-th to last row in the slide.
+    ///
+    /// The index is zero based where 0 represents the bottom row.
+    JumpToBottomRow { index: u16 },
 
     /// Render text.
     RenderText { line: WeightedLine, alignment: Alignment },

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -112,10 +112,22 @@ impl<'a> Presenter<'a> {
     }
 
     fn apply_command(&mut self, command: Command) -> CommandSideEffect {
-        // This one always happens no matter our state.
-        if matches!(command, Command::Exit) {
-            return CommandSideEffect::Exit;
-        }
+        // These ones always happens no matter our state.
+        match command {
+            Command::Reload => {
+                return CommandSideEffect::Reload;
+            }
+            Command::HardReload => {
+                if matches!(self.mode, PresentMode::Development) {
+                    self.resources.clear();
+                }
+                return CommandSideEffect::Reload;
+            }
+            Command::Exit => return CommandSideEffect::Exit,
+            _ => (),
+        };
+
+        // Now apply the commands that require a presentation.
         let PresenterState::Presenting(presentation) = &mut self.state else {
             return CommandSideEffect::None;
         };
@@ -134,16 +146,8 @@ impl<'a> Presenter<'a> {
                     return CommandSideEffect::None;
                 }
             }
-            Command::Reload => {
-                return CommandSideEffect::Reload;
-            }
-            Command::HardReload => {
-                if matches!(self.mode, PresentMode::Development) {
-                    self.resources.clear();
-                }
-                return CommandSideEffect::Reload;
-            }
-            Command::Exit => return CommandSideEffect::Exit,
+            // These are handled above as they don't require the presentation
+            Command::Reload | Command::HardReload | Command::Exit => panic!("unreachable commands"),
         };
         if needs_redraw { CommandSideEffect::Redraw } else { CommandSideEffect::None }
     }

--- a/src/render/engine.rs
+++ b/src/render/engine.rs
@@ -51,7 +51,7 @@ where
             RenderOperation::PopMargin => self.pop_margin(),
             RenderOperation::SetColors(colors) => self.set_colors(colors),
             RenderOperation::JumpToVerticalCenter => self.jump_to_vertical_center(),
-            RenderOperation::JumpToBottom => self.jump_to_bottom(),
+            RenderOperation::JumpToBottomRow { index } => self.jump_to_bottom(*index),
             RenderOperation::RenderText { line: texts, alignment } => self.render_text(texts, alignment),
             RenderOperation::RenderLineBreak => self.render_line_break(),
             RenderOperation::RenderImage(image) => self.render_image(image),
@@ -115,8 +115,9 @@ where
         Ok(())
     }
 
-    fn jump_to_bottom(&mut self) -> RenderResult {
-        self.terminal.move_to_row(self.current_dimensions().rows)?;
+    fn jump_to_bottom(&mut self, index: u16) -> RenderResult {
+        let target_row = self.current_dimensions().rows.saturating_sub(index).saturating_sub(1);
+        self.terminal.move_to_row(target_row)?;
         Ok(())
     }
 


### PR DESCRIPTION
This makes it so the template style footer shows up in one-row-to-last rather than in the last one as this looks a little nicer.

Fixes #36