### PR TITLE
Reduce flickering when displaying images

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,10 @@ pub use crate::{
     input::source::CommandSource,
     markdown::parse::MarkdownParser,
     presenter::{PresentMode, Presenter},
-    render::highlighting::{CodeHighlighter, HighlightThemeSet},
+    render::{
+        highlighting::{CodeHighlighter, HighlightThemeSet},
+        media::MediaRender,
+    },
     resource::Resources,
     theme::{LoadThemeError, PresentationTheme, PresentationThemeSet},
     typst::TypstRender,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use clap::{error::ErrorKind, CommandFactory, Parser};
 use comrak::Arena;
 use presenterm::{
-    CommandSource, Config, Exporter, HighlightThemeSet, LoadThemeError, MarkdownParser, PresentMode,
+    CommandSource, Config, Exporter, HighlightThemeSet, LoadThemeError, MarkdownParser, MediaRender, PresentMode,
     PresentationBuilderOptions, PresentationThemeSet, Presenter, Resources, Themes, TypstRender,
 };
 use std::{
@@ -120,6 +120,9 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         display_acknowledgements();
         return Ok(());
     }
+    // Pre-load this so we don't flicker on the first displayed image.
+    MediaRender::detect_terminal_protocol();
+
     let path = cli.path.expect("no path");
     let resources_path = path.parent().unwrap_or(Path::new("/"));
     let resources = Resources::new(resources_path);

--- a/src/render/engine.rs
+++ b/src/render/engine.rs
@@ -134,11 +134,11 @@ where
 
     fn render_image(&mut self, image: &Image) -> RenderResult {
         let position = CursorPosition { row: self.terminal.cursor_row, column: self.current_rect().start_column };
-        MediaRender::default()
+        let (_, height) = MediaRender::default()
             .draw_image(image, position, self.current_dimensions())
             .map_err(|e| RenderError::Other(Box::new(e)))?;
-        // TODO try to avoid
-        self.terminal.sync_cursor_row()?;
+        let row = self.terminal.cursor_row + height as u16;
+        self.terminal.sync_cursor_row(row);
         Ok(())
     }
 
@@ -161,7 +161,7 @@ where
         if *unformatted_length as u16 > max_line_length {
             let lines_wrapped = *unformatted_length as u16 / max_line_length;
             let new_row = self.terminal.cursor_row + lines_wrapped;
-            self.terminal.manual_sync_cursor_row(new_row);
+            self.terminal.sync_cursor_row(new_row);
         }
 
         // Restore colors

--- a/src/render/engine.rs
+++ b/src/render/engine.rs
@@ -190,8 +190,8 @@ where
             self.exit_layout()?;
         }
         let columns = columns.iter().copied().map(u16::from).collect();
-        let current_position = CursorPosition::current()?;
-        self.layout = LayoutState::InitializedColumn { columns, start_row: current_position.row };
+        let current_position = self.terminal.cursor_row;
+        self.layout = LayoutState::InitializedColumn { columns, start_row: current_position };
         Ok(())
     }
 

--- a/src/render/media.rs
+++ b/src/render/media.rs
@@ -67,7 +67,7 @@ impl MediaRender {
         image: &Image,
         position: CursorPosition,
         dimensions: &WindowSize,
-    ) -> Result<(), RenderImageError> {
+    ) -> Result<(u32, u32), RenderImageError> {
         if !dimensions.has_pixels {
             return Err(RenderImageError::NoWindowSize);
         }
@@ -108,11 +108,11 @@ impl MediaRender {
         //
         // This switch is because otherwise `viuer::print_from_file` for kitty/ascii blocks will
         // re-read the image every time.
-        match (&self.mode, source) {
+        let dimensions = match (&self.mode, source) {
             (TerminalMode::Iterm2, ImageSource::Filesystem(image_path)) => viuer::print_from_file(image_path, &config)?,
             (TerminalMode::Other, _) | (_, ImageSource::Generated) => viuer::print(image, &config)?,
         };
-        Ok(())
+        Ok(dimensions)
     }
 }
 

--- a/src/render/media.rs
+++ b/src/render/media.rs
@@ -49,7 +49,7 @@ pub(crate) enum ImageSource {
 }
 
 /// A media render.
-pub(crate) struct MediaRender {
+pub struct MediaRender {
     mode: TerminalMode,
 }
 
@@ -113,6 +113,14 @@ impl MediaRender {
             (TerminalMode::Other, _) | (_, ImageSource::Generated) => viuer::print(image, &config)?,
         };
         Ok(dimensions)
+    }
+
+    /// Detect the terminal protocol we're using.
+    ///
+    /// This simply forces all of the lazy constants in viuer to initialize.
+    pub fn detect_terminal_protocol() {
+        viuer::is_iterm_supported();
+        viuer::get_kitty_support();
     }
 }
 

--- a/src/render/properties.rs
+++ b/src/render/properties.rs
@@ -1,4 +1,4 @@
-use crossterm::{cursor::position, terminal};
+use crossterm::terminal;
 use std::io::{self, ErrorKind};
 
 /// The size of the terminal window.
@@ -86,14 +86,6 @@ impl From<(u16, u16)> for WindowSize {
 pub(crate) struct CursorPosition {
     pub(crate) column: u16,
     pub(crate) row: u16,
-}
-
-impl CursorPosition {
-    /// Get the current cursor position.
-    pub(crate) fn current() -> io::Result<Self> {
-        let (column, row) = position()?;
-        Ok(Self { column, row })
-    }
 }
 
 #[cfg(test)]

--- a/src/render/terminal.rs
+++ b/src/render/terminal.rs
@@ -1,4 +1,3 @@
-use super::properties::CursorPosition;
 use crate::style::Colors;
 use crossterm::{
     cursor,
@@ -82,12 +81,7 @@ impl<W: io::Write> Terminal<W> {
         Ok(())
     }
 
-    pub(crate) fn sync_cursor_row(&mut self) -> io::Result<()> {
-        self.cursor_row = CursorPosition::current()?.row;
-        Ok(())
-    }
-
-    pub(crate) fn manual_sync_cursor_row(&mut self, position: u16) {
+    pub(crate) fn sync_cursor_row(&mut self, position: u16) {
         self.cursor_row = position;
     }
 }


### PR DESCRIPTION
This fixes a few things that causes flickering mostly when displaying images:

* We rely on `viuer`'s return value when printing an image to figure out how many rows the cursor moved. This allows us to drop the manual sync that was there and now the terminal never needs to be resynced which is cool.
*  When entering a layout, we were pulling the cursor position from crossterm. This was leftover code from when the `Terminal` type was introduced, and should have (and now does) pulled this information out of that type as it requires no IO.
* Pre-detect `viuer's support for iterm and kitty. Before the latter would be payed when you displayed the first image which could add some flickering. The iterm support was already being loaded but it's done there too for consistency.

cc @rmartine-ias this may help reduce the flickering issue you had. I still have some flickering, but it's a lot better than it used to be. 