### PR TITLE
Explicitly set execution output fg color in built-in themes

### DIFF
--- a/themes/dark.yaml
+++ b/themes/dark.yaml
@@ -24,6 +24,7 @@ code:
 
 execution_output:
   colors:
+    foreground: "e6e6e6"
     background: "2d2d2d"
 
 inline_code:

--- a/themes/light.yaml
+++ b/themes/light.yaml
@@ -24,6 +24,7 @@ code:
 
 execution_output:
   colors:
+    foreground: "212529"
     background: "e9ecef"
 
 inline_code:

--- a/themes/tokyonight-storm.yaml
+++ b/themes/tokyonight-storm.yaml
@@ -24,6 +24,7 @@ code:
 
 execution_output:
   colors:
+    foreground: "c0caf5"
     background: "2d2d2d"
 
 inline_code:


### PR DESCRIPTION
The foreground color for execution in built-in themes wasn't being set so it could look bad depending on the environment.

Fixes #121