### PR TITLE
Unset LC_TERMINAL before exporting to pdf

### DIFF
--- a/scripts/test-pdf-generation.sh
+++ b/scripts/test-pdf-generation.sh
@@ -11,19 +11,17 @@ trap 'rm -rf "${env_dir}"' EXIT
 python -mvenv "${env_dir}/pyenv"
 source "${env_dir}/pyenv/bin/activate"
 
-echo "Installing presenterm-export==0.1.2"
+echo "Installing presenterm-export==0.2.0"
 pip install presenterm-export
 
 echo "Running presenterm..."
 rm -f "${root_dir}/examples/demo.pdf"
 cargo run -q -- --export-pdf "${root_dir}/examples/demo.md"
 
-if test -f "${root_dir}/examples/demo.pdf"
-then
-  echo "PDF file has been created"
-  rm -f "${root_dir}/examples/demo.pdf"
+if test -f "${root_dir}/examples/demo.pdf"; then
+	echo "PDF file has been created"
+	rm -f "${root_dir}/examples/demo.pdf"
 else
-  echo "PDF file does not exist"
-  exit 1
+	echo "PDF file does not exist"
+	exit 1
 fi
-

--- a/src/export.rs
+++ b/src/export.rs
@@ -97,6 +97,10 @@ impl<'a> Exporter<'a> {
         let presenterm_path = presenterm_path.display().to_string();
         let presentation_path = metadata.presentation_path.display().to_string();
         let metadata = serde_json::to_vec(&metadata).expect("serialization failed");
+        // Remove the LC_TERMINAL environment variable as otherwise viuer will try to talk in
+        // iterm2 protocol to tmux and that breaks.
+        env::remove_var("LC_TERMINAL");
+
         ThirdPartyTools::presenterm_export(&[&presenterm_path, "--export", &presentation_path])
             .stdin(metadata)
             .run()?;


### PR DESCRIPTION
It seems like `viuer` thinks that we support the iterm image protocol when exporting a pdf. Unset the `LC_TERMINAL` environment variable so it doesn't believe that anymore and it emits images as ascii blocs.

Fixes #98