### PR TITLE
Allow selecting a prefix for comment commands

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -43,11 +43,12 @@ pub struct Themes {
 pub struct PresentationBuilderOptions {
     pub allow_mutations: bool,
     pub implicit_slide_ends: bool,
+    pub command_prefix: String,
 }
 
 impl Default for PresentationBuilderOptions {
     fn default() -> Self {
-        Self { allow_mutations: true, implicit_slide_ends: false }
+        Self { allow_mutations: true, implicit_slide_ends: false, command_prefix: String::default() }
     }
 }
 
@@ -266,9 +267,10 @@ impl<'a> PresentationBuilder<'a> {
     }
 
     fn process_comment(&mut self, comment: String, source_position: SourcePosition) -> Result<(), BuildError> {
-        if Self::should_ignore_comment(&comment) {
+        if self.should_ignore_comment(&comment) {
             return Ok(());
         }
+        let comment = comment.trim_start_matches(&self.options.command_prefix);
         let comment = match comment.parse::<CommentCommand>() {
             Ok(comment) => comment,
             Err(error) => return Err(BuildError::CommandParse { line: source_position.start.line + 1, error }),
@@ -307,14 +309,16 @@ impl<'a> PresentationBuilder<'a> {
         Ok(())
     }
 
-    fn should_ignore_comment(comment: &str) -> bool {
-        // Ignore any multi line comment; those are assumed to be user comments
-        if comment.contains('\n') {
-            return true;
+    fn should_ignore_comment(&self, comment: &str) -> bool {
+        if comment.contains('\n') || !comment.starts_with(&self.options.command_prefix) {
+            // Ignore any multi line comment; those are assumed to be user comments
+            // Ignore any line that doesn't start with the selected prefix.
+            true
+        } else {
+            // Ignore vim-like code folding tags
+            let comment = comment.trim();
+            comment == "{{{" || comment == "}}}"
         }
-        // Ignore vim-like code folding tags
-        let comment = comment.trim();
-        comment == "{{{" || comment == "}}}"
     }
 
     fn validate_column_layout(columns: &[u8]) -> Result<(), BuildError> {
@@ -1538,7 +1542,21 @@ mod test {
     #[case::many_open_braces("{{{")]
     #[case::many_close_braces("}}}")]
     fn ignore_comments(#[case] comment: &str) {
-        assert!(PresentationBuilder::should_ignore_comment(comment));
+        let element = MarkdownElement::Comment { comment: comment.into(), source_position: Default::default() };
+        build_presentation(vec![element]);
+    }
+
+    #[rstest]
+    #[case::command_with_prefix("cmd:end_slide", true)]
+    #[case::non_command_with_prefix("cmd:bogus", false)]
+    #[case::non_prefixed("random", true)]
+    fn comment_prefix(#[case] comment: &str, #[case] should_work: bool) {
+        let mut options = PresentationBuilderOptions::default();
+        options.command_prefix = "cmd:".into();
+
+        let element = MarkdownElement::Comment { comment: comment.into(), source_position: Default::default() };
+        let result = try_build_presentation_with_options(vec![element], options);
+        assert_eq!(result.is_ok(), should_work, "{result:?}");
     }
 
     #[test]

--- a/src/custom.rs
+++ b/src/custom.rs
@@ -43,7 +43,10 @@ pub struct DefaultsConfig {
 #[derive(Clone, Debug, Default, Deserialize)]
 pub struct OptionsConfig {
     /// Whether slides are automatically terminated when a slide title is found.
-    pub implicit_slide_ends: bool,
+    pub implicit_slide_ends: Option<bool>,
+
+    /// The prefix to use for commands.
+    pub command_prefix: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,7 +93,8 @@ fn display_acknowledgements() {
 fn make_builder_options(config: &Config, mode: &PresentMode) -> PresentationBuilderOptions {
     PresentationBuilderOptions {
         allow_mutations: !matches!(mode, PresentMode::Export),
-        implicit_slide_ends: config.options.implicit_slide_ends,
+        implicit_slide_ends: config.options.implicit_slide_ends.unwrap_or_default(),
+        command_prefix: config.options.command_prefix.clone().unwrap_or_default(),
     }
 }
 

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -1,4 +1,5 @@
 use crate::{
+    custom::OptionsConfig,
     markdown::text::WeightedLine,
     render::{media::Image, properties::WindowSize},
     style::Colors,
@@ -324,6 +325,10 @@ pub(crate) struct PresentationMetadata {
     /// The presentation's theme metadata.
     #[serde(default)]
     pub(crate) theme: PresentationThemeMetadata,
+
+    /// The presentation's options.
+    #[serde(default)]
+    pub(crate) options: Option<OptionsConfig>,
 }
 
 /// A presentation's theme metadata.


### PR DESCRIPTION
This allows setting a prefix that'll be used to consider a comment command as such, which defaults to an empty string. An HTML comment is considered as such if a) it's single line and b) it starts with the prefix.

Fixes #90