### PR TITLE
Support printing gifs under iterm2

### DIFF
--- a/src/render/engine.rs
+++ b/src/render/engine.rs
@@ -134,7 +134,7 @@ where
 
     fn render_image(&mut self, image: &Image) -> RenderResult {
         let position = CursorPosition { row: self.terminal.cursor_row, column: self.current_rect().start_column };
-        MediaRender
+        MediaRender::default()
             .draw_image(image, position, self.current_dimensions())
             .map_err(|e| RenderError::Other(Box::new(e)))?;
         // TODO try to avoid

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -34,7 +34,7 @@ impl Resources {
         }
 
         let contents = fs::read(&path).map_err(|e| LoadImageError::Io(path.clone(), e))?;
-        let image = Image::new(&contents)?;
+        let image = Image::new(&contents, path.clone())?;
         self.images.insert(path, image.clone());
         Ok(image)
     }


### PR DESCRIPTION
This allows including animated gifs in presentations when using terminals that support the iterm2 protocol (e.g. iterm2 and wezterm).  

Fixes #54