### PR TITLE
Allow configuring theme in dotfile

### DIFF
--- a/src/custom.rs
+++ b/src/custom.rs
@@ -1,0 +1,35 @@
+use serde::Deserialize;
+use std::{fs, io, path::Path};
+
+#[derive(Clone, Debug, Default, Deserialize)]
+pub struct Config {
+    #[serde(default)]
+    pub defaults: DefaultsConfig,
+}
+
+impl Config {
+    /// Load the config from a path.
+    pub fn load(path: &Path) -> Result<Self, ConfigLoadError> {
+        let contents = match fs::read_to_string(path) {
+            Ok(contents) => contents,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(Self::default()),
+            Err(e) => return Err(e.into()),
+        };
+        let config = serde_yaml::from_str(&contents)?;
+        Ok(config)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ConfigLoadError {
+    #[error("io: {0}")]
+    Io(#[from] io::Error),
+
+    #[error("invalid configuration: {0}")]
+    Invalid(#[from] serde_yaml::Error),
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+pub struct DefaultsConfig {
+    pub theme: Option<String>,
+}

--- a/src/export.rs
+++ b/src/export.rs
@@ -1,5 +1,5 @@
 use crate::{
-    builder::{BuildError, PresentationBuilder, PresentationBuilderOptions},
+    builder::{BuildError, PresentationBuilder, PresentationBuilderOptions, Themes},
     markdown::{elements::MarkdownElement, parse::ParseError},
     presentation::{Presentation, RenderOperation},
     CodeHighlighter, MarkdownParser, PresentationTheme, Resources,
@@ -20,6 +20,7 @@ pub struct Exporter<'a> {
     default_theme: &'a PresentationTheme,
     default_highlighter: CodeHighlighter,
     resources: Resources,
+    themes: Themes,
 }
 
 impl<'a> Exporter<'a> {
@@ -29,8 +30,9 @@ impl<'a> Exporter<'a> {
         default_theme: &'a PresentationTheme,
         default_highlighter: CodeHighlighter,
         resources: Resources,
+        themes: Themes,
     ) -> Self {
-        Self { parser, default_theme, default_highlighter, resources }
+        Self { parser, default_theme, default_highlighter, resources, themes }
     }
 
     /// Export the given presentation into PDF.
@@ -60,6 +62,7 @@ impl<'a> Exporter<'a> {
             self.default_highlighter.clone(),
             self.default_theme,
             &mut self.resources,
+            &self.themes,
             options,
         )
         .build(elements)?;
@@ -190,15 +193,17 @@ enum CaptureCommand {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::theme::PresentationThemeSet;
     use comrak::Arena;
 
     fn extract_metadata(content: &str, path: &str) -> ExportMetadata {
         let arena = Arena::new();
         let parser = MarkdownParser::new(&arena);
-        let theme = PresentationTheme::from_name("dark").unwrap();
+        let theme = PresentationThemeSet::default().load_by_name("dark").unwrap();
         let highlighter = CodeHighlighter::default();
         let resources = Resources::new("examples");
-        let mut exporter = Exporter::new(parser, &theme, highlighter, resources);
+        let themes = Themes::default();
+        let mut exporter = Exporter::new(parser, &theme, highlighter, resources, themes);
         exporter.extract_metadata(content, Path::new(path)).expect("metadata extraction failed")
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 //! This is not meant to be used as a crate!
 
 pub(crate) mod builder;
+pub(crate) mod custom;
 pub(crate) mod diff;
 pub(crate) mod execute;
 pub(crate) mod export;
@@ -17,6 +18,7 @@ pub(crate) mod theme;
 
 pub use crate::{
     builder::Themes,
+    custom::Config,
     export::{ExportError, Exporter},
     input::source::CommandSource,
     markdown::parse::MarkdownParser,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ pub use crate::{
     input::source::CommandSource,
     markdown::parse::MarkdownParser,
     presenter::{PresentMode, Presenter},
-    render::highlighting::CodeHighlighter,
+    render::highlighting::{CodeHighlighter, HighlightThemeSet},
     resource::Resources,
     theme::{LoadThemeError, PresentationTheme, PresentationThemeSet},
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,11 +16,12 @@ pub(crate) mod style;
 pub(crate) mod theme;
 
 pub use crate::{
+    builder::Themes,
     export::{ExportError, Exporter},
     input::source::CommandSource,
     markdown::parse::MarkdownParser,
     presenter::{PresentMode, Presenter},
     render::highlighting::CodeHighlighter,
     resource::Resources,
-    theme::{LoadThemeError, PresentationTheme},
+    theme::{LoadThemeError, PresentationTheme, PresentationThemeSet},
 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
 use clap::{error::ErrorKind, CommandFactory, Parser};
 use comrak::Arena;
 use presenterm::{
-    CodeHighlighter, CommandSource, Exporter, LoadThemeError, MarkdownParser, PresentMode, PresentationThemeSet,
-    Presenter, Resources, Themes,
+    CodeHighlighter, CommandSource, Exporter, HighlightThemeSet, LoadThemeError, MarkdownParser, PresentMode,
+    PresentationThemeSet, Presenter, Resources, Themes,
 };
 use std::{
     env,
@@ -64,14 +64,17 @@ fn load_themes() -> Result<Themes, Box<dyn std::error::Error>> {
     };
     let config_path = PathBuf::from(home).join(".config/presenterm");
     let themes_path = config_path.join("themes");
-    CodeHighlighter::register_themes_from_path(&themes_path.join("highlighting"))?;
-    let mut presentation_themes = PresentationThemeSet::default();
 
+    let mut highlight_themes = HighlightThemeSet::default();
+    highlight_themes.register_from_directory(&themes_path.join("highlighting"))?;
+
+    let mut presentation_themes = PresentationThemeSet::default();
     let register_result = presentation_themes.register_from_directory(&themes_path);
     if let Err(e @ (LoadThemeError::Duplicate(_) | LoadThemeError::Corrupted(..))) = register_result {
         return Err(e.into());
     }
-    let themes = Themes { presentation: presentation_themes };
+
+    let themes = Themes { presentation: presentation_themes, highlight: highlight_themes };
     Ok(themes)
 }
 

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -1,5 +1,5 @@
 use crate::{
-    builder::{BuildError, PresentationBuilder, PresentationBuilderOptions},
+    builder::{BuildError, PresentationBuilder, PresentationBuilderOptions, Themes},
     diff::PresentationDiffer,
     input::source::{Command, CommandSource},
     markdown::parse::{MarkdownParser, ParseError},
@@ -31,6 +31,7 @@ pub struct Presenter<'a> {
     mode: PresentMode,
     state: PresenterState,
     slides_with_pending_widgets: HashSet<usize>,
+    themes: Themes,
 }
 
 impl<'a> Presenter<'a> {
@@ -41,6 +42,7 @@ impl<'a> Presenter<'a> {
         commands: CommandSource,
         parser: MarkdownParser<'a>,
         resources: Resources,
+        themes: Themes,
         mode: PresentMode,
     ) -> Self {
         Self {
@@ -52,6 +54,7 @@ impl<'a> Presenter<'a> {
             mode,
             state: PresenterState::Empty,
             slides_with_pending_widgets: HashSet::new(),
+            themes,
         }
     }
 
@@ -187,6 +190,7 @@ impl<'a> Presenter<'a> {
             self.default_highlighter.clone(),
             self.default_theme,
             &mut self.resources,
+            &self.themes,
             options,
         )
         .build(elements)?;


### PR DESCRIPTION
This adds the ability to drop a yaml file in `~/.config/presenterm/config.yaml` which lets you configure the default theme to be used on presentations. This will override the `--theme` parameter but a presentation configuring the theme via the front matter still has the highest precedence. So `front-matter-theme > dotfile-theme > cli-parameter-theme`.

Example file contents:

```yaml
defaults:
  theme: potato
```