### PR TITLE
Feature: Load syntax highlighting themes from bat's config dir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,6 +489,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "exr"
 version = "1.71.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -592,6 +603,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "home"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+dependencies = [
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -903,6 +923,7 @@ dependencies = [
  "clap",
  "comrak",
  "crossterm",
+ "etcetera",
  "hex",
  "image",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ bincode = "1.3"
 clap = { version = "4.4", features = ["derive", "string"] }
 comrak = { version = "0.19", default-features = false }
 crossterm = { version = "0.27", features = ["serde"] }
+etcetera = { version = "0.8.0" }
 hex = "0.4"
 image = "0.24"
 merge-struct = "0.1.0"
@@ -30,7 +31,7 @@ viuer = "0.7"
 [dependencies.syntect]
 version = "5.1"
 default-features = false
-features = ["parsing", "default-themes", "regex-onig"]
+features = ["parsing", "default-themes", "regex-onig", "plist-load"]
 
 [dev-dependencies]
 rstest = { version = "0.18", default-features = false }

--- a/src/render/highlighting.rs
+++ b/src/render/highlighting.rs
@@ -1,5 +1,6 @@
 use crate::markdown::elements::CodeLanguage;
 use once_cell::sync::Lazy;
+use etcetera::BaseStrategy;
 use syntect::{
     easy::HighlightLines,
     highlighting::{Style, Theme, ThemeSet},
@@ -11,7 +12,14 @@ static SYNTAX_SET: Lazy<SyntaxSet> = Lazy::new(|| {
     let contents = include_bytes!("../../syntaxes/syntaxes.bin");
     bincode::deserialize(contents).expect("syntaxes are broken")
 });
-static THEMES: Lazy<ThemeSet> = Lazy::new(ThemeSet::load_defaults);
+static THEMES: Lazy<ThemeSet> = Lazy::new(|| {
+    let mut theme_set = ThemeSet::load_defaults();
+    let basedirs = etcetera::choose_base_strategy().expect("could not choose base strategy");
+    let bat_themes = basedirs.config_dir().join("bat").join("themes");
+
+    theme_set.add_from_folder(&bat_themes).unwrap();
+    theme_set
+});
 
 /// A code highlighter.
 #[derive(Clone)]


### PR DESCRIPTION
Hi! I was trying out your project, and wanted to be able to load my own syntax highlighting theme (`tokyonight_day`). [Bat](https://github.com/sharkdp/bat) also uses `syntect`, and has a [directory](https://github.com/sharkdp/bat/blob/7658334645936d2a956fb19aa96e6fca849cb754/src/bin/bat/directories.rs#L28) for custom themes, so I figured it would be neat if presenterm could pick up themes from there as well.

I haven't written much Rust before, so this is more of a starting point/suggestion than an actual PR -- there aren't any tests, this panics if the dir doesn't exist, it doesn't take into account the existence of the `BAT_CONFIG_DIR` variable, and it isn't the most forward-thinking solution (maybe this could be an env var `PRESENTERM_TMTHEMES_DIR` that one points at the bat themes dir instead?). That said, it works :)

<img width="609" alt="Screenshot 2023-11-20 at 3 24 06 PM" src="https://github.com/mfontanini/presenterm/assets/107639398/2dac3594-998f-4711-98cc-9ca6cf5e1893">

Let me know if this is something you'd want to implement yourself, or if you'd prefer I take a proper crack at it. I can't promise any timeliness if I do.