### PR TITLE
Allow having implicit slide ends

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -39,13 +39,15 @@ pub struct Themes {
     pub highlight: HighlightThemeSet,
 }
 
-pub(crate) struct PresentationBuilderOptions {
-    pub(crate) allow_mutations: bool,
+#[derive(Clone, Debug)]
+pub struct PresentationBuilderOptions {
+    pub allow_mutations: bool,
+    pub implicit_slide_ends: bool,
 }
 
 impl Default for PresentationBuilderOptions {
     fn default() -> Self {
-        Self { allow_mutations: true }
+        Self { allow_mutations: true, implicit_slide_ends: false }
     }
 }
 
@@ -167,7 +169,7 @@ impl<'a> PresentationBuilder<'a> {
             MarkdownElement::Image { path, .. } => self.push_image_from_path(path)?,
         };
         if should_clear_last {
-            self.slide_state.last_element = Default::default();
+            self.slide_state.last_element = LastElement::Other;
         }
         Ok(())
     }
@@ -326,6 +328,12 @@ impl<'a> PresentationBuilder<'a> {
     }
 
     fn push_slide_title(&mut self, mut text: Text) {
+        if self.options.implicit_slide_ends
+            && !matches!(self.slide_state.last_element, LastElement::EndSlide | LastElement::SlideStart)
+        {
+            self.terminate_slide();
+        }
+
         let style = self.theme.slide_title.clone();
         text.apply_style(&TextStyle::default().bold().colors(style.colors.clone()));
 
@@ -576,6 +584,7 @@ impl<'a> PresentationBuilder<'a> {
         self.slides.push(Slide::new(chunks, footer));
         self.push_slide_prelude();
         self.slide_state = Default::default();
+        self.slide_state.last_element = LastElement::EndSlide;
     }
 
     fn generate_footer(&mut self) -> Vec<RenderOperation> {
@@ -823,10 +832,12 @@ enum LayoutState {
 #[derive(Debug, Default)]
 enum LastElement {
     #[default]
-    Any,
+    SlideStart,
+    EndSlide,
     List {
         last_index: usize,
     },
+    Other,
 }
 
 #[derive(Debug, Default)]
@@ -1187,12 +1198,25 @@ mod test {
         try_build_presentation(elements).expect("build failed")
     }
 
+    fn build_presentation_with_options(
+        elements: Vec<MarkdownElement>,
+        options: PresentationBuilderOptions,
+    ) -> Presentation {
+        try_build_presentation_with_options(elements, options).expect("build failed")
+    }
+
     fn try_build_presentation(elements: Vec<MarkdownElement>) -> Result<Presentation, BuildError> {
+        try_build_presentation_with_options(elements, Default::default())
+    }
+
+    fn try_build_presentation_with_options(
+        elements: Vec<MarkdownElement>,
+        options: PresentationBuilderOptions,
+    ) -> Result<Presentation, BuildError> {
         let highlighter = CodeHighlighter::default();
         let theme = PresentationTheme::default();
         let mut resources = Resources::new("/tmp");
         let mut typst = TypstRender::default();
-        let options = PresentationBuilderOptions::default();
         let themes = Themes::default();
         let builder = PresentationBuilder::new(highlighter, &theme, &mut resources, &mut typst, &themes, options);
         builder.build(elements)
@@ -1472,6 +1496,24 @@ mod test {
         // This is pretty easy to break, refactor soon
         let last_operation = &operations[operations.len() - 4];
         assert!(matches!(last_operation, RenderOperation::RenderLineBreak), "last operation is {last_operation:?}");
+    }
+
+    #[test]
+    fn implicit_slide_ends() {
+        let elements = vec![
+            // first slide
+            MarkdownElement::SetexHeading { text: "hi".into() },
+            // second
+            MarkdownElement::SetexHeading { text: "hi".into() },
+            MarkdownElement::Heading { level: 1, text: "hi".into() },
+            // explicitly ends
+            MarkdownElement::Comment { comment: "end_slide".into(), source_position: Default::default() },
+            // third starts
+            MarkdownElement::SetexHeading { text: "hi".into() },
+        ];
+        let options = PresentationBuilderOptions { implicit_slide_ends: true, ..Default::default() };
+        let slides = build_presentation_with_options(elements, options).into_slides();
+        assert_eq!(slides.len(), 3);
     }
 
     #[rstest]

--- a/src/custom.rs
+++ b/src/custom.rs
@@ -8,6 +8,9 @@ pub struct Config {
 
     #[serde(default)]
     pub typst: TypstConfig,
+
+    #[serde(default)]
+    pub options: OptionsConfig,
 }
 
 impl Config {
@@ -35,6 +38,12 @@ pub enum ConfigLoadError {
 #[derive(Clone, Debug, Default, Deserialize)]
 pub struct DefaultsConfig {
     pub theme: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+pub struct OptionsConfig {
+    /// Whether slides are automatically terminated when a slide title is found.
+    pub implicit_slide_ends: bool,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/src/export.rs
+++ b/src/export.rs
@@ -26,6 +26,7 @@ pub struct Exporter<'a> {
     resources: Resources,
     typst: TypstRender,
     themes: Themes,
+    options: PresentationBuilderOptions,
 }
 
 impl<'a> Exporter<'a> {
@@ -36,8 +37,9 @@ impl<'a> Exporter<'a> {
         resources: Resources,
         typst: TypstRender,
         themes: Themes,
+        options: PresentationBuilderOptions,
     ) -> Self {
-        Self { parser, default_theme, resources, typst, themes }
+        Self { parser, default_theme, resources, typst, themes, options }
     }
 
     /// Export the given presentation into PDF.
@@ -73,14 +75,13 @@ impl<'a> Exporter<'a> {
     fn extract_metadata(&mut self, content: &str, path: &Path) -> Result<ExportMetadata, ExportError> {
         let elements = self.parser.parse(content)?;
         let path = path.canonicalize().expect("canonicalize");
-        let options = PresentationBuilderOptions { allow_mutations: false };
         let mut presentation = PresentationBuilder::new(
             CodeHighlighter::default(),
             self.default_theme,
             &mut self.resources,
             &mut self.typst,
             &self.themes,
-            options,
+            self.options.clone(),
         )
         .build(elements)?;
 
@@ -286,7 +287,8 @@ mod test {
         let resources = Resources::new("examples");
         let typst = TypstRender::default();
         let themes = Themes::default();
-        let mut exporter = Exporter::new(parser, &theme, resources, typst, themes);
+        let options = PresentationBuilderOptions { allow_mutations: false, ..Default::default() };
+        let mut exporter = Exporter::new(parser, &theme, resources, typst, themes, options);
         exporter.extract_metadata(content, Path::new(path)).expect("metadata extraction failed")
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ pub(crate) mod tools;
 pub(crate) mod typst;
 
 pub use crate::{
-    builder::Themes,
+    builder::{PresentationBuilderOptions, Themes},
     custom::Config,
     export::{ExportError, Exporter},
     input::source::CommandSource,


### PR DESCRIPTION
This allow shaving implicit slide ends by using a setex header (e.g. slide title). This is an optional behavior and can be enabled by editting `~/.config/presenterm/config.yaml` and adding:

```yaml
options:
  implicit_slide_ends: true
```

Fixes #65