### PR TITLE
Support images to some extent on Windows

### DIFF
--- a/src/custom.rs
+++ b/src/custom.rs
@@ -40,6 +40,8 @@ pub enum ConfigLoadError {
 #[serde(deny_unknown_fields)]
 pub struct DefaultsConfig {
     pub theme: Option<String>,
+
+    pub terminal_font_size: Option<u8>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ pub use crate::{
     export::{ExportError, Exporter},
     input::source::CommandSource,
     markdown::parse::MarkdownParser,
-    presenter::{PresentMode, Presenter},
+    presenter::{PresentMode, Presenter, PresenterOptions},
     render::{
         highlighting::{CodeHighlighter, HighlightThemeSet},
         media::MediaRender,

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,8 @@ use clap::{error::ErrorKind, CommandFactory, Parser};
 use comrak::Arena;
 use presenterm::{
     CommandSource, Config, Exporter, HighlightThemeSet, LoadThemeError, MarkdownParser, MediaRender, PresentMode,
-    PresentationBuilderOptions, PresentationTheme, PresentationThemeSet, Presenter, Resources, Themes, TypstRender,
+    PresentationBuilderOptions, PresentationTheme, PresentationThemeSet, Presenter, PresenterOptions, Resources,
+    Themes, TypstRender,
 };
 use std::{
     env,
@@ -152,7 +153,9 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         }
     } else {
         let commands = CommandSource::new(&path);
-        let presenter = Presenter::new(&default_theme, commands, parser, resources, typst, themes, mode, options);
+        let options =
+            PresenterOptions { builder_options: options, mode, font_size_fallback: config.defaults.terminal_font_size };
+        let presenter = Presenter::new(&default_theme, commands, parser, resources, typst, themes, options);
         presenter.present(&path)?;
     }
     Ok(())

--- a/src/render/engine.rs
+++ b/src/render/engine.rs
@@ -150,7 +150,7 @@ where
             .draw_image(image, position, self.current_dimensions())
             .map_err(|e| RenderError::Other(Box::new(e)))?;
         let row = self.terminal.cursor_row + height as u16;
-        self.terminal.sync_cursor_row(row);
+        self.terminal.sync_cursor_row(row)?;
         Ok(())
     }
 
@@ -173,7 +173,7 @@ where
         if *unformatted_length as u16 > max_line_length {
             let lines_wrapped = *unformatted_length as u16 / max_line_length;
             let new_row = self.terminal.cursor_row + lines_wrapped;
-            self.terminal.sync_cursor_row(new_row);
+            self.terminal.sync_cursor_row(new_row)?;
         }
 
         // Restore colors

--- a/src/render/layout.rs
+++ b/src/render/layout.rs
@@ -161,7 +161,7 @@ mod test {
         Positioning{ max_line_length: 60, start_column: 20 }
     )]
     fn layout(#[case] alignment: Alignment, #[case] length: u16, #[case] expected: Positioning) {
-        let dimensions = WindowSize { rows: 0, columns: 100, width: 0, height: 0, has_pixels: true };
+        let dimensions = WindowSize { rows: 0, columns: 100, width: 0, height: 0 };
         let positioning = Layout::new(alignment).compute(&dimensions, length);
         assert_eq!(positioning, expected);
     }

--- a/src/render/media.rs
+++ b/src/render/media.rs
@@ -73,9 +73,6 @@ impl MediaRender {
         position: CursorPosition,
         dimensions: &WindowSize,
     ) -> Result<(u32, u32), RenderImageError> {
-        if !dimensions.has_pixels {
-            return Err(RenderImageError::NoWindowSize);
-        }
         let source = &image.source;
         let image = &image.contents;
 
@@ -179,7 +176,4 @@ pub enum RenderImageError {
 
     #[error("invalid image: {0}")]
     InvalidImage(#[from] InvalidImage),
-
-    #[error("no window size support in terminal")]
-    NoWindowSize,
 }

--- a/src/render/terminal.rs
+++ b/src/render/terminal.rs
@@ -19,7 +19,9 @@ where
 impl<W: io::Write> Terminal<W> {
     pub(crate) fn new(mut writer: W) -> io::Result<Self> {
         terminal::enable_raw_mode()?;
-        writer.queue(cursor::Hide)?;
+        if should_hide_cursor() {
+            writer.queue(cursor::Hide)?;
+        }
         writer.queue(terminal::EnterAlternateScreen)?;
 
         Ok(Self { writer, cursor_row: 0 })
@@ -92,8 +94,24 @@ where
 {
     fn drop(&mut self) {
         let _ = self.writer.queue(terminal::LeaveAlternateScreen);
-        let _ = self.writer.queue(cursor::Show);
+        if should_hide_cursor() {
+            let _ = self.writer.queue(cursor::Show);
+        }
         let _ = self.writer.flush();
         let _ = terminal::disable_raw_mode();
     }
+}
+
+fn should_hide_cursor() -> bool {
+    // WezTerm on Windows fails to display images if we've hidden the cursor so we **always** hide it
+    // unless we're on WezTerm on Windows.
+    let term = std::env::var("TERM_PROGRAM");
+    let is_wezterm = term.as_ref().map(|s| s.as_str()) == Ok("WezTerm");
+    !(is_windows_based_os() && is_wezterm)
+}
+
+fn is_windows_based_os() -> bool {
+    let is_windows = std::env::consts::OS == "windows";
+    let is_wsl = std::env::var("WSL_DISTRO_NAME").is_ok();
+    is_windows || is_wsl
 }

--- a/src/render/terminal.rs
+++ b/src/render/terminal.rs
@@ -83,8 +83,10 @@ impl<W: io::Write> Terminal<W> {
         Ok(())
     }
 
-    pub(crate) fn sync_cursor_row(&mut self, position: u16) {
+    pub(crate) fn sync_cursor_row(&mut self, position: u16) -> io::Result<()> {
         self.cursor_row = position;
+        self.writer.queue(cursor::MoveToRow(position))?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
This PR attempts to add _some_ support for images on Windows. Specifically:
* Getting the terminal size in pixels fails in that platform so instead we default to a 16 pixel font size and let you specify some other via the config file. This ain't great but it gets the job done.
* WezTerm seems to completely break if you hide the cursor and then display images on Windows (works fine in Linux!). So in that specific combo we don't hide the cursor. This is done only in that scenario as not hiding the cursor is suboptimal as you can sometimes see it moving, especially when printing images. Unfortunately without this images are completely broken there so this is better than nothing.

There's still more work to be done here. e.g. this doesn't work well in the git bash for windows terminal (whatever that is) but at least it seems to work on wezterm.

Relates to #13 