### PR TITLE
chore(entry): Don't panic if path isn't specified rather show helpful msg

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -134,7 +134,10 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
     // Pre-load this so we don't flicker on the first displayed image.
     MediaRender::detect_terminal_protocol();
 
-    let path = cli.path.expect("no path");
+    let path = cli.path.unwrap_or_else(|| {
+        eprintln!("Error: No path specified.");
+        std::process::exit(1);
+    });
     let resources_path = path.parent().unwrap_or(Path::new("/"));
     let resources = Resources::new(resources_path);
     let typst = TypstRender::new(config.typst.ppi);


### PR DESCRIPTION
If no path is provided, the current setup panics. Prooly showing some helpful msg is better ig? 

### Before: 

![screenshot_2024-01-09_12-02-47](https://github.com/mfontanini/presenterm/assets/90331517/6d01a103-9113-4174-8328-74f78cf6a998)

### After

![screenshot_2024-01-09_12-03-22](https://github.com/mfontanini/presenterm/assets/90331517/56f4a09c-fb18-4f47-8e3e-408ec90f22a8)
