### PR TITLE
Don't enable kitty/iterm in export mode

### DIFF
--- a/scripts/test-pdf-generation.sh
+++ b/scripts/test-pdf-generation.sh
@@ -11,17 +11,19 @@ trap 'rm -rf "${env_dir}"' EXIT
 python -mvenv "${env_dir}/pyenv"
 source "${env_dir}/pyenv/bin/activate"
 
-echo "Installing presenterm-export==0.2.0"
+echo "Installing presenterm-export==0.1.2"
 pip install presenterm-export
 
 echo "Running presenterm..."
 rm -f "${root_dir}/examples/demo.pdf"
 cargo run -q -- --export-pdf "${root_dir}/examples/demo.md"
 
-if test -f "${root_dir}/examples/demo.pdf"; then
-	echo "PDF file has been created"
-	rm -f "${root_dir}/examples/demo.pdf"
+if test -f "${root_dir}/examples/demo.pdf"
+then
+  echo "PDF file has been created"
+  rm -f "${root_dir}/examples/demo.pdf"
 else
-	echo "PDF file does not exist"
-	exit 1
+  echo "PDF file does not exist"
+  exit 1
 fi
+

--- a/src/export.rs
+++ b/src/export.rs
@@ -97,10 +97,6 @@ impl<'a> Exporter<'a> {
         let presenterm_path = presenterm_path.display().to_string();
         let presentation_path = metadata.presentation_path.display().to_string();
         let metadata = serde_json::to_vec(&metadata).expect("serialization failed");
-        // Remove the LC_TERMINAL environment variable as otherwise viuer will try to talk in
-        // iterm2 protocol to tmux and that breaks.
-        env::remove_var("LC_TERMINAL");
-
         ThirdPartyTools::presenterm_export(&[&presenterm_path, "--export", &presentation_path])
             .stdin(metadata)
             .run()?;

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -8,6 +8,7 @@ use crate::{
     render::{
         draw::{RenderError, RenderResult, TerminalDrawer},
         highlighting::CodeHighlighter,
+        media::GraphicsMode,
     },
     resource::Resources,
     theme::PresentationTheme,
@@ -68,7 +69,11 @@ impl<'a> Presenter<'a> {
     pub fn present(mut self, path: &Path) -> Result<(), PresentationError> {
         self.state = PresenterState::Presenting(self.load_presentation(path)?);
 
-        let mut drawer = TerminalDrawer::new(io::stdout())?;
+        let graphics_mode = match self.mode {
+            PresentMode::Export => GraphicsMode::AsciiBlocks,
+            _ => GraphicsMode::default(),
+        };
+        let mut drawer = TerminalDrawer::new(io::stdout(), graphics_mode)?;
         loop {
             self.render(&mut drawer)?;
             self.update_widgets(&mut drawer)?;


### PR DESCRIPTION
This disables kitty/iterm2 when running in export mode. This otherwise can get messed up when running under some terminals, e.g. iterm, and we don't want to leave it up to chance: we know we want ascii blocks in export mode.

Fixes #98