### PR TITLE
Add terminal colored themes

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -26,10 +26,10 @@ fn main() -> io::Result<()> {
         let theme_name = file_name.split_once('.').unwrap().0;
         // TODO this wastes a bit of space
         output_file.write_all(format!("(\"{theme_name}\", {contents:?}.as_slice()),\n").as_bytes())?;
-
-        // Rebuild if this theme changes.
-        println!("cargo:rerun-if-changed={}", path.display());
     }
     output_file.write_all(b"]));\n")?;
+
+    // Rebuild if anything changes.
+    println!("cargo:rerun-if-changed=themes");
     Ok(())
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -475,6 +475,7 @@ impl<'a> PresentationBuilder<'a> {
         for line in lines {
             self.chunk_operations.push(RenderOperation::RenderDynamic(Rc::new(line)));
         }
+        self.chunk_operations.push(RenderOperation::SetColors(self.theme.default_style.colors.clone()));
         if self.options.allow_mutations && context.borrow().groups.len() > 1 {
             self.chunk_mutators.push(Box::new(HighlightMutator { context }));
         }

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -8,6 +8,7 @@ use serde::Deserialize;
 use std::{fmt::Debug, rc::Rc};
 
 /// A presentation.
+#[derive(Debug)]
 pub(crate) struct Presentation {
     slides: Vec<Slide>,
     current_slide_index: usize,

--- a/src/render/terminal.rs
+++ b/src/render/terminal.rs
@@ -72,6 +72,7 @@ impl<W: io::Write> Terminal<W> {
     }
 
     pub(crate) fn set_colors(&mut self, colors: Colors) -> io::Result<()> {
+        self.writer.queue(style::ResetColor)?;
         self.writer.queue(style::SetColors(colors.into()))?;
         Ok(())
     }

--- a/src/style.rs
+++ b/src/style.rs
@@ -131,18 +131,55 @@ impl FromStr for Color {
     type Err = ParseColorError;
 
     fn from_str(input: &str) -> Result<Self, Self::Err> {
-        let values = <[u8; 3]>::from_hex(input)?;
-        Ok(Self(crossterm::style::Color::Rgb { r: values[0], g: values[1], b: values[2] }))
+        use crossterm::style::Color as C;
+        let output = match input {
+            "black" => Self(C::Black),
+            "white" => Self(C::White),
+            "grey" => Self(C::Grey),
+            "red" => Self(C::Red),
+            "dark_red" => Self(C::DarkRed),
+            "green" => Self(C::Green),
+            "dark_green" => Self(C::DarkGreen),
+            "blue" => Self(C::Blue),
+            "dark_blue" => Self(C::DarkBlue),
+            "yellow" => Self(C::Yellow),
+            "dark_yellow" => Self(C::DarkYellow),
+            "magenta" => Self(C::Magenta),
+            "dark_magenta" => Self(C::DarkMagenta),
+            "cyan" => Self(C::Cyan),
+            "dark_cyan" => Self(C::DarkCyan),
+            // Fallback to hex-encoded rgb
+            _ => {
+                let values = <[u8; 3]>::from_hex(input)?;
+                Self(crossterm::style::Color::Rgb { r: values[0], g: values[1], b: values[2] })
+            }
+        };
+        Ok(output)
     }
 }
 
 impl Display for Color {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let rgb = match self.0 {
-            crossterm::style::Color::Rgb { r, g, b } => [r, g, b],
-            _ => panic!("not rgb"),
-        };
-        write!(f, "{}", hex::encode(rgb))
+        use crossterm::style::Color as C;
+        match self.0 {
+            C::Rgb { r, g, b } => write!(f, "{}", hex::encode([r, g, b])),
+            C::Black => write!(f, "black"),
+            C::White => write!(f, "white"),
+            C::Grey => write!(f, "grey"),
+            C::Red => write!(f, "red"),
+            C::DarkRed => write!(f, "dark_red"),
+            C::Green => write!(f, "green"),
+            C::DarkGreen => write!(f, "dark_green"),
+            C::Blue => write!(f, "blue"),
+            C::DarkBlue => write!(f, "dark_blue"),
+            C::Yellow => write!(f, "yellow"),
+            C::DarkYellow => write!(f, "dark_yellow"),
+            C::Magenta => write!(f, "magenta"),
+            C::DarkMagenta => write!(f, "dark_magenta"),
+            C::Cyan => write!(f, "cyan"),
+            C::DarkCyan => write!(f, "dark_cyan"),
+            _ => panic!("unsupported color"),
+        }
     }
 }
 

--- a/themes/terminal-dark.yaml
+++ b/themes/terminal-dark.yaml
@@ -1,0 +1,84 @@
+default:
+  margin:
+    percent: 8
+  colors:
+    foreground: null
+    background: null 
+
+slide_title:
+  alignment: center
+  padding_bottom: 1
+  padding_top: 1
+  colors:
+    foreground: yellow
+
+code:
+  alignment: center
+  minimum_size: 50
+  minimum_margin:
+    percent: 8
+  theme_name: base16-eighties.dark
+  padding:
+    horizontal: 2
+    vertical: 1
+
+execution_output:
+  colors:
+    background: grey
+
+inline_code:
+  colors:
+    foreground: green
+
+intro_slide:
+  title:
+    alignment: center
+    colors:
+      foreground: green
+  subtitle:
+    alignment: center
+    colors:
+      foreground: blue
+  author:
+    alignment: center
+    colors:
+      foreground: white
+    positioning: page_bottom
+
+headings:
+  h1:
+    prefix: "██"
+    colors:
+      foreground: cyan
+  h2:
+    prefix: "▓▓▓"
+    colors:
+      foreground: magenta
+  h3:
+    prefix: "▒▒▒▒"
+    colors:
+      foreground: red
+  h4:
+    prefix: "░░░░░"
+    colors:
+      foreground: blue
+  h5:
+    prefix: "░░░░░░"
+    colors:
+      foreground: blue
+  h6:
+    prefix: "░░░░░░░"
+    colors:
+      foreground: blue
+
+block_quote:
+  prefix: "▍ "
+  colors:
+    foreground: white
+    background: black
+
+footer: 
+  style: progress_bar
+  colors:
+    foreground: blue
+

--- a/themes/terminal-light.yaml
+++ b/themes/terminal-light.yaml
@@ -1,0 +1,84 @@
+default:
+  margin:
+    percent: 8
+  colors:
+    foreground: null
+    background: null
+
+slide_title:
+  alignment: center
+  padding_bottom: 1
+  padding_top: 1
+  colors:
+    foreground: dark_yellow
+
+code:
+  alignment: center
+  minimum_size: 50
+  minimum_margin:
+    percent: 8
+  theme_name: GitHub
+  padding:
+    horizontal: 2
+    vertical: 1
+
+execution_output:
+  colors:
+    background: grey
+
+inline_code:
+  colors:
+    foreground: dark_green
+
+intro_slide:
+  title:
+    alignment: center
+    colors:
+      foreground: dark_green
+  subtitle:
+    alignment: center
+    colors:
+      foreground: dark_blue
+  author:
+    alignment: center
+    colors:
+      foreground: black
+    positioning: page_bottom
+
+headings:
+  h1:
+    prefix: "██"
+    colors:
+      foreground: dark_cyan
+  h2:
+    prefix: "▓▓▓"
+    colors:
+      foreground: dark_magenta
+  h3:
+    prefix: "▒▒▒▒"
+    colors:
+      foreground: dark_red
+  h4:
+    prefix: "░░░░░"
+    colors:
+      foreground: dark_blue
+  h5:
+    prefix: "░░░░░░"
+    colors:
+      foreground: dark_blue
+  h6:
+    prefix: "░░░░░░░"
+    colors:
+      foreground: dark_blue
+
+block_quote:
+  prefix: "▍ "
+  colors:
+    foreground: black
+    background: grey
+
+footer: 
+  style: progress_bar
+  colors:
+    foreground: dark_blue
+


### PR DESCRIPTION
This adds a `terminal-dark` and `terminal-light` themes that use the terminal's background/foreground colors and uses named terminal colors for elements that need them.

Fixes #64 