### PR TITLE
Validate config file and fix docs

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -108,5 +108,5 @@ theme explicitly will use this one:
 
 ```yaml
 defaults:
-  themes: light
+  theme: light
 ```

--- a/src/custom.rs
+++ b/src/custom.rs
@@ -37,11 +37,13 @@ pub enum ConfigLoadError {
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct DefaultsConfig {
     pub theme: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct OptionsConfig {
     /// Whether slides are automatically terminated when a slide title is found.
     pub implicit_slide_ends: Option<bool>,
@@ -51,6 +53,7 @@ pub struct OptionsConfig {
 }
 
 #[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct TypstConfig {
     #[serde(default = "default_typst_ppi")]
     pub ppi: u32,


### PR DESCRIPTION
Ideally we'd also do these validations on theme files but apparently serde and deny_unknown_fields don't get along well with our flattened fields so maybe we'll do that some other day.

Fixes #104

