### PR TITLE
Progressive highlighting

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -465,7 +465,7 @@ impl<'a> PresentationBuilder<'a> {
         let mut code_highlighter = self.highlighter.language_highlighter(&code.language);
         for line in lines.into_iter() {
             let needs_highlight = match &code.attributes.highlighted_lines {
-                Some(lines) => line.line_number.map(|number| lines.contains(&number)).unwrap_or_default(),
+                Some(lines) => line.line_number.map(|number| lines.contains(number)).unwrap_or_default(),
                 None => true,
             };
             let text = match needs_highlight {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -2,13 +2,13 @@ use crate::{
     execute::{CodeExecuter, ExecutionHandle, ExecutionState, ProcessStatus},
     markdown::{
         elements::{
-            Code, CodeLanguage, ListItem, ListItemType, MarkdownElement, ParagraphElement, SourcePosition, StyledText,
-            Table, TableRow, Text,
+            Code, CodeLanguage, HighlightGroup, ListItem, ListItemType, MarkdownElement, ParagraphElement,
+            SourcePosition, StyledText, Table, TableRow, Text,
         },
         text::{WeightedLine, WeightedText},
     },
     presentation::{
-        AsRenderOperations, MarginProperties, PreformattedLine, Presentation, PresentationMetadata,
+        AsRenderOperations, ChunkMutator, MarginProperties, PreformattedLine, Presentation, PresentationMetadata,
         PresentationThemeMetadata, RenderOnDemand, RenderOnDemandState, RenderOperation, Slide, SlideChunk,
     },
     render::{
@@ -35,6 +35,7 @@ static DEFAULT_BOTTOM_SLIDE_MARGIN: u16 = 3;
 pub(crate) struct PresentationBuilder<'a> {
     slide_chunks: Vec<SlideChunk>,
     chunk_operations: Vec<RenderOperation>,
+    chunk_mutators: Vec<Box<dyn ChunkMutator>>,
     slides: Vec<Slide>,
     highlighter: CodeHighlighter,
     theme: Cow<'a, PresentationTheme>,
@@ -53,6 +54,7 @@ impl<'a> PresentationBuilder<'a> {
         Self {
             slide_chunks: Vec::new(),
             chunk_operations: Vec::new(),
+            chunk_mutators: Vec::new(),
             slides: Vec::new(),
             highlighter: default_highlighter,
             theme: Cow::Borrowed(default_theme),
@@ -285,7 +287,8 @@ impl<'a> PresentationBuilder<'a> {
         self.slide_state.last_chunk_ended_in_list = matches!(self.slide_state.last_element, LastElement::List { .. });
 
         let chunk_operations = mem::take(&mut self.chunk_operations);
-        self.slide_chunks.push(SlideChunk::new(chunk_operations));
+        let mutators = mem::take(&mut self.chunk_mutators);
+        self.slide_chunks.push(SlideChunk::new(chunk_operations, mutators));
     }
 
     fn push_slide_title(&mut self, mut text: Text) {
@@ -455,34 +458,43 @@ impl<'a> PresentationBuilder<'a> {
     }
 
     fn push_code(&mut self, code: Code) {
-        let lines = CodePreparer { theme: &self.theme }.prepare(&code);
+        let (lines, context) = self.highlight_lines(&code);
+        for line in lines {
+            self.chunk_operations.push(RenderOperation::RenderDynamic(Rc::new(line)));
+        }
+        self.chunk_mutators.push(Box::new(HighlightMutator { context }));
+        if code.attributes.execute {
+            self.push_code_execution(code);
+        }
+    }
+
+    fn highlight_lines(&self, code: &Code) -> (Vec<HighlightedLine>, Rc<RefCell<HighlightContext>>) {
+        let lines = CodePreparer { theme: &self.theme }.prepare(code);
         let block_length = lines.iter().map(|line| line.width()).max().unwrap_or(0);
+        let mut empty_highlighter = self.highlighter.language_highlighter(&CodeLanguage::Unknown);
+        let mut code_highlighter = self.highlighter.language_highlighter(&code.language);
         let padding_style = {
             let mut highlighter = self.highlighter.language_highlighter(&CodeLanguage::Rust);
             highlighter.style_line("//").first().expect("no styles").style
         };
-        let mut empty_highlighter = self.highlighter.language_highlighter(&CodeLanguage::Unknown);
-        let mut code_highlighter = self.highlighter.language_highlighter(&code.language);
+        let groups = code.attributes.highlight_groups.clone();
+        let context = Rc::new(RefCell::new(HighlightContext {
+            groups,
+            current: 0,
+            block_length,
+            alignment: self.theme.alignment(&ElementType::Code),
+        }));
+
+        let mut output = Vec::new();
         for line in lines.into_iter() {
-            let needs_highlight = match &code.attributes.highlighted_lines {
-                Some(lines) => line.line_number.map(|number| lines.contains(number)).unwrap_or_default(),
-                None => true,
-            };
-            let text = match needs_highlight {
-                true => line.highlight(&padding_style, &mut code_highlighter),
-                false => line.highlight(&padding_style, &mut empty_highlighter),
-            };
-            self.chunk_operations.push(RenderOperation::RenderPreformattedLine(PreformattedLine {
-                text,
-                unformatted_length: line.width(),
-                block_length,
-                alignment: self.theme.alignment(&ElementType::Code),
-            }));
-            self.push_line_break();
+            let highlighted = line.highlight(&padding_style, &mut code_highlighter);
+            let not_highlighted = line.highlight(&padding_style, &mut empty_highlighter);
+            let width = line.width();
+            let line_number = line.line_number;
+            let context = context.clone();
+            output.push(HighlightedLine { highlighted, not_highlighted, line_number, width, context });
         }
-        if code.attributes.execute {
-            self.push_code_execution(code);
-        }
+        (output, context)
     }
 
     fn push_code_execution(&mut self, code: Code) {
@@ -499,7 +511,8 @@ impl<'a> PresentationBuilder<'a> {
         let footer = self.generate_footer();
 
         let operations = mem::take(&mut self.chunk_operations);
-        self.slide_chunks.push(SlideChunk::new(operations));
+        let mutators = mem::take(&mut self.chunk_mutators);
+        self.slide_chunks.push(SlideChunk::new(operations, mutators));
 
         let chunks = mem::take(&mut self.slide_chunks);
         self.slides.push(Slide::new(chunks, footer));
@@ -610,7 +623,6 @@ impl<'a> CodePreparer<'a> {
                 let number_padding = total_lines_width - line_number_width;
                 prefix.push_str(&" ".repeat(number_padding as usize));
                 prefix.push_str(&line_number.to_string());
-                // TODO pad based on total lines
                 prefix.push(' ');
             }
             line.push('\n');
@@ -643,6 +655,90 @@ impl CodeLine {
         output.pop();
         output.push_str(&StyledTokens { style: *padding_style, tokens: &self.suffix }.apply_style());
         output
+    }
+}
+
+#[derive(Debug)]
+struct HighlightContext {
+    groups: Vec<HighlightGroup>,
+    current: usize,
+    block_length: usize,
+    alignment: Alignment,
+}
+
+#[derive(Debug)]
+struct HighlightedLine {
+    highlighted: String,
+    not_highlighted: String,
+    line_number: Option<u16>,
+    width: usize,
+    context: Rc<RefCell<HighlightContext>>,
+}
+
+impl AsRenderOperations for HighlightedLine {
+    fn as_render_operations(&self, _: &WindowSize) -> Vec<RenderOperation> {
+        let context = self.context.borrow();
+        let group = &context.groups[context.current];
+        let needs_highlight = self.line_number.map(|number| group.contains(number)).unwrap_or_default();
+        // TODO: Cow<str>?
+        let text = match needs_highlight {
+            true => self.highlighted.clone(),
+            false => self.not_highlighted.clone(),
+        };
+        vec![
+            RenderOperation::RenderPreformattedLine(PreformattedLine {
+                text,
+                unformatted_length: self.width,
+                block_length: context.block_length,
+                alignment: context.alignment.clone(),
+            }),
+            RenderOperation::RenderLineBreak,
+        ]
+    }
+
+    fn diffable_content(&self) -> Option<&str> {
+        Some(&self.highlighted)
+    }
+}
+
+#[derive(Debug)]
+struct HighlightMutator {
+    context: Rc<RefCell<HighlightContext>>,
+}
+
+impl ChunkMutator for HighlightMutator {
+    fn mutate_next(&self) -> bool {
+        let mut context = self.context.borrow_mut();
+        if context.current == context.groups.len() - 1 {
+            false
+        } else {
+            context.current += 1;
+            true
+        }
+    }
+
+    fn mutate_previous(&self) -> bool {
+        let mut context = self.context.borrow_mut();
+        if context.current == 0 {
+            false
+        } else {
+            context.current -= 1;
+            true
+        }
+    }
+
+    fn reset_mutations(&self) {
+        self.context.borrow_mut().current = 0;
+    }
+
+    fn apply_all_mutations(&self) {
+        let mut context = self.context.borrow_mut();
+        context.current = context.groups.len() - 1;
+    }
+
+    fn mutations(&self) -> (usize, usize) {
+        let context = self.context.borrow();
+        (context.current, context.groups.len())
     }
 }
 
@@ -751,6 +847,10 @@ impl AsRenderOperations for FooterGenerator {
             }
             FooterStyle::Empty => vec![],
         }
+    }
+
+    fn diffable_content(&self) -> Option<&str> {
+        None
     }
 }
 
@@ -887,6 +987,10 @@ impl AsRenderOperations for RunCodeOperation {
         operations.push(RenderOperation::SetColors(self.default_colors.clone()));
         operations
     }
+
+    fn diffable_content(&self) -> Option<&str> {
+        None
+    }
 }
 
 impl RenderOnDemand for RunCodeOperation {
@@ -958,6 +1062,10 @@ impl AsRenderOperations for RenderSeparator {
         };
         vec![RenderOperation::RenderText { line: separator.into(), alignment: Default::default() }]
     }
+
+    fn diffable_content(&self) -> Option<&str> {
+        None
+    }
 }
 
 struct ListIterator<I> {
@@ -1012,13 +1120,9 @@ struct IndexedListItem {
 
 #[cfg(test)]
 mod test {
-    use rstest::rstest;
-
     use super::*;
-    use crate::{
-        markdown::elements::{CodeAttributes, CodeLanguage},
-        presentation::PreformattedLine,
-    };
+    use crate::markdown::elements::{CodeAttributes, CodeLanguage};
+    use rstest::rstest;
 
     fn build_presentation(elements: Vec<MarkdownElement>) -> Presentation {
         try_build_presentation(elements).expect("build failed")
@@ -1134,34 +1238,6 @@ mod test {
             // And the second one should _not_ be a newline
             assert!(!matches!(ops.next(), Some(RenderOperation::RenderLineBreak)));
         }
-    }
-
-    #[test]
-    fn preformatted_blocks_account_for_unicode_widths() {
-        let text = "苹果".to_string();
-        let elements = vec![
-            MarkdownElement::BlockQuote(vec![text.clone()]),
-            MarkdownElement::Code(Code {
-                contents: text.clone(),
-                language: CodeLanguage::Unknown,
-                attributes: Default::default(),
-            }),
-        ];
-        let presentation = build_presentation(elements);
-        let slides = presentation.into_slides();
-        let lengths: Vec<_> = slides[0]
-            .iter_operations()
-            .filter_map(|op| match op {
-                RenderOperation::RenderPreformattedLine(PreformattedLine {
-                    block_length, unformatted_length, ..
-                }) => Some((block_length, unformatted_length)),
-                _ => None,
-            })
-            .collect();
-        assert_eq!(lengths.len(), 2);
-        let width = &text.width();
-        assert_eq!(lengths[0], (width, width));
-        assert_eq!(lengths[1], (width, width));
     }
 
     #[test]

--- a/src/export.rs
+++ b/src/export.rs
@@ -1,5 +1,5 @@
 use crate::{
-    builder::{BuildError, PresentationBuilder},
+    builder::{BuildError, PresentationBuilder, PresentationBuilderOptions},
     markdown::{elements::MarkdownElement, parse::ParseError},
     presentation::Presentation,
     CodeHighlighter, MarkdownParser, PresentationTheme, Resources,
@@ -54,9 +54,14 @@ impl<'a> Exporter<'a> {
         let elements = self.parser.parse(content)?;
         let base_path = path.parent().expect("no parent").canonicalize().expect("canonicalize");
         let images = Self::build_image_metadata(&elements, &base_path);
-        let presentation =
-            PresentationBuilder::new(self.default_highlighter.clone(), self.default_theme, &mut self.resources)
-                .build(elements)?;
+        let options = PresentationBuilderOptions { allow_mutations: false };
+        let presentation = PresentationBuilder::new(
+            self.default_highlighter.clone(),
+            self.default_theme,
+            &mut self.resources,
+            options,
+        )
+        .build(elements)?;
         let commands = Self::build_capture_commands(presentation);
         let presentation_path = path.canonicalize().map_err(ExportError::ReadPresentation)?;
         let metadata = ExportMetadata { commands, presentation_path, images };

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,10 @@ struct Cli {
     #[clap(long, hide = true)]
     generate_pdf_metadata: bool,
 
+    /// Run in export mode.
+    #[clap(long, hide = true)]
+    export: bool,
+
     /// Whether to use presentation mode.
     #[clap(short, long, default_value_t = false)]
     present: bool,
@@ -53,9 +57,10 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         cmd.error(ErrorKind::InvalidValue, error_message).exit();
     };
 
-    let mode = match cli.present {
-        true => PresentMode::Presentation,
-        false => PresentMode::Development,
+    let mode = match (cli.present, cli.export) {
+        (true, _) => PresentMode::Presentation,
+        (false, true) => PresentMode::Export,
+        (false, false) => PresentMode::Development,
     };
     let arena = Arena::new();
     let parser = MarkdownParser::new(&arena);

--- a/src/markdown/elements.rs
+++ b/src/markdown/elements.rs
@@ -257,22 +257,20 @@ pub(crate) struct CodeAttributes {
     /// Whether the code block should show line numbers.
     pub(crate) line_numbers: bool,
 
-    /// Highlight only these lines.
-    pub(crate) highlighted_lines: Option<HighlightedLines>,
+    /// The groups of lines to highlight.
+    pub(crate) highlight_groups: Vec<HighlightGroup>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub(crate) struct HighlightedLines {
-    highlights: Vec<Highlight>,
-}
+pub(crate) struct HighlightGroup(Vec<Highlight>);
 
-impl HighlightedLines {
+impl HighlightGroup {
     pub(crate) fn new(highlights: Vec<Highlight>) -> Self {
-        Self { highlights }
+        Self(highlights)
     }
 
     pub(crate) fn contains(&self, line_number: u16) -> bool {
-        for higlight in &self.highlights {
+        for higlight in &self.0 {
             match higlight {
                 Highlight::All => return true,
                 Highlight::Single(number) if number == &line_number => return true,

--- a/src/markdown/elements.rs
+++ b/src/markdown/elements.rs
@@ -1,5 +1,5 @@
 use crate::style::TextStyle;
-use std::{iter, path::PathBuf};
+use std::{iter, ops::Range, path::PathBuf};
 use strum::EnumIter;
 use unicode_width::UnicodeWidthStr;
 
@@ -258,7 +258,38 @@ pub(crate) struct CodeAttributes {
     pub(crate) line_numbers: bool,
 
     /// Highlight only these lines.
-    pub(crate) highlighted_lines: Option<Vec<u16>>,
+    pub(crate) highlighted_lines: Option<HighlightedLines>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct HighlightedLines {
+    highlights: Vec<Highlight>,
+}
+
+impl HighlightedLines {
+    pub(crate) fn new(highlights: Vec<Highlight>) -> Self {
+        Self { highlights }
+    }
+
+    pub(crate) fn contains(&self, line_number: u16) -> bool {
+        for higlight in &self.highlights {
+            match higlight {
+                Highlight::All => return true,
+                Highlight::Single(number) if number == &line_number => return true,
+                Highlight::Range(range) if range.contains(&line_number) => return true,
+                _ => continue,
+            };
+        }
+        false
+    }
+}
+
+/// A highlighted set of lines
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum Highlight {
+    All,
+    Single(u16),
+    Range(Range<u16>),
 }
 
 /// A table.

--- a/src/markdown/parse.rs
+++ b/src/markdown/parse.rs
@@ -1,3 +1,4 @@
+use super::{code::CodeBlockParseError, elements::SourcePosition};
 use crate::{
     markdown::{
         code::CodeBlockParser,
@@ -17,8 +18,6 @@ use std::{
     io::BufWriter,
     mem,
 };
-
-use super::{code::CodeBlockParseError, elements::SourcePosition};
 
 /// The result of parsing a markdown file.
 pub(crate) type ParseResult<T> = Result<T, ParseError>;


### PR DESCRIPTION
This implements progressive highlighting as an extension to the custom line highlighting implemented in #48. This uses the notation `{1-2|all|1,2,3}` where every group in between `|` is going to be rendered progressively every time you move the slides forward/backwards.

Closes #41