### PR TITLE
Add slide index modal

### DIFF
--- a/examples/demo.md
+++ b/examples/demo.md
@@ -134,7 +134,6 @@ impl Person {
         println!("hello, I'm {}", self.name)
     }
 }
-
 ```
 
 <!-- end_slide -->

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -10,7 +10,8 @@ use crate::{
     },
     presentation::{
         AsRenderOperations, ChunkMutator, MarginProperties, PreformattedLine, Presentation, PresentationMetadata,
-        PresentationThemeMetadata, RenderOnDemand, RenderOnDemandState, RenderOperation, Slide, SlideChunk,
+        PresentationState, PresentationThemeMetadata, RenderOnDemand, RenderOnDemandState, RenderOperation, Slide,
+        SlideBuilder, SlideChunk,
     },
     render::{
         highlighting::{CodeHighlighter, HighlightThemeSet, LanguageHighlighter, StyledTokens},
@@ -87,6 +88,7 @@ pub(crate) struct PresentationBuilder<'a> {
     slide_state: SlideState,
     footer_context: Rc<RefCell<FooterContext>>,
     themes: &'a Themes,
+    index_builder: IndexBuilder,
     options: PresentationBuilderOptions,
 }
 
@@ -112,6 +114,7 @@ impl<'a> PresentationBuilder<'a> {
             slide_state: Default::default(),
             footer_context: Default::default(),
             themes,
+            index_builder: Default::default(),
             options,
         }
     }
@@ -146,7 +149,10 @@ impl<'a> PresentationBuilder<'a> {
         }
         self.footer_context.borrow_mut().total_slides = self.slides.len();
 
-        let presentation = Presentation::new(self.slides);
+        // TODO consider a separate color palette
+        let presentation_state = PresentationState::default();
+        let index = self.index_builder.build(self.theme.default_style.colors.clone(), presentation_state.clone());
+        let presentation = Presentation::new(self.slides, index, presentation_state);
         Ok(presentation)
     }
 
@@ -289,6 +295,7 @@ impl<'a> PresentationBuilder<'a> {
             };
             self.push_text(Text::from(text), ElementType::PresentationAuthor);
         }
+        self.slide_state.title = Some(Text::from("[Introduction]"));
         self.terminate_slide();
     }
 
@@ -372,6 +379,10 @@ impl<'a> PresentationBuilder<'a> {
     fn push_slide_title(&mut self, mut text: Text) {
         if self.options.implicit_slide_ends && !matches!(self.slide_state.last_element, LastElement::None) {
             self.terminate_slide();
+        }
+
+        if self.slide_state.title.is_none() {
+            self.slide_state.title = Some(text.clone());
         }
 
         let style = self.theme.slide_title.clone();
@@ -625,7 +636,12 @@ impl<'a> PresentationBuilder<'a> {
         self.slide_chunks.push(SlideChunk::new(operations, mutators));
 
         let chunks = mem::take(&mut self.slide_chunks);
-        self.slides.push(Slide::new(chunks, footer));
+        let slide = SlideBuilder::default().chunks(chunks).footer(footer).build();
+        self.index_builder
+            .titles
+            .push(self.slide_state.title.take().unwrap_or_else(|| StyledText::from("<no title>").into()));
+        self.slides.push(slide);
+
         self.push_slide_prelude();
         self.slide_state = Default::default();
         self.slide_state.last_element = LastElement::None;
@@ -698,6 +714,124 @@ impl<'a> PresentationBuilder<'a> {
     }
 }
 
+#[derive(Default)]
+struct IndexBuilder {
+    titles: Vec<Text>,
+}
+
+impl IndexBuilder {
+    fn build(self, colors: Colors, state: PresentationState) -> Vec<RenderOperation> {
+        if self.titles.is_empty() {
+            return Vec::new();
+        }
+        let heading = "Slides";
+        let longest_line = self.titles.iter().map(Text::width).max().unwrap_or(0) as u16;
+        let longest_line = longest_line.max(heading.len() as u16);
+        // Ensure we have a minimum width so it doesn't look too narrow.
+        let longest_line = longest_line.max(12);
+        let numbers_length = self.titles.len().ilog10() as usize + 1;
+        // The final text looks like "| <number>: <content> |"
+        let content_width = longest_line + numbers_length as u16 + 6;
+        let mut prefix = vec![RenderOperation::SetColors(colors)];
+
+        prefix.extend(Self::make_horizontal_border(content_width, '┌', '┐'));
+        prefix.extend([
+            RenderOperation::RenderText {
+                line: Self::build_line(heading, [], content_width),
+                alignment: Default::default(),
+            },
+            RenderOperation::RenderLineBreak,
+        ]);
+        prefix.extend(Self::make_horizontal_border(content_width, '├', '┤'));
+        let mut titles = Vec::new();
+        for (index, title) in self.titles.into_iter().enumerate() {
+            let index = pad_right(index + 1, numbers_length);
+            titles.push(Self::build_line(format!("{index}:"), title.chunks, content_width));
+        }
+        let suffix = Self::make_horizontal_border(content_width, '└', '┘').into_iter().collect();
+        let drawer = IndexDrawer { prefix, titles, suffix, state, content_width };
+        vec![RenderOperation::RenderDynamic(Rc::new(drawer))]
+    }
+
+    fn build_line<S, C>(prefix: S, text_chunks: C, content_width: u16) -> WeightedLine
+    where
+        S: Display,
+        C: IntoIterator<Item = StyledText>,
+    {
+        let mut chunks = vec![WeightedText::from(format!("│ {prefix} "))];
+        chunks.extend(text_chunks.into_iter().map(WeightedText::from));
+        let missing = content_width as usize - 1 - chunks.iter().map(|c| c.width()).sum::<usize>();
+        chunks.extend([WeightedText::from(" ".repeat(missing)), WeightedText::from("│")]);
+
+        WeightedLine::from(chunks)
+    }
+
+    fn make_horizontal_border(content_length: u16, opening: char, closing: char) -> [RenderOperation; 2] {
+        let mut line = String::from(opening);
+        line.push_str(&"─".repeat((content_length - 2) as usize));
+        line.push(closing);
+        let horizontal_border = WeightedLine::from(vec![WeightedText::from(line)]);
+        [
+            RenderOperation::RenderText { line: horizontal_border.clone(), alignment: Default::default() },
+            RenderOperation::RenderLineBreak,
+        ]
+    }
+}
+
+#[derive(Debug)]
+struct IndexDrawer {
+    prefix: Vec<RenderOperation>,
+    titles: Vec<WeightedLine>,
+    suffix: Vec<RenderOperation>,
+    content_width: u16,
+    state: PresentationState,
+}
+
+impl IndexDrawer {
+    fn initialize_layout(&self, dimensions: &WindowSize, visible_titles: usize) -> Vec<RenderOperation> {
+        let margin = dimensions.columns.saturating_sub(self.content_width) / 2;
+        let properties = MarginProperties { horizontal_margin: Margin::Fixed(margin), bottom_slide_margin: 0 };
+        // However many we see + 3 for the title and 1 at the bottom.
+        let content_height = (visible_titles + 4) as u16;
+        let target_row = dimensions.rows.saturating_sub(content_height) / 2;
+        vec![RenderOperation::ApplyMargin(properties), RenderOperation::JumpToRow { index: target_row }]
+    }
+}
+
+impl AsRenderOperations for IndexDrawer {
+    fn as_render_operations(&self, dimensions: &WindowSize) -> Vec<RenderOperation> {
+        let current_slide_index = self.state.current_slide_index();
+        let max_rows = (dimensions.rows as f64 * 0.8) as u16;
+        let titles = self.titles.iter().cloned();
+        let (skip, take) = match titles.len() as u16 > max_rows {
+            true => {
+                let start = (current_slide_index as u16).saturating_sub(max_rows / 2);
+                let start = start.min(titles.len() as u16 - max_rows);
+                (start as usize, max_rows as usize)
+            }
+            false => (0, titles.len()),
+        };
+
+        let visible_titles = self.titles.iter().cloned().enumerate().skip(skip).take(take);
+        let mut operations = self.initialize_layout(dimensions, take);
+        operations.extend(self.prefix.iter().cloned());
+        for (index, mut title) in visible_titles {
+            if index == current_slide_index {
+                title.apply_style(TextStyle::default().bold());
+            }
+            let operation = RenderOperation::RenderText { line: title, alignment: Default::default() };
+            operations.extend([operation, RenderOperation::RenderLineBreak]);
+        }
+        operations.extend(self.suffix.iter().cloned());
+        operations
+    }
+
+    fn diffable_content(&self) -> Option<&str> {
+        // The index is just a view over the underlying data so it won't change in isolation.
+        None
+    }
+}
+
 struct CodePreparer<'a> {
     theme: &'a PresentationTheme,
 }
@@ -723,17 +857,13 @@ impl<'a> CodePreparer<'a> {
         }
 
         let padding = " ".repeat(horizontal_padding as usize);
-        let total_lines_width = code.contents.lines().count().ilog10();
+        let total_lines_width = code.contents.lines().count().ilog10() as usize + 1;
         for (index, line) in code.contents.lines().enumerate() {
             let mut line = line.to_string();
             let mut prefix = padding.clone();
             if code.attributes.line_numbers {
                 let line_number = index + 1;
-                let line_number_width = line_number.ilog10();
-                // Suffix this with padding to make all numbers pad to the right
-                let number_padding = total_lines_width - line_number_width;
-                prefix.push_str(&" ".repeat(number_padding as usize));
-                prefix.push_str(&line_number.to_string());
+                prefix.push_str(&pad_right(line_number, total_lines_width));
                 prefix.push(' ');
             }
             line.push('\n');
@@ -859,6 +989,7 @@ struct SlideState {
     last_element: LastElement,
     incremental_lists: Option<bool>,
     layout: LayoutState,
+    title: Option<Text>,
 }
 
 #[derive(Debug, Default)]
@@ -1235,6 +1366,16 @@ struct IndexedListItem {
     item: ListItem,
 }
 
+fn pad_right(number: usize, pad: usize) -> String {
+    let line_number_width = number.ilog10() as usize + 1;
+    let number_padding = pad - line_number_width;
+
+    let mut output = String::new();
+    output.extend(iter::repeat(' ').take(number_padding));
+    output.push_str(&number.to_string());
+    output
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -1291,6 +1432,7 @@ mod test {
             ClearScreen
             | SetColors(_)
             | JumpToVerticalCenter
+            | JumpToRow { .. }
             | JumpToBottomRow { .. }
             | InitColumnLayout { .. }
             | EnterColumn { .. }

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -108,7 +108,7 @@ where
 mod test {
     use super::*;
     use crate::{
-        presentation::{AsRenderOperations, PreformattedLine, Slide},
+        presentation::{AsRenderOperations, PreformattedLine, Slide, SlideBuilder},
         render::properties::WindowSize,
         style::{Color, Colors},
         theme::{Alignment, Margin},
@@ -196,7 +196,7 @@ mod test {
 
     #[test]
     fn no_slide_changes() {
-        let presentation = Presentation::new(vec![
+        let presentation = Presentation::from(vec![
             Slide::from(vec![RenderOperation::ClearScreen]),
             Slide::from(vec![RenderOperation::ClearScreen]),
             Slide::from(vec![RenderOperation::ClearScreen]),
@@ -206,11 +206,11 @@ mod test {
 
     #[test]
     fn slides_truncated() {
-        let lhs = Presentation::new(vec![
+        let lhs = Presentation::from(vec![
             Slide::from(vec![RenderOperation::ClearScreen]),
             Slide::from(vec![RenderOperation::ClearScreen]),
         ]);
-        let rhs = Presentation::new(vec![Slide::from(vec![RenderOperation::ClearScreen])]);
+        let rhs = Presentation::from(vec![Slide::from(vec![RenderOperation::ClearScreen])]);
 
         assert_eq!(
             PresentationDiffer::find_first_modification(&lhs, &rhs),
@@ -220,8 +220,8 @@ mod test {
 
     #[test]
     fn slides_added() {
-        let lhs = Presentation::new(vec![Slide::from(vec![RenderOperation::ClearScreen])]);
-        let rhs = Presentation::new(vec![
+        let lhs = Presentation::from(vec![Slide::from(vec![RenderOperation::ClearScreen])]);
+        let rhs = Presentation::from(vec![
             Slide::from(vec![RenderOperation::ClearScreen]),
             Slide::from(vec![RenderOperation::ClearScreen]),
         ]);
@@ -234,12 +234,12 @@ mod test {
 
     #[test]
     fn second_slide_content_changed() {
-        let lhs = Presentation::new(vec![
+        let lhs = Presentation::from(vec![
             Slide::from(vec![RenderOperation::ClearScreen]),
             Slide::from(vec![RenderOperation::ClearScreen]),
             Slide::from(vec![RenderOperation::ClearScreen]),
         ]);
-        let rhs = Presentation::new(vec![
+        let rhs = Presentation::from(vec![
             Slide::from(vec![RenderOperation::ClearScreen]),
             Slide::from(vec![RenderOperation::JumpToVerticalCenter]),
             Slide::from(vec![RenderOperation::ClearScreen]),
@@ -253,11 +253,11 @@ mod test {
 
     #[test]
     fn presentation_changed_style() {
-        let lhs = Presentation::new(vec![Slide::from(vec![RenderOperation::SetColors(Colors {
+        let lhs = Presentation::from(vec![Slide::from(vec![RenderOperation::SetColors(Colors {
             background: None,
             foreground: Some(Color::new(255, 0, 0)),
         })])]);
-        let rhs = Presentation::new(vec![Slide::from(vec![RenderOperation::SetColors(Colors {
+        let rhs = Presentation::from(vec![Slide::from(vec![RenderOperation::SetColors(Colors {
             background: None,
             foreground: Some(Color::new(0, 0, 0)),
         })])]);
@@ -267,22 +267,20 @@ mod test {
 
     #[test]
     fn chunk_change() {
-        let lhs = Presentation::new(vec![
+        let lhs = Presentation::from(vec![
             Slide::from(vec![RenderOperation::ClearScreen]),
-            Slide::new(
-                vec![SlideChunk::default(), SlideChunk::new(vec![RenderOperation::ClearScreen], vec![])],
-                vec![],
-            ),
+            SlideBuilder::default()
+                .chunks(vec![SlideChunk::default(), SlideChunk::new(vec![RenderOperation::ClearScreen], vec![])])
+                .build(),
         ]);
-        let rhs = Presentation::new(vec![
+        let rhs = Presentation::from(vec![
             Slide::from(vec![RenderOperation::ClearScreen]),
-            Slide::new(
-                vec![
+            SlideBuilder::default()
+                .chunks(vec![
                     SlideChunk::default(),
                     SlideChunk::new(vec![RenderOperation::ClearScreen, RenderOperation::ClearScreen], vec![]),
-                ],
-                vec![],
-            ),
+                ])
+                .build(),
         ]);
 
         assert_eq!(

--- a/src/input/source.rs
+++ b/src/input/source.rs
@@ -64,4 +64,7 @@ pub(crate) enum Command {
     ///
     /// Like [Command::Reload] but also reloads any external resources like images and themes.
     HardReload,
+
+    /// Toggle the slide index view.
+    ToggleSlideIndex,
 }

--- a/src/input/user.rs
+++ b/src/input/user.rs
@@ -53,6 +53,9 @@ impl UserInput {
             KeyCode::Char('r') if event.modifiers == KeyModifiers::CONTROL => {
                 (Some(Command::HardReload), InputState::Empty)
             }
+            KeyCode::Char('p') if event.modifiers == KeyModifiers::CONTROL => {
+                (Some(Command::ToggleSlideIndex), InputState::Empty)
+            }
             _ => (None, InputState::Empty),
         }
     }

--- a/src/render/draw.rs
+++ b/src/render/draw.rs
@@ -33,11 +33,10 @@ where
 
     /// Render a slide.
     pub(crate) fn render_slide(&mut self, presentation: &Presentation) -> RenderResult {
-        let window_dimensions = WindowSize::current(self.font_size_fallback)?;
+        let dimensions = WindowSize::current(self.font_size_fallback)?;
         let slide = presentation.current_slide();
-        let engine = RenderEngine::new(&mut self.terminal, window_dimensions, self.graphics_mode.clone());
+        let engine = self.create_engine(dimensions);
         engine.render(slide.iter_operations())?;
-        self.terminal.flush()?;
         Ok(())
     }
 
@@ -46,7 +45,7 @@ where
         let dimensions = WindowSize::current(self.font_size_fallback)?;
         let heading = vec![
             WeightedText::from(StyledText::new("Error loading presentation", TextStyle::default().bold())),
-            WeightedText::from(StyledText::from(": ")),
+            WeightedText::from(": "),
         ];
 
         let alignment = Alignment::Center { minimum_size: 0, minimum_margin: Margin::Percent(8) };
@@ -62,14 +61,24 @@ where
             RenderOperation::RenderLineBreak,
         ];
         for line in message.lines() {
-            let error = vec![WeightedText::from(StyledText::from(line))];
+            let error = vec![WeightedText::from(line)];
             let op = RenderOperation::RenderText { line: WeightedLine::from(error), alignment: alignment.clone() };
             operations.extend([op, RenderOperation::RenderLineBreak]);
         }
-        let engine = RenderEngine::new(&mut self.terminal, dimensions, self.graphics_mode.clone());
+        let engine = self.create_engine(dimensions);
         engine.render(operations.iter())?;
-        self.terminal.flush()?;
         Ok(())
+    }
+
+    pub(crate) fn render_slide_index(&mut self, presentation: &Presentation) -> RenderResult {
+        let dimensions = WindowSize::current(self.font_size_fallback)?;
+        let engine = self.create_engine(dimensions);
+        engine.render(presentation.iter_index_operations())?;
+        Ok(())
+    }
+
+    fn create_engine(&mut self, dimensions: WindowSize) -> RenderEngine<W> {
+        RenderEngine::new(&mut self.terminal, dimensions, self.graphics_mode.clone())
     }
 }
 

--- a/src/render/engine.rs
+++ b/src/render/engine.rs
@@ -53,6 +53,7 @@ where
         for operation in operations {
             self.render_one(operation)?;
         }
+        self.terminal.flush()?;
         Ok(())
     }
 
@@ -63,8 +64,9 @@ where
             RenderOperation::PopMargin => self.pop_margin(),
             RenderOperation::SetColors(colors) => self.set_colors(colors),
             RenderOperation::JumpToVerticalCenter => self.jump_to_vertical_center(),
+            RenderOperation::JumpToRow { index } => self.jump_to_row(*index),
             RenderOperation::JumpToBottomRow { index } => self.jump_to_bottom(*index),
-            RenderOperation::RenderText { line: texts, alignment } => self.render_text(texts, alignment),
+            RenderOperation::RenderText { line, alignment } => self.render_text(line, alignment),
             RenderOperation::RenderLineBreak => self.render_line_break(),
             RenderOperation::RenderImage(image) => self.render_image(image),
             RenderOperation::RenderPreformattedLine(operation) => self.render_preformatted_line(operation),
@@ -124,6 +126,11 @@ where
     fn jump_to_vertical_center(&mut self) -> RenderResult {
         let center_row = self.current_dimensions().rows / 2;
         self.terminal.move_to_row(center_row)?;
+        Ok(())
+    }
+
+    fn jump_to_row(&mut self, index: u16) -> RenderResult {
+        self.terminal.move_to_row(index)?;
         Ok(())
     }
 


### PR DESCRIPTION
This adds a slide index modal, which shows the slide number + slide name for all the slides (capped if there's too many). You can still move forward/backward and jump to slides using the usual keybindings while having this modal open, so you can use this to navigate and find a particular slide you may be looking for.

This is how this looks like:

[![asciicast](https://asciinema.org/a/1VgRxVIEyLrMmq6OZ3oKx4PGi.svg)](https://asciinema.org/a/1VgRxVIEyLrMmq6OZ3oKx4PGi)

Fixes #123