### PR TITLE
Allow enabling code block line numbers

### DIFF
--- a/src/execute.rs
+++ b/src/execute.rs
@@ -18,7 +18,7 @@ impl CodeExecuter {
         if !code.language.supports_execution() {
             return Err(CodeExecuteError::UnsupportedExecution);
         }
-        if !code.flags.execute {
+        if !code.attributes.execute {
             return Err(CodeExecuteError::NotExecutableCode);
         }
         match &code.language {
@@ -147,7 +147,7 @@ impl ProcessStatus {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::markdown::elements::CodeFlags;
+    use crate::markdown::elements::CodeAttributes;
 
     #[test]
     fn shell_code_execution() {
@@ -155,7 +155,11 @@ mod test {
 echo 'hello world'
 echo 'bye'"
             .into();
-        let code = Code { contents, language: CodeLanguage::Shell("sh".into()), flags: CodeFlags { execute: true } };
+        let code = Code {
+            contents,
+            language: CodeLanguage::Shell("sh".into()),
+            attributes: CodeAttributes { execute: true, ..Default::default() },
+        };
         let handle = CodeExecuter::execute(&code).expect("execution failed");
         let state = loop {
             let state = handle.state();
@@ -171,7 +175,11 @@ echo 'bye'"
     #[test]
     fn non_executable_code_cant_be_executed() {
         let contents = String::new();
-        let code = Code { contents, language: CodeLanguage::Shell("sh".into()), flags: CodeFlags { execute: false } };
+        let code = Code {
+            contents,
+            language: CodeLanguage::Shell("sh".into()),
+            attributes: CodeAttributes { execute: false, ..Default::default() },
+        };
         let result = CodeExecuter::execute(&code);
         assert!(result.is_err());
     }

--- a/src/markdown/elements.rs
+++ b/src/markdown/elements.rs
@@ -184,8 +184,8 @@ pub(crate) struct Code {
     /// The programming language this code is written in.
     pub(crate) language: CodeLanguage,
 
-    /// The flags used for this code.
-    pub(crate) flags: CodeFlags,
+    /// The attributes used for this code.
+    pub(crate) attributes: CodeAttributes,
 }
 
 /// The language of a piece of code.
@@ -248,11 +248,14 @@ impl CodeLanguage {
     }
 }
 
-/// Flags for code blocks.
+/// Attributes for code blocks.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub(crate) struct CodeFlags {
-    /// Whether a code block is marked as executable.
+pub(crate) struct CodeAttributes {
+    /// Whether the code block is marked as executable.
     pub(crate) execute: bool,
+
+    /// Whether the code block should show line numbers.
+    pub(crate) line_numbers: bool,
 }
 
 /// A table.

--- a/src/markdown/parse.rs
+++ b/src/markdown/parse.rs
@@ -1,7 +1,7 @@
 use crate::{
     markdown::elements::{
-        Code, CodeFlags, CodeLanguage, ListItem, ListItemType, MarkdownElement, ParagraphElement, StyledText, Table,
-        TableRow, Text,
+        Code, CodeAttributes, CodeLanguage, ListItem, ListItemType, MarkdownElement, ParagraphElement, StyledText,
+        Table, TableRow, Text,
     },
     style::TextStyle,
 };
@@ -204,8 +204,15 @@ impl<'a> MarkdownParser<'a> {
             "zig" => Zig,
             _ => Unknown,
         };
-        let flags = CodeFlags { execute: tokens.any(|token| token == "+exec") };
-        let code = Code { contents: block.literal.clone(), language, flags };
+        let mut attributes = CodeAttributes::default();
+        for token in tokens {
+            match token {
+                "+exec" => attributes.execute = true,
+                "+line_numbers" => attributes.line_numbers = true,
+                _ => (),
+            };
+        }
+        let code = Code { contents: block.literal.clone(), language, attributes };
         Ok(MarkdownElement::Code(code))
     }
 
@@ -683,7 +690,7 @@ let q = 42;
         let MarkdownElement::Code(code) = parsed else { panic!("not a code block: {parsed:?}") };
         assert_eq!(code.language, CodeLanguage::Rust);
         assert_eq!(code.contents, "let q = 42;\n");
-        assert!(!code.flags.execute);
+        assert!(!code.attributes.execute);
     }
 
     #[test]
@@ -697,7 +704,7 @@ echo hi mom
         );
         let MarkdownElement::Code(code) = parsed else { panic!("not a code block: {parsed:?}") };
         assert_eq!(code.language, CodeLanguage::Shell("bash".into()));
-        assert!(code.flags.execute);
+        assert!(code.attributes.execute);
     }
 
     #[test]


### PR DESCRIPTION
This allows enabling line numbers on code blocks by using the `+line_numbers` attribute.