### PR TITLE
Generate PDF replacement images in presenterm directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -922,6 +922,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 name = "presenterm"
 version = "0.3.0"
 dependencies = [
+ "base64",
  "bincode",
  "clap",
  "comrak",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ version = "0.3.0"
 edition = "2021"
 
 [dependencies]
+base64 = "0.21.5"
 bincode = "1.3"
 clap = { version = "4.4", features = ["derive", "string"] }
 comrak = { version = "0.19", default-features = false }

--- a/src/markdown/elements.rs
+++ b/src/markdown/elements.rs
@@ -22,7 +22,7 @@ pub(crate) enum MarkdownElement {
     Paragraph(Vec<ParagraphElement>),
 
     /// An image.
-    Image { path: PathBuf, source_position: SourcePosition },
+    Image { path: PathBuf },
 
     /// A list.
     ///

--- a/src/markdown/parse.rs
+++ b/src/markdown/parse.rs
@@ -176,10 +176,7 @@ impl<'a> MarkdownParser<'a> {
                     if !paragraph_elements.is_empty() {
                         elements.push(MarkdownElement::Paragraph(mem::take(&mut paragraph_elements)));
                     }
-                    elements.push(MarkdownElement::Image {
-                        path: path.into(),
-                        source_position: node.data.borrow().sourcepos.into(),
-                    });
+                    elements.push(MarkdownElement::Image { path: path.into() });
                 }
             }
         }

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -130,6 +130,22 @@ impl Presentation {
         all_rendered
     }
 
+    /// Run a callback through every operation and let it mutate it in place.
+    ///
+    /// This should be used with care!
+    pub(crate) fn mutate_operations<F>(&mut self, mut callback: F)
+    where
+        F: FnMut(&mut RenderOperation),
+    {
+        for slide in &mut self.slides {
+            for chunk in &mut slide.chunks {
+                for operation in &mut chunk.operations {
+                    callback(operation);
+                }
+            }
+        }
+    }
+
     fn current_slide_mut(&mut self) -> &mut Slide {
         &mut self.slides[self.current_slide_index]
     }

--- a/src/render/media.rs
+++ b/src/render/media.rs
@@ -1,6 +1,6 @@
 use crate::render::properties::WindowSize;
 use image::{DynamicImage, ImageError};
-use std::{fmt::Debug, io, path::PathBuf, rc::Rc};
+use std::{fmt::Debug, io, ops::Deref, path::PathBuf, rc::Rc};
 use viuer::{is_iterm_supported, ViuError};
 
 use super::properties::CursorPosition;
@@ -11,7 +11,7 @@ use super::properties::CursorPosition;
 #[derive(Clone, PartialEq)]
 pub(crate) struct Image {
     contents: Rc<DynamicImage>,
-    source: ImageSource,
+    pub(crate) source: ImageSource,
 }
 
 impl Debug for Image {
@@ -21,11 +21,24 @@ impl Debug for Image {
 }
 
 impl Image {
-    /// Construct a new image from a byte sequence.
-    pub(crate) fn new(contents: &[u8], source: ImageSource) -> Result<Self, InvalidImage> {
+    /// Constructs a new image.
+    pub(crate) fn new(image: DynamicImage) -> Self {
+        Self { contents: Rc::new(image), source: ImageSource::Generated }
+    }
+
+    /// Decodes an image from a byte sequence.
+    pub(crate) fn decode(contents: &[u8], source: ImageSource) -> Result<Self, InvalidImage> {
         let contents = image::load_from_memory(contents)?;
         let contents = Rc::new(contents);
         Ok(Self { contents, source })
+    }
+}
+
+impl Deref for Image {
+    type Target = DynamicImage;
+
+    fn deref(&self) -> &Self::Target {
+        &self.contents
     }
 }
 

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -34,7 +34,7 @@ impl Resources {
         }
 
         let contents = fs::read(&path).map_err(|e| LoadImageError::Io(path.clone(), e))?;
-        let image = Image::new(&contents, ImageSource::Filesystem(path.clone()))?;
+        let image = Image::decode(&contents, ImageSource::Filesystem(path.clone()))?;
         self.images.insert(path, image.clone());
         Ok(image)
     }

--- a/src/typst.rs
+++ b/src/typst.rs
@@ -69,7 +69,7 @@ impl TypstRender {
         Self::validate_output(&output, "typst")?;
 
         let png_contents = fs::read(&output_path)?;
-        let image = Image::new(&png_contents, ImageSource::Generated)?;
+        let image = Image::decode(&png_contents, ImageSource::Generated)?;
         Ok(image)
     }
 


### PR DESCRIPTION
This shifts the responsibilities of replacing images during PDF export from presenterm-export to presenterm. This is necessary for latex formulas to be rendered correctly, as those images don't exist in the original markdown file so presenterm-export can't do anything about it. This also simplifies things a bit as presenterm-export doesn't need to hackily half-parse the markdown. 

Needs the presenterm-export changes on https://github.com/mfontanini/presenterm-export/pull/1.

Relates to #6