### PR TITLE
Manually sync terminal row if pre-formatted text wraps

### DIFF
--- a/src/render/engine.rs
+++ b/src/render/engine.rs
@@ -156,6 +156,15 @@ where
         self.terminal.print_line(text)?;
         self.terminal.print_line(&" ".repeat(until_right_edge))?;
 
+        // If this line is longer than the screen, our cursor wrapped around so we need to update
+        // the terminal.
+        let current_dimensions = self.current_dimensions();
+        if *unformatted_length as u16 > current_dimensions.columns {
+            let lines_wrapped = *unformatted_length as u16 / current_dimensions.columns;
+            let new_row = self.terminal.cursor_row + lines_wrapped;
+            self.terminal.manual_sync_cursor_row(new_row);
+        }
+
         // Restore colors
         self.apply_colors()?;
         Ok(())

--- a/src/render/terminal.rs
+++ b/src/render/terminal.rs
@@ -85,6 +85,10 @@ impl<W: io::Write> Terminal<W> {
         self.cursor_row = CursorPosition::current()?.row;
         Ok(())
     }
+
+    pub(crate) fn manual_sync_cursor_row(&mut self, position: u16) {
+        self.cursor_row = position;
+    }
 }
 
 impl<W> Drop for Terminal<W>


### PR DESCRIPTION
This causes preformatted lines (code blocks and quotes) which are too long and wrap around not to lose the sync we have between the terminal's cursor and where we think it is.

Reported in #54