### PR TITLE
Add syntax highlighting for nix

### DIFF
--- a/docs/highlighting.md
+++ b/docs/highlighting.md
@@ -31,6 +31,7 @@ Code highlighting is supported for the following languages:
 * lua
 * makefile
 * markdown
+* nix
 * ocaml
 * perl
 * php

--- a/src/markdown/code.rs
+++ b/src/markdown/code.rs
@@ -56,6 +56,7 @@ impl CodeBlockParser {
             "lua" => Lua,
             "make" => Makefile,
             "markdown" => Markdown,
+            "nix" => Nix,
             "ocaml" => OCaml,
             "perl" => Perl,
             "php" => Php,

--- a/src/markdown/elements.rs
+++ b/src/markdown/elements.rs
@@ -220,6 +220,7 @@ pub(crate) enum CodeLanguage {
     Lua,
     Makefile,
     Markdown,
+    Nix,
     OCaml,
     Perl,
     Php,

--- a/src/render/highlighting.rs
+++ b/src/render/highlighting.rs
@@ -136,6 +136,7 @@ impl CodeHighlighter {
             Lua => "lua",
             Makefile => "make",
             Markdown => "md",
+            Nix => "nix",
             OCaml => "ml",
             Perl => "pl",
             Php => "php",


### PR DESCRIPTION
`bat` supports `nix` syntax highlighting.