### PR TITLE
Load themes under ~/.config/presenterm/themes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,5 +22,5 @@ pub use crate::{
     presenter::{PresentMode, Presenter},
     render::highlighting::CodeHighlighter,
     resource::Resources,
-    theme::PresentationTheme,
+    theme::{LoadThemeError, PresentationTheme},
 };

--- a/src/render/highlighting.rs
+++ b/src/render/highlighting.rs
@@ -8,6 +8,7 @@ use once_cell::sync::Lazy;
 use serde::Deserialize;
 use std::{
     collections::BTreeMap,
+    fs,
     io::{self, Write},
     path::Path,
     sync::{Arc, Mutex},
@@ -77,7 +78,13 @@ impl CodeHighlighter {
     }
 
     /// Load .tmTheme themes from the provided path.
-    pub fn load_themes_from_path(path: &Path) -> Result<(), LoadingError> {
+    pub fn register_themes_from_path(path: &Path) -> Result<(), LoadingError> {
+        let Ok(metadata) = fs::metadata(path) else {
+            return Ok(());
+        };
+        if !metadata.is_dir() {
+            return Ok(());
+        }
         let themes = ThemeSet::load_from_folder(path)?;
         THEMES.merge(themes);
         Ok(())


### PR DESCRIPTION
This allows defining custom themes under `~/.config/presenterm/themes`. These themes can then be used as if they were built in: referencing them by name.