### PR TITLE
Don't override default footer if none is specified

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -540,7 +540,7 @@ impl<'a> PresentationBuilder<'a> {
 
     fn generate_footer(&mut self) -> Vec<RenderOperation> {
         let generator = FooterGenerator {
-            style: self.theme.footer.clone(),
+            style: self.theme.footer.clone().unwrap_or_default(),
             current_slide: self.slides.len(),
             context: self.footer_context.clone(),
         };

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -45,7 +45,7 @@ pub struct PresentationTheme {
 
     /// The style of the presentation footer.
     #[serde(default)]
-    pub(crate) footer: FooterStyle,
+    pub(crate) footer: Option<FooterStyle>,
 }
 
 impl PresentationTheme {


### PR DESCRIPTION
The footer style needs to be an `Option`, otherwise merging themes when overriding causes the original one to be lost.

Fixes #51.