### PR TITLE
Don't pop new line if list is not right after pause

### DIFF
--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -260,7 +260,7 @@ pub enum PresentationError {
     Render(#[from] RenderError),
 
     #[error(transparent)]
-    LoadPresentationError(#[from] LoadPresentationError),
+    LoadPresentation(#[from] LoadPresentationError),
 
     #[error("io: {0}")]
     Io(#[from] io::Error),


### PR DESCRIPTION
This fixes the case of list-pause-notlist-list. This needs better tests as it's very fragile!