### PR TITLE
Allow exporting presentations to PDF

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,6 +1051,7 @@ dependencies = [
  "once_cell",
  "rstest",
  "serde",
+ "serde_json",
  "serde_with",
  "serde_yaml",
  "strum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ itertools = "0.11"
 once_cell = "1.18"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
+serde_json = "1.0"
 serde_with = "3.3"
 syntect = "5.1"
 strum = { version = "0.25", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ nix run github:mfontanini/presenterm
 * Support for an introduction slide that displays the presentation title and your name.
 * Support for slide titles.
 * Support for shell code execution.
+* Support for generating a PDF version of your presentation to share with other people.
 * Create pauses in between each slide so that it progressively renders for a more interactive presentation.
 * Text formatting support for **bold**, _italics_, ~strikethrough~, and `inline code`.
 * Automatically reload your presentation every time it changes for a fast development loop.
@@ -197,6 +198,27 @@ Any shell code can be marked for execution, making  _presenterm_ execute it and 
 In order to do this, annotate the code block with `+exec` (e.g. `bash +exec`). **Obviously use this at your own risk!**
 
 [![asciicast](https://asciinema.org/a/1v3IqCEtU9tqDjVj78Pp7SSe2.svg)](https://asciinema.org/a/1v3IqCEtU9tqDjVj78Pp7SSe2)
+
+## PDF export
+
+Presentations can be converted into PDF by using a helper tool. You can install it by running:
+
+```shell
+pip install presenterm-export
+```
+
+The only external dependency you'll need is [tmux](https://github.com/tmux/tmux/). After you've installed both of these, 
+simply run _presenterm_ with the `--export-pdf` parameter to generate the output PDF:
+
+```shell
+presenterm --export-pdf examples/demo.md
+```
+
+The output PDF will be placed in `examples/demo.pdf`. The size of each page will depend on the size of your terminal so 
+make sure to adjust accordingly before running the command above.
+
+> Note: if you're using a separate virtual env to install _presenterm-export_ just make sure you activate it before 
+> running _presenterm_ with the `--export-pdf` parameter.
 
 ## Navigation
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -131,7 +131,7 @@ impl<'a> PresentationBuilder<'a> {
             MarkdownElement::ThematicBreak => self.push_separator(),
             MarkdownElement::Comment { comment, source_position } => self.process_comment(comment, source_position)?,
             MarkdownElement::BlockQuote(lines) => self.push_block_quote(lines),
-            MarkdownElement::Image(path) => self.push_image(path)?,
+            MarkdownElement::Image { path, .. } => self.push_image(path)?,
         };
         if should_clear_last {
             self.slide_state.last_element = Default::default();

--- a/src/export.rs
+++ b/src/export.rs
@@ -1,0 +1,225 @@
+use crate::{
+    builder::{BuildError, PresentationBuilder},
+    markdown::{elements::MarkdownElement, parse::ParseError},
+    presentation::Presentation,
+    CodeHighlighter, MarkdownParser, PresentationTheme, Resources,
+};
+use serde::Serialize;
+use std::{
+    env, fs,
+    io::{self, Write},
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+};
+
+const COMMAND: &str = "presenterm-export";
+
+/// Allows exporting presentations into PDF.
+pub struct Exporter<'a> {
+    parser: MarkdownParser<'a>,
+    default_theme: &'a PresentationTheme,
+    default_highlighter: CodeHighlighter,
+    resources: Resources,
+}
+
+impl<'a> Exporter<'a> {
+    /// Construct a new exporter.
+    pub fn new(
+        parser: MarkdownParser<'a>,
+        default_theme: &'a PresentationTheme,
+        default_highlighter: CodeHighlighter,
+        resources: Resources,
+    ) -> Self {
+        Self { parser, default_theme, default_highlighter, resources }
+    }
+
+    /// Export the given presentation into PDF.
+    ///
+    /// This uses a separate `presenterm-export` tool.
+    pub fn export_pdf(&mut self, presentation_path: &Path) -> Result<(), ExportError> {
+        let metadata = self.generate_metadata(presentation_path)?;
+        Self::execute_exporter(metadata).map_err(ExportError::InvokeExporter)?;
+        Ok(())
+    }
+
+    /// Generate the metadata for the given presentation.
+    pub fn generate_metadata(&mut self, presentation_path: &Path) -> Result<ExportMetadata, ExportError> {
+        let content = fs::read_to_string(presentation_path).map_err(ExportError::ReadPresentation)?;
+        let metadata = self.extract_metadata(&content, presentation_path)?;
+        Ok(metadata)
+    }
+
+    /// Extract the metadata necessary to make an export.
+    fn extract_metadata(&mut self, content: &str, path: &Path) -> Result<ExportMetadata, ExportError> {
+        let elements = self.parser.parse(content)?;
+        let base_path = path.parent().expect("no parent").canonicalize().expect("canonicalize");
+        let images = Self::build_image_metadata(&elements, &base_path);
+        let presentation =
+            PresentationBuilder::new(self.default_highlighter.clone(), self.default_theme, &mut self.resources)
+                .build(elements)?;
+        let commands = Self::build_capture_commands(presentation);
+        let presentation_path = path.canonicalize().map_err(ExportError::ReadPresentation)?;
+        let metadata = ExportMetadata { commands, presentation_path, images };
+        Ok(metadata)
+    }
+
+    fn execute_exporter(metadata: ExportMetadata) -> io::Result<()> {
+        let presenterm_path = env::current_exe()?;
+        let mut command =
+            Command::new(COMMAND).arg("--presenterm-path").arg(presenterm_path).stdin(Stdio::piped()).spawn()?;
+        let mut stdin = command.stdin.take().expect("no stdin");
+        let metadata = serde_json::to_vec(&metadata).expect("serialization failed");
+        stdin.write_all(&metadata)?;
+        stdin.flush()?;
+        drop(stdin);
+
+        let status = command.wait()?;
+        if !status.success() {
+            println!("PDF generation failed");
+        }
+        // huh?
+        Ok(())
+    }
+
+    fn build_capture_commands(mut presentation: Presentation) -> Vec<CaptureCommand> {
+        let mut commands = Vec::new();
+        let slide_chunks: Vec<_> = presentation.iter_slides().map(|slide| slide.iter_chunks().count()).collect();
+        let mut next_slide = |commands: &mut Vec<CaptureCommand>| {
+            commands.push(CaptureCommand::SendKeys { keys: "l" });
+            commands.push(CaptureCommand::WaitForChange);
+            presentation.jump_next_slide();
+        };
+        for chunks in slide_chunks {
+            for _ in 0..chunks - 1 {
+                next_slide(&mut commands);
+            }
+            commands.push(CaptureCommand::Capture);
+            next_slide(&mut commands);
+        }
+        commands
+    }
+
+    fn build_image_metadata(elements: &[MarkdownElement], base_path: &Path) -> Vec<ImageMetadata> {
+        let mut positions = Vec::new();
+        for element in elements {
+            if let MarkdownElement::Image { path, source_position } = element {
+                let full_path = base_path.join(path);
+                let meta = ImageMetadata {
+                    content_path: path.into(),
+                    full_path,
+                    line: source_position.start.line,
+                    column: source_position.start.column,
+                };
+                positions.push(meta);
+            }
+        }
+        positions
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum ExportError {
+    #[error("failed to read presentation: {0}")]
+    ReadPresentation(io::Error),
+
+    #[error("failed to parse presentation: {0}")]
+    ParsePresentation(#[from] ParseError),
+
+    #[error("failed to build presentation: {0}")]
+    BuildPresentation(#[from] BuildError),
+
+    #[error("failed to invoke presenterm-export (is it installed?): {0}")]
+    InvokeExporter(io::Error),
+}
+
+/// The metadata necessary to export a presentation.
+#[derive(Clone, Debug, Serialize)]
+pub struct ExportMetadata {
+    presentation_path: PathBuf,
+    images: Vec<ImageMetadata>,
+    commands: Vec<CaptureCommand>,
+}
+
+/// Metadata about an image.
+#[derive(Clone, Debug, Serialize)]
+struct ImageMetadata {
+    content_path: PathBuf,
+    full_path: PathBuf,
+    line: usize,
+    column: usize,
+}
+
+/// A command to whoever is capturing us indicating what to do.
+#[derive(Clone, Debug, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case", tag = "type")]
+enum CaptureCommand {
+    Capture,
+    SendKeys { keys: &'static str },
+    WaitForChange,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use comrak::Arena;
+
+    fn extract_metadata(content: &str, path: &str) -> ExportMetadata {
+        let arena = Arena::new();
+        let parser = MarkdownParser::new(&arena);
+        let theme = Default::default();
+        let highlighter = CodeHighlighter::new("base16-ocean.dark").unwrap();
+        let resources = Resources::new("examples");
+        let mut exporter = Exporter::new(parser, &theme, highlighter, resources);
+        exporter.extract_metadata(content, Path::new(path)).expect("metadata extraction failed")
+    }
+
+    #[test]
+    fn metadata() {
+        let presentation = r"
+First
+
+<!-- end_slide -->
+
+hi
+<!-- pause -->
+mom
+
+<!-- end_slide -->
+
+![](doge.png)
+
+<!-- end_slide -->
+
+bye
+<!-- pause -->
+mom
+        ";
+
+        let meta = extract_metadata(presentation, "examples/demo.md");
+
+        use CaptureCommand::*;
+        let expected_commands = vec![
+            // First slide
+            Capture,
+            SendKeys { keys: "l" },
+            WaitForChange,
+            // Second slide...
+            SendKeys { keys: "l" },
+            WaitForChange,
+            Capture,
+            SendKeys { keys: "l" },
+            WaitForChange,
+            // Third slide...
+            Capture,
+            SendKeys { keys: "l" },
+            WaitForChange,
+            // Fourth slide...
+            SendKeys { keys: "l" },
+            WaitForChange,
+            Capture,
+            SendKeys { keys: "l" },
+            WaitForChange,
+        ];
+        assert_eq!(meta.commands, expected_commands);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 pub(crate) mod builder;
 pub(crate) mod diff;
 pub(crate) mod execute;
+pub(crate) mod export;
 pub(crate) mod input;
 pub(crate) mod markdown;
 pub(crate) mod presentation;
@@ -15,6 +16,7 @@ pub(crate) mod style;
 pub(crate) mod theme;
 
 pub use crate::{
+    export::{ExportError, Exporter},
     input::source::CommandSource,
     markdown::parse::MarkdownParser,
     presenter::{PresentMode, Presenter},

--- a/src/markdown/elements.rs
+++ b/src/markdown/elements.rs
@@ -22,7 +22,7 @@ pub(crate) enum MarkdownElement {
     Paragraph(Vec<ParagraphElement>),
 
     /// An image.
-    Image(PathBuf),
+    Image { path: PathBuf, source_position: SourcePosition },
 
     /// A list.
     ///

--- a/src/markdown/parse.rs
+++ b/src/markdown/parse.rs
@@ -74,7 +74,7 @@ impl<'a> MarkdownParser<'a> {
                 | MarkdownElement::SetexHeading { .. }
                 | MarkdownElement::Heading { .. }
                 | MarkdownElement::Paragraph(_)
-                | MarkdownElement::Image(_)
+                | MarkdownElement::Image { .. }
                 | MarkdownElement::List(_)
                 | MarkdownElement::Code(_)
                 | MarkdownElement::Table(_)
@@ -230,7 +230,10 @@ impl<'a> MarkdownParser<'a> {
                     if !paragraph_elements.is_empty() {
                         elements.push(MarkdownElement::Paragraph(mem::take(&mut paragraph_elements)));
                     }
-                    elements.push(MarkdownElement::Image(path.into()));
+                    elements.push(MarkdownElement::Image {
+                        path: path.into(),
+                        source_position: node.data.borrow().sourcepos.into(),
+                    });
                 }
             }
         }
@@ -586,7 +589,7 @@ boop
     #[test]
     fn image() {
         let parsed = parse_single("![](potato.png)");
-        let MarkdownElement::Image(path) = parsed else { panic!("not an image: {parsed:?}") };
+        let MarkdownElement::Image { path, .. } = parsed else { panic!("not an image: {parsed:?}") };
         assert_eq!(path, Path::new("potato.png"));
     }
 


### PR DESCRIPTION
This adds the ability to export presentations to PDF. This needs a separate tool that can be installed via pip.

Fixes #9