### PR TITLE
Deny unknown fields in yaml models

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1597,4 +1597,11 @@ mod test {
             assert_eq!(&line.prefix, &format!("{line_number} "));
         }
     }
+
+    #[test]
+    fn extra_fields_in_metadata() {
+        let element = MarkdownElement::FrontMatter("nope: 42".into());
+        let result = try_build_presentation(vec![element]);
+        assert!(result.is_err());
+    }
 }

--- a/src/custom.rs
+++ b/src/custom.rs
@@ -2,6 +2,7 @@ use serde::Deserialize;
 use std::{fs, io, path::Path};
 
 #[derive(Clone, Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     #[serde(default)]
     pub defaults: DefaultsConfig,

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -310,6 +310,7 @@ pub(crate) trait ChunkMutator: Debug {
 
 /// The metadata for a presentation.
 #[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct PresentationMetadata {
     /// The presentation title.
     pub(crate) title: Option<String>,

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -55,6 +55,7 @@ impl PresentationThemeSet {
 
 /// A presentation theme.
 #[derive(Default, Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct PresentationTheme {
     /// The style for a slide's title.
     #[serde(default)]


### PR DESCRIPTION
Now any unknown field name in the front matter, presentation or config file will cause an error. This should prevent (honest) user errors like the one in #96.