### PR TITLE
Allow using incremental lists globally

### DIFF
--- a/src/custom.rs
+++ b/src/custom.rs
@@ -50,6 +50,9 @@ pub struct OptionsConfig {
 
     /// The prefix to use for commands.
     pub command_prefix: Option<String>,
+
+    /// Show all lists incrementally, by implicitly adding pauses in between elements.
+    pub incremental_lists: Option<bool>,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,6 +95,7 @@ fn make_builder_options(config: &Config, mode: &PresentMode) -> PresentationBuil
         allow_mutations: !matches!(mode, PresentMode::Export),
         implicit_slide_ends: config.options.implicit_slide_ends.unwrap_or_default(),
         command_prefix: config.options.command_prefix.clone().unwrap_or_default(),
+        incremental_lists: config.options.incremental_lists.unwrap_or_default(),
     }
 }
 


### PR DESCRIPTION
This allows setting a new [config option](https://github.com/mfontanini/presenterm/blob/master/docs/config.md) which makes the behavior in #106 enabled for the entire presentation. e.g. add in front matter

```markdown
---
options:
  incremental_lists: true
---
```

And now all lists will have an implicit pause in between. Do note that if you add an explicit `<!-- pause -->` in between bullet points, there will be double pauses but that's up to you.

Relates to #105