### PR TITLE
Allow providing custom syntect themes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -715,6 +715,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
+name = "line-wrap"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f30344350a2a51da54c1d53be93fade8a237e545dbcc4bdbe635413f2117cab9"
+dependencies = [
+ "safemem",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -877,6 +886,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
+name = "plist"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a4a0cfc5fb21a09dc6af4bf834cf10d4a32fccd9e2ea468c4b1751a097487aa"
+dependencies = [
+ "base64",
+ "indexmap 1.9.3",
+ "line-wrap",
+ "quick-xml",
+ "serde",
+ "time",
+]
+
+[[package]]
 name = "png"
 version = "0.17.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -938,6 +961,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1088,6 +1120,12 @@ name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+
+[[package]]
+name = "safemem"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
 name = "same-file"
@@ -1324,6 +1362,7 @@ dependencies = [
  "fnv",
  "once_cell",
  "onig",
+ "plist",
  "regex-syntax 0.7.5",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ viuer = "0.7"
 [dependencies.syntect]
 version = "5.1"
 default-features = false
-features = ["parsing", "default-themes", "regex-onig"]
+features = ["parsing", "default-themes", "regex-onig", "plist-load"]
 
 [dev-dependencies]
 rstest = { version = "0.18", default-features = false }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,10 @@ use comrak::Arena;
 use presenterm::{
     CodeHighlighter, CommandSource, Exporter, MarkdownParser, PresentMode, PresentationTheme, Presenter, Resources,
 };
-use std::path::{Path, PathBuf};
+use std::{
+    env,
+    path::{Path, PathBuf},
+};
 
 /// Run slideshows from your terminal.
 #[derive(Parser)]
@@ -54,6 +57,14 @@ fn create_splash() -> String {
     )
 }
 
+fn load_custom_themes() {
+    let Ok(home) = env::var("HOME") else {
+        return;
+    };
+    let config = PathBuf::from(home).join(".config/presenterm");
+    let _ = CodeHighlighter::load_themes_from_path(&config.join("themes/highlighting"));
+}
+
 fn display_acknowledgements() {
     let acknowledgements = include_bytes!("../bat/acknowledgements.txt");
     println!("{}", String::from_utf8_lossy(acknowledgements));
@@ -66,6 +77,7 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         let error_message = format!("invalid theme name, valid themes are: {valid_themes}");
         cmd.error(ErrorKind::InvalidValue, error_message).exit();
     };
+    load_custom_themes();
 
     let mode = match (cli.present, cli.export) {
         (true, _) => PresentMode::Presentation,

--- a/src/render/highlighting.rs
+++ b/src/render/highlighting.rs
@@ -9,12 +9,14 @@ use serde::Deserialize;
 use std::{
     collections::BTreeMap,
     io::{self, Write},
+    path::Path,
     sync::{Arc, Mutex},
 };
 use syntect::{
     easy::HighlightLines,
     highlighting::{Style, Theme, ThemeSet},
     parsing::SyntaxSet,
+    LoadingError,
 };
 
 static SYNTAX_SET: Lazy<SyntaxSet> = Lazy::new(|| {
@@ -72,6 +74,13 @@ impl CodeHighlighter {
     pub fn new(theme: &str) -> Result<Self, ThemeNotFound> {
         let theme = THEMES.get(theme).ok_or(ThemeNotFound)?;
         Ok(Self { theme })
+    }
+
+    /// Load .tmTheme themes from the provided path.
+    pub fn load_themes_from_path(path: &Path) -> Result<(), LoadingError> {
+        let themes = ThemeSet::load_from_folder(path)?;
+        THEMES.merge(themes);
+        Ok(())
     }
 
     /// Create a highlighter for a specific language.


### PR DESCRIPTION
This lets you drop `.tmTheme` files in `~/.config/presenterm/themes/highlighting/` which can then be used to highlight code blocks referencing them by name. 

Fixes #50