### PR TITLE
Offset source positions by hand when input has front matter

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -225,7 +225,7 @@ impl<'a> PresentationBuilder<'a> {
         }
         let comment = match comment.parse::<CommentCommand>() {
             Ok(comment) => comment,
-            Err(error) => return Err(BuildError::CommandParse { line: source_position.line, error }),
+            Err(error) => return Err(BuildError::CommandParse { line: source_position.start.line + 1, error }),
         };
         match comment {
             CommentCommand::Pause => self.process_pause(),

--- a/src/markdown/elements.rs
+++ b/src/markdown/elements.rs
@@ -47,7 +47,33 @@ pub(crate) enum MarkdownElement {
 
 #[derive(Clone, Debug, Default)]
 pub(crate) struct SourcePosition {
+    pub(crate) start: LineColumn,
+}
+
+impl SourcePosition {
+    pub(crate) fn offset_lines(&self, offset: usize) -> SourcePosition {
+        let mut output = self.clone();
+        output.start.line += offset;
+        output
+    }
+}
+
+impl From<comrak::nodes::Sourcepos> for SourcePosition {
+    fn from(position: comrak::nodes::Sourcepos) -> Self {
+        Self { start: position.start.into() }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct LineColumn {
     pub(crate) line: usize,
+    pub(crate) column: usize,
+}
+
+impl From<comrak::nodes::LineColumn> for LineColumn {
+    fn from(position: comrak::nodes::LineColumn) -> Self {
+        Self { line: position.line, column: position.column }
+    }
 }
 
 /// The components that make up a paragraph.


### PR DESCRIPTION
comrak doesn't seem to include the front matter's length when setting the source positions so this does it by hand.