### PR TITLE
Add syntax highlighting for diff

### DIFF
--- a/docs/highlighting.md
+++ b/docs/highlighting.md
@@ -15,6 +15,7 @@ Code highlighting is supported for the following languages:
 * C++
 * CSS
 * D
+* diff
 * docker
 * dotenv
 * elixir
@@ -54,9 +55,9 @@ Code highlighting is supported for the following languages:
 
 ## Enabling line numbers
 
-If you would like line numbers to be shown on the left of a code block use the `+line_numbers` switch after specifying 
+If you would like line numbers to be shown on the left of a code block use the `+line_numbers` switch after specifying
 the language in a code block:
- 
+
 ~~~
 ```rust +line_numbers
    fn hello_world() {
@@ -67,7 +68,7 @@ the language in a code block:
 
 ## Selective highlighting
 
-By default, the entire code block will be syntax-highlighted. If instead you only wanted a subset of it to be 
+By default, the entire code block will be syntax-highlighted. If instead you only wanted a subset of it to be
 highlighted, you can use braces and a list of either individual lines, or line ranges that you'd want to highlight.
 
 ~~~
@@ -84,7 +85,7 @@ highlighted, you can use braces and a list of either individual lines, or line r
 
 ## Dynamic highlighting
 
-Similar to the syntax used for selective highlighting, dynamic highlighting will change which lines of the code in a 
+Similar to the syntax used for selective highlighting, dynamic highlighting will change which lines of the code in a
 code block are highlighted every time you move to the next/previous slide.
 
 This is achieved by using the separator `|` to indicate what sections of the code will be highlighted at a given time.
@@ -101,8 +102,8 @@ This is achieved by using the separator `|` to indicate what sections of the cod
 ```
 ~~~
 
-In this example, lines 1 and 3 will be highlighted initially. Then once you press a key to move to the next slide, lines 
-1 and 3 will no longer be highlighted and instead lines 5 through 7 will. This allows you to create more dynamic 
+In this example, lines 1 and 3 will be highlighted initially. Then once you press a key to move to the next slide, lines
+1 and 3 will no longer be highlighted and instead lines 5 through 7 will. This allows you to create more dynamic
 presentations where you can display sections of the code to explain something specific about each of them.
 
 See this real example of how this looks like.
@@ -111,8 +112,8 @@ See this real example of how this looks like.
 
 ## Executing code
 
-Annotating a shell code block with a `+exec` switch will make it executable. Once you're in a slide that contains an 
-executable block, press `control+e` to execute it. The output of the execution will be displayed on a box below the 
+Annotating a shell code block with a `+exec` switch will make it executable. Once you're in a slide that contains an
+executable block, press `control+e` to execute it. The output of the execution will be displayed on a box below the
 code. The code execution is stateful so if you switch to another slide and then go back, you will still see the output.
 
 ~~~

--- a/src/markdown/code.rs
+++ b/src/markdown/code.rs
@@ -40,6 +40,7 @@ impl CodeBlockParser {
             "cpp" | "c++" => Cpp,
             "css" => Css,
             "d" => DLang,
+            "diff" => Diff,
             "docker" => Docker,
             "dotenv" => Dotenv,
             "elixir" => Elixir,

--- a/src/markdown/elements.rs
+++ b/src/markdown/elements.rs
@@ -204,6 +204,7 @@ pub(crate) enum CodeLanguage {
     Cpp,
     Css,
     DLang,
+    Diff,
     Docker,
     Dotenv,
     Elixir,

--- a/src/render/highlighting.rs
+++ b/src/render/highlighting.rs
@@ -120,6 +120,7 @@ impl CodeHighlighter {
             Crontab => "crontab",
             Css => "css",
             DLang => "d",
+            Diff => "diff",
             Docker => "Dockerfile",
             Dotenv => "env",
             Elixir => "ex",


### PR DESCRIPTION
Saw [this PR](https://github.com/mfontanini/presenterm/pull/78) and realized adding additional languages was easy.

What I want to be able to show is the changes I made to some code, and this is the simplest way to do that.

<img width="902" alt="Screenshot 2023-12-08 at 12 54 25 PM" src="https://github.com/mfontanini/presenterm/assets/107639398/25d6a159-c445-4b10-bea2-3c0aa743dde6">

My editor strips trailing spaces; I can leave them in if you want, though.
