### PR TITLE
Add hashes for windows artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,8 @@ jobs:
           if [ "${{ matrix.config.OS }}" = "windows-latest" ]; then
             7z a -tzip "presenterm-${{ env.RELEASE_VERSION }}-${{ matrix.config.TARGET }}.zip" \
               presenterm-${{ env.RELEASE_VERSION }}
+            sha512sum "presenterm-${{ env.RELEASE_VERSION }}-${{ matrix.config.TARGET }}.zip" \
+              > presenterm-${{ env.RELEASE_VERSION }}-${{ matrix.config.TARGET }}.zip.sha512
           else
             tar -czvf presenterm-${{ env.RELEASE_VERSION }}-${{ matrix.config.TARGET }}.tar.gz \
               presenterm-${{ env.RELEASE_VERSION }}/


### PR DESCRIPTION
While trying newly created manifest for scoop (ScoopInstaller/Main#5409), noticed that hash files are absent for both generated Windows artifacts.
Suppose it could be useful to fix this injustice since generated hashes are already available for all the other artifacts.

Tested [here](https://github.com/aliesbelik/presenterm/actions/runs/7470080963/job/20328289340), sample release [here](https://github.com/aliesbelik/presenterm/releases/tag/v0.4.2).