### PR TITLE
Display first presentation load error as any other

### DIFF
--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -67,7 +67,8 @@ impl<'a> Presenter<'a> {
 
     /// Run a presentation.
     pub fn present(mut self, path: &Path) -> Result<(), PresentationError> {
-        self.state = PresenterState::Presenting(self.load_presentation(path)?);
+        self.state = PresenterState::Presenting(Presentation::new(vec![]));
+        self.try_reload(path);
 
         let graphics_mode = match self.mode {
             PresentMode::Export => GraphicsMode::AsciiBlocks,


### PR DESCRIPTION
For some reason I thought the first load should error different than if you load a well formed presentation and then modify it, causing a reload that detects the error and displays it. Upon playing around with presentations this becomes very annoying as errors behave inconsistently.

This treats that first error as the same as any other.