### PR TITLE
Allow rendering typst/latex formulas

### DIFF
--- a/src/custom.rs
+++ b/src/custom.rs
@@ -5,6 +5,9 @@ use std::{fs, io, path::Path};
 pub struct Config {
     #[serde(default)]
     pub defaults: DefaultsConfig,
+
+    #[serde(default)]
+    pub typst: TypstConfig,
 }
 
 impl Config {
@@ -32,4 +35,20 @@ pub enum ConfigLoadError {
 #[derive(Clone, Debug, Default, Deserialize)]
 pub struct DefaultsConfig {
     pub theme: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct TypstConfig {
+    #[serde(default = "default_typst_ppi")]
+    pub ppi: u32,
+}
+
+impl Default for TypstConfig {
+    fn default() -> Self {
+        Self { ppi: default_typst_ppi() }
+    }
+}
+
+fn default_typst_ppi() -> u32 {
+    300
 }

--- a/src/export.rs
+++ b/src/export.rs
@@ -2,6 +2,7 @@ use crate::{
     builder::{BuildError, PresentationBuilder, PresentationBuilderOptions, Themes},
     markdown::{elements::MarkdownElement, parse::ParseError},
     presentation::{Presentation, RenderOperation},
+    typst::TypstRender,
     CodeHighlighter, MarkdownParser, PresentationTheme, Resources,
 };
 use serde::Serialize;
@@ -18,8 +19,8 @@ const COMMAND: &str = "presenterm-export";
 pub struct Exporter<'a> {
     parser: MarkdownParser<'a>,
     default_theme: &'a PresentationTheme,
-    default_highlighter: CodeHighlighter,
     resources: Resources,
+    typst: TypstRender,
     themes: Themes,
 }
 
@@ -28,11 +29,11 @@ impl<'a> Exporter<'a> {
     pub fn new(
         parser: MarkdownParser<'a>,
         default_theme: &'a PresentationTheme,
-        default_highlighter: CodeHighlighter,
         resources: Resources,
+        typst: TypstRender,
         themes: Themes,
     ) -> Self {
-        Self { parser, default_theme, default_highlighter, resources, themes }
+        Self { parser, default_theme, resources, typst, themes }
     }
 
     /// Export the given presentation into PDF.
@@ -59,9 +60,10 @@ impl<'a> Exporter<'a> {
         let images = Self::build_image_metadata(&elements, base_path);
         let options = PresentationBuilderOptions { allow_mutations: false };
         let presentation = PresentationBuilder::new(
-            self.default_highlighter.clone(),
+            CodeHighlighter::default(),
             self.default_theme,
             &mut self.resources,
+            &mut self.typst,
             &self.themes,
             options,
         )
@@ -200,10 +202,10 @@ mod test {
         let arena = Arena::new();
         let parser = MarkdownParser::new(&arena);
         let theme = PresentationThemeSet::default().load_by_name("dark").unwrap();
-        let highlighter = CodeHighlighter::default();
         let resources = Resources::new("examples");
+        let typst = TypstRender::default();
         let themes = Themes::default();
-        let mut exporter = Exporter::new(parser, &theme, highlighter, resources, themes);
+        let mut exporter = Exporter::new(parser, &theme, resources, typst, themes);
         exporter.extract_metadata(content, Path::new(path)).expect("metadata extraction failed")
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub(crate) mod render;
 pub(crate) mod resource;
 pub(crate) mod style;
 pub(crate) mod theme;
+pub(crate) mod typst;
 
 pub use crate::{
     builder::Themes,
@@ -26,4 +27,5 @@ pub use crate::{
     render::highlighting::{CodeHighlighter, HighlightThemeSet},
     resource::Resources,
     theme::{LoadThemeError, PresentationTheme, PresentationThemeSet},
+    typst::TypstRender,
 };

--- a/src/markdown/elements.rs
+++ b/src/markdown/elements.rs
@@ -235,6 +235,7 @@ pub(crate) enum CodeLanguage {
     Svelte,
     Terraform,
     TypeScript,
+    Typst,
     Unknown,
     Xml,
     Yaml,
@@ -246,6 +247,10 @@ impl CodeLanguage {
     pub(crate) fn supports_execution(&self) -> bool {
         matches!(self, Self::Shell(_))
     }
+
+    pub(crate) fn supports_auto_render(&self) -> bool {
+        matches!(self, Self::Latex | Self::Typst)
+    }
 }
 
 /// Attributes for code blocks.
@@ -253,6 +258,12 @@ impl CodeLanguage {
 pub(crate) struct CodeAttributes {
     /// Whether the code block is marked as executable.
     pub(crate) execute: bool,
+
+    /// Whether a code block is marked to be auto rendered.
+    ///
+    /// An auto rendered piece of code is transformed during parsing, leading to some visual
+    /// representation of it being shown rather than the original code.
+    pub(crate) auto_render: bool,
 
     /// Whether the code block should show line numbers.
     pub(crate) line_numbers: bool,

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -10,6 +10,7 @@ use crate::{
     },
     resource::Resources,
     theme::PresentationTheme,
+    typst::TypstRender,
 };
 use std::{
     collections::HashSet,
@@ -24,10 +25,10 @@ use std::{
 /// This type puts everything else together.
 pub struct Presenter<'a> {
     default_theme: &'a PresentationTheme,
-    default_highlighter: CodeHighlighter,
     commands: CommandSource,
     parser: MarkdownParser<'a>,
     resources: Resources,
+    typst: TypstRender,
     mode: PresentMode,
     state: PresenterState,
     slides_with_pending_widgets: HashSet<usize>,
@@ -38,19 +39,19 @@ impl<'a> Presenter<'a> {
     /// Construct a new presenter.
     pub fn new(
         default_theme: &'a PresentationTheme,
-        default_highlighter: CodeHighlighter,
         commands: CommandSource,
         parser: MarkdownParser<'a>,
         resources: Resources,
+        typst: TypstRender,
         themes: Themes,
         mode: PresentMode,
     ) -> Self {
         Self {
             default_theme,
-            default_highlighter,
             commands,
             parser,
             resources,
+            typst,
             mode,
             state: PresenterState::Empty,
             slides_with_pending_widgets: HashSet::new(),
@@ -187,9 +188,10 @@ impl<'a> Presenter<'a> {
             options.allow_mutations = false;
         }
         let presentation = PresentationBuilder::new(
-            self.default_highlighter.clone(),
+            CodeHighlighter::default(),
             self.default_theme,
             &mut self.resources,
+            &mut self.typst,
             &self.themes,
             options,
         )

--- a/src/render/highlighting.rs
+++ b/src/render/highlighting.rs
@@ -151,6 +151,7 @@ impl CodeHighlighter {
             Svelte => "svelte",
             Terraform => "tf",
             TypeScript => "ts",
+            Typst => "txt",
             // default to plain text so we get the same look&feel
             Unknown => "txt",
             Vue => "vue",

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -1,5 +1,5 @@
 use crate::{
-    render::media::{Image, InvalidImage},
+    render::media::{Image, ImageSource, InvalidImage},
     theme::{LoadThemeError, PresentationTheme},
 };
 use std::{
@@ -34,7 +34,7 @@ impl Resources {
         }
 
         let contents = fs::read(&path).map_err(|e| LoadImageError::Io(path.clone(), e))?;
-        let image = Image::new(&contents, path.clone())?;
+        let image = Image::new(&contents, ImageSource::Filesystem(path.clone()))?;
         self.images.insert(path, image.clone());
         Ok(image)
     }

--- a/src/style.rs
+++ b/src/style.rs
@@ -125,6 +125,13 @@ impl Color {
     pub(crate) fn new(r: u8, g: u8, b: u8) -> Self {
         Self(crossterm::style::Color::Rgb { r, g, b })
     }
+
+    pub(crate) fn as_rgb(&self) -> Option<(u8, u8, u8)> {
+        match self.0 {
+            crossterm::style::Color::Rgb { r, g, b } => Some((r, g, b)),
+            _ => None,
+        }
+    }
 }
 
 impl FromStr for Color {

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -95,6 +95,10 @@ pub struct PresentationTheme {
     /// The style of the presentation footer.
     #[serde(default)]
     pub(crate) footer: Option<FooterStyle>,
+
+    /// The style for typst auto-rendered code blocks.
+    #[serde(default)]
+    pub(crate) typst: TypstStyle,
 }
 
 impl PresentationTheme {
@@ -463,6 +467,19 @@ pub(crate) enum AuthorPositioning {
     /// At the bottom of the page.
     #[default]
     PageBottom,
+}
+
+/// Where to position the author's name in the intro slide.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub(crate) struct TypstStyle {
+    /// The horizontal margin on the generated images.
+    pub(crate) horizontal_margin: Option<u16>,
+
+    /// The vertical margin on the generated images.
+    pub(crate) vertical_margin: Option<u16>,
+
+    /// The colors to be used.
+    pub(crate) colors: Colors,
 }
 
 /// An error loading a presentation theme.

--- a/src/typst.rs
+++ b/src/typst.rs
@@ -1,0 +1,128 @@
+use crate::{
+    render::media::{Image, ImageSource, InvalidImage},
+    style::Color,
+    theme::TypstStyle,
+};
+use std::{
+    fs,
+    io::{self, Write},
+    path::Path,
+    process::{Command, Output, Stdio},
+};
+use tempfile::tempdir;
+
+const DEFAULT_PPI: u32 = 300;
+const DEFAULT_HORIZONTAL_MARGIN: u16 = 5;
+const DEFAULT_VERTICAL_MARGIN: u16 = 7;
+
+pub struct TypstRender {
+    ppi: String,
+}
+
+impl TypstRender {
+    pub fn new(ppi: u32) -> Self {
+        Self { ppi: ppi.to_string() }
+    }
+
+    pub(crate) fn render_typst(&self, input: &str, style: &TypstStyle) -> Result<Image, TypstRenderError> {
+        let workdir = tempdir()?;
+        let mut typst_input = Self::generate_page_header(style)?;
+        typst_input.push_str(input);
+
+        let input_path = workdir.path().join("input.typst");
+        fs::write(&input_path, &typst_input)?;
+        self.render_to_image(workdir.path(), &input_path)
+    }
+
+    pub(crate) fn render_latex(&self, input: &str, style: &TypstStyle) -> Result<Image, TypstRenderError> {
+        let mut child = Command::new("pandoc")
+            .args(["--from", "latex", "--to", "typst"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| TypstRenderError::CommandRun("pandoc", e.to_string()))?;
+
+        child.stdin.take().expect("no stdin").write_all(input.as_bytes())?;
+        let output = child.wait_with_output().map_err(|e| TypstRenderError::CommandRun("pandoc", e.to_string()))?;
+        Self::validate_output(&output, "pandoc")?;
+
+        let input = String::from_utf8_lossy(&output.stdout);
+        self.render_typst(&input, style)
+    }
+
+    fn render_to_image(&self, base_path: &Path, path: &Path) -> Result<Image, TypstRenderError> {
+        let output_path = base_path.join("output.png");
+        let output = Command::new("typst")
+            .args([
+                "compile",
+                "--format",
+                "png",
+                "--ppi",
+                &self.ppi,
+                &path.to_string_lossy(),
+                &output_path.to_string_lossy(),
+            ])
+            .stderr(Stdio::piped())
+            .output()
+            .map_err(|e| TypstRenderError::CommandRun("typst", e.to_string()))?;
+        Self::validate_output(&output, "typst")?;
+
+        let png_contents = fs::read(&output_path)?;
+        let image = Image::new(&png_contents, ImageSource::Generated)?;
+        Ok(image)
+    }
+
+    fn validate_output(output: &Output, name: &'static str) -> Result<(), TypstRenderError> {
+        if output.status.success() {
+            Ok(())
+        } else {
+            let error = String::from_utf8_lossy(&output.stderr);
+            let error = error.lines().take(10).collect();
+            Err(TypstRenderError::CommandRun(name, error))
+        }
+    }
+
+    fn generate_page_header(style: &TypstStyle) -> Result<String, TypstRenderError> {
+        let x_margin = style.horizontal_margin.unwrap_or(DEFAULT_HORIZONTAL_MARGIN);
+        let y_margin = style.vertical_margin.unwrap_or(DEFAULT_VERTICAL_MARGIN);
+        let background =
+            style.colors.background.as_ref().map(Self::as_typst_color).unwrap_or_else(|| Ok(String::from("none")))?;
+        let mut header = format!(
+            "#set page(width: auto, height: auto, margin: (x: {x_margin}pt, y: {y_margin}pt), fill: {background})\n"
+        );
+        if let Some(color) = &style.colors.foreground {
+            let color = Self::as_typst_color(color)?;
+            header.push_str(&format!("#set text(fill: {color})\n"));
+        }
+        Ok(header)
+    }
+
+    fn as_typst_color(color: &Color) -> Result<String, TypstRenderError> {
+        match color.as_rgb() {
+            Some((r, g, b)) => Ok(format!("rgb(\"#{r:02x}{g:02x}{b:02x}\")")),
+            None => Err(TypstRenderError::UnsupportedColor(color.to_string())),
+        }
+    }
+}
+
+impl Default for TypstRender {
+    fn default() -> Self {
+        Self::new(DEFAULT_PPI)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum TypstRenderError {
+    #[error("io: {0}")]
+    Io(#[from] io::Error),
+
+    #[error("invalid output image: {0}")]
+    InvalidImage(#[from] InvalidImage),
+
+    #[error("running command '{0}': {1}")]
+    CommandRun(&'static str, String),
+
+    #[error("unsupported color '{0}', only RGB is supported")]
+    UnsupportedColor(String),
+}


### PR DESCRIPTION
This adds support for rendering typst/latex formulas by tagging code blocks with the right language (`typst` and `latex` respectively) and using the `+render` property on them. For this to work you need:
* [Typst](https://github.com/typst/typst). This is the rendering engine used for both formats.
* If you want latex fomulas, you need typst _and_ [pandoc](https://pandoc.org/). This is used to transform latex into typst before rendering it.

The rationale behind using typst for this is that the language requires no bloat to do this as opposed to latex, and it produces pngs directly rather than going through an intermediate pdf step which simplifies things greatly. 

PS: I still need to test this a bit more but this in a working state.