### PR TITLE
Allow defining custom keybindings in config file

### DIFF
--- a/src/custom.rs
+++ b/src/custom.rs
@@ -1,6 +1,8 @@
 use serde::Deserialize;
 use std::{fs, io, path::Path};
 
+use crate::input::user::KeyBinding;
+
 #[derive(Clone, Debug, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Config {
@@ -12,6 +14,9 @@ pub struct Config {
 
     #[serde(default)]
     pub options: OptionsConfig,
+
+    #[serde(default)]
+    pub bindings: KeyBindingsConfig,
 }
 
 impl Config {
@@ -72,4 +77,107 @@ impl Default for TypstConfig {
 
 fn default_typst_ppi() -> u32 {
     300
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct KeyBindingsConfig {
+    #[serde(default = "default_next_slide_bindings")]
+    pub(crate) next_slide: Vec<KeyBinding>,
+
+    #[serde(default = "default_previous_slide_bindings")]
+    pub(crate) previous_slide: Vec<KeyBinding>,
+
+    #[serde(default = "default_first_slide_bindings")]
+    pub(crate) first_slide: Vec<KeyBinding>,
+
+    #[serde(default = "default_last_slide_bindings")]
+    pub(crate) last_slide: Vec<KeyBinding>,
+
+    #[serde(default = "default_go_to_slide_bindings")]
+    pub(crate) go_to_slide: Vec<KeyBinding>,
+
+    #[serde(default = "default_render_widgets_bindings")]
+    pub(crate) render_widgets: Vec<KeyBinding>,
+
+    #[serde(default = "default_hard_reload_bindings")]
+    pub(crate) hard_reload: Vec<KeyBinding>,
+
+    #[serde(default = "default_toggle_index_bindings")]
+    pub(crate) toggle_slide_index: Vec<KeyBinding>,
+
+    #[serde(default = "default_exit_bindings")]
+    pub(crate) exit: Vec<KeyBinding>,
+}
+
+impl Default for KeyBindingsConfig {
+    fn default() -> Self {
+        Self {
+            next_slide: default_next_slide_bindings(),
+            previous_slide: default_previous_slide_bindings(),
+            first_slide: default_first_slide_bindings(),
+            last_slide: default_last_slide_bindings(),
+            go_to_slide: default_go_to_slide_bindings(),
+            render_widgets: default_render_widgets_bindings(),
+            hard_reload: default_hard_reload_bindings(),
+            toggle_slide_index: default_toggle_index_bindings(),
+            exit: default_exit_bindings(),
+        }
+    }
+}
+
+fn make_keybindings<const N: usize>(raw_bindings: [&str; N]) -> Vec<KeyBinding> {
+    let mut bindings = Vec::new();
+    for binding in raw_bindings {
+        bindings.push(binding.parse().expect("invalid binding"));
+    }
+    bindings
+}
+
+fn default_next_slide_bindings() -> Vec<KeyBinding> {
+    make_keybindings(["l", "j", "<right>", "<page_down>", "<down>", " "])
+}
+
+fn default_previous_slide_bindings() -> Vec<KeyBinding> {
+    make_keybindings(["h", "k", "<left>", "<page_up>", "<up>"])
+}
+
+fn default_first_slide_bindings() -> Vec<KeyBinding> {
+    make_keybindings(["gg"])
+}
+
+fn default_last_slide_bindings() -> Vec<KeyBinding> {
+    make_keybindings(["G"])
+}
+
+fn default_go_to_slide_bindings() -> Vec<KeyBinding> {
+    make_keybindings(["<number>G"])
+}
+
+fn default_render_widgets_bindings() -> Vec<KeyBinding> {
+    make_keybindings(["<c-e>"])
+}
+
+fn default_hard_reload_bindings() -> Vec<KeyBinding> {
+    make_keybindings(["<c-r>"])
+}
+
+fn default_toggle_index_bindings() -> Vec<KeyBinding> {
+    make_keybindings(["<c-p>"])
+}
+
+fn default_exit_bindings() -> Vec<KeyBinding> {
+    make_keybindings(["<c-c>"])
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::input::user::CommandKeyBindings;
+
+    #[test]
+    fn default_bindings() {
+        let config = KeyBindingsConfig::default();
+        CommandKeyBindings::try_from(config).expect("construction failed");
+    }
 }

--- a/src/input/user.rs
+++ b/src/input/user.rs
@@ -1,14 +1,20 @@
-use super::source::Command;
+use super::source::{Command, CommandDiscriminants};
+use crate::custom::KeyBindingsConfig;
 use crossterm::event::{poll, read, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
-use std::{io, mem, time::Duration};
+use serde_with::DeserializeFromStr;
+use std::{fmt, io, iter, mem, str::FromStr, time::Duration};
 
 /// A user input handler.
-#[derive(Default)]
 pub(crate) struct UserInput {
-    state: InputState,
+    bindings: CommandKeyBindings,
+    events: Vec<KeyEvent>,
 }
 
 impl UserInput {
+    pub(crate) fn new(bindings: CommandKeyBindings) -> Self {
+        Self { bindings, events: Vec::new() }
+    }
+
     /// Polls for the next input command coming from the keyboard.
     pub(crate) fn poll_next_command(&mut self, timeout: Duration) -> io::Result<Option<Command>> {
         if poll(timeout)? { self.next_command() } else { Ok(None) }
@@ -16,128 +22,532 @@ impl UserInput {
 
     /// Blocks waiting for the next command.
     pub(crate) fn next_command(&mut self) -> io::Result<Option<Command>> {
-        let current_state = mem::take(&mut self.state);
-        let (command, next_state) = match read()? {
-            Event::Key(event) => Self::apply_key_event(event, current_state),
-            Event::Resize(..) => (Some(Command::Redraw), current_state),
-            _ => (None, current_state),
+        let mut events = mem::take(&mut self.events);
+        let (command, events) = match read()? {
+            Event::Key(event) => {
+                if event.kind == KeyEventKind::Release {
+                    return Ok(None);
+                }
+                events.push(event);
+                self.match_events(events)
+            }
+            Event::Resize(..) => (Some(Command::Redraw), events),
+            _ => (None, mem::take(&mut self.events)),
         };
-        self.state = next_state;
+        self.events = events;
         Ok(command)
     }
 
-    fn apply_key_event(event: KeyEvent, state: InputState) -> (Option<Command>, InputState) {
-        if event.kind == KeyEventKind::Release {
-            return (None, state);
-        }
-        match event.code {
-            KeyCode::Char('h') | KeyCode::Char('k') | KeyCode::Left | KeyCode::PageUp | KeyCode::Up => {
-                (Some(Command::JumpPreviousSlide), InputState::Empty)
-            }
-            KeyCode::Char('l')
-            | KeyCode::Char('j')
-            | KeyCode::Right
-            | KeyCode::PageDown
-            | KeyCode::Down
-            | KeyCode::Char(' ') => (Some(Command::JumpNextSlide), InputState::Empty),
-            KeyCode::Char('c') if event.modifiers == KeyModifiers::CONTROL => (Some(Command::Exit), InputState::Empty),
-            KeyCode::Char('e') if event.modifiers == KeyModifiers::CONTROL => {
-                (Some(Command::RenderWidgets), InputState::Empty)
-            }
-            KeyCode::Char('G') => Self::apply_uppercase_g(state),
-            KeyCode::Char('g') => Self::apply_lowercase_g(state),
-            KeyCode::Char(number) if number.is_ascii_digit() => {
-                let number = number.to_digit(10).expect("not a digit");
-                (None, Self::apply_number(number, state))
-            }
-            KeyCode::Char('r') if event.modifiers == KeyModifiers::CONTROL => {
-                (Some(Command::HardReload), InputState::Empty)
-            }
-            KeyCode::Char('p') if event.modifiers == KeyModifiers::CONTROL => {
-                (Some(Command::ToggleSlideIndex), InputState::Empty)
-            }
-            _ => (None, InputState::Empty),
-        }
-    }
-
-    fn apply_lowercase_g(state: InputState) -> (Option<Command>, InputState) {
-        match state {
-            InputState::PendingG => (Some(Command::JumpFirstSlide), InputState::Empty),
-            InputState::Empty => (None, InputState::PendingG),
-            _ => (None, InputState::Empty),
-        }
-    }
-
-    fn apply_uppercase_g(state: InputState) -> (Option<Command>, InputState) {
-        match state {
-            InputState::Empty => (Some(Command::JumpLastSlide), InputState::Empty),
-            InputState::PendingNumber(number) => (Some(Command::JumpSlide(number)), InputState::Empty),
-            _ => (None, InputState::Empty),
-        }
-    }
-
-    fn apply_number(number: u32, state: InputState) -> InputState {
-        let maybe_next = match state {
-            InputState::PendingNumber(current) => current.checked_mul(10).and_then(|n| n.checked_add(number)),
-            InputState::Empty => Some(number),
-            _ => {
-                return InputState::Empty;
-            }
-        };
-        // If we overflowed, jump to a terminal state that indicates so. This way 123123123G is not
-        // an alias for G
-        match maybe_next {
-            Some(number) => InputState::PendingNumber(number),
-            None => InputState::OverflowedNumber,
+    fn match_events(&self, events: Vec<KeyEvent>) -> (Option<Command>, Vec<KeyEvent>) {
+        match self.bindings.apply(&events) {
+            InputAction::Emit(command) => (Some(command), Vec::new()),
+            InputAction::Buffer => (None, events),
+            InputAction::Reset => (None, Vec::new()),
         }
     }
 }
 
-#[derive(Default, Debug, PartialEq, Eq)]
-enum InputState {
-    #[default]
-    Empty,
-    PendingG,
-    PendingNumber(u32),
-    OverflowedNumber,
+enum InputAction {
+    Buffer,
+    Reset,
+    Emit(Command),
+}
+
+pub struct CommandKeyBindings {
+    bindings: Vec<(KeyBinding, CommandDiscriminants)>,
+}
+
+impl CommandKeyBindings {
+    fn apply(&self, events: &[KeyEvent]) -> InputAction {
+        let mut any_partials = false;
+        for (binding, identifier) in &self.bindings {
+            match binding.match_events(events) {
+                BindingMatch::Full(context) => return Self::instantiate(identifier, context),
+                BindingMatch::Partial => any_partials = true,
+                BindingMatch::None => (),
+            }
+        }
+        if any_partials { InputAction::Buffer } else { InputAction::Reset }
+    }
+
+    fn instantiate(discriminant: &CommandDiscriminants, context: MatchContext) -> InputAction {
+        use CommandDiscriminants::*;
+        let command = match discriminant {
+            Redraw => Command::Redraw,
+            NextSlide => Command::NextSlide,
+            PreviousSlide => Command::PreviousSlide,
+            FirstSlide => Command::FirstSlide,
+            LastSlide => Command::LastSlide,
+            GoToSlide => {
+                match context {
+                    // this means the command is malformed and this should have been caught earlier
+                    // on.
+                    MatchContext::None => return InputAction::Reset,
+                    MatchContext::Number(number) => Command::GoToSlide(number),
+                }
+            }
+            RenderWidgets => Command::RenderWidgets,
+            Exit => Command::Exit,
+            Reload => Command::Reload,
+            HardReload => Command::HardReload,
+            ToggleSlideIndex => Command::ToggleSlideIndex,
+        };
+        InputAction::Emit(command)
+    }
+
+    fn validate_conflicts<'a>(
+        bindings: impl Iterator<Item = &'a KeyBinding>,
+    ) -> Result<(), KeyBindingsValidationError> {
+        let mut bindings: Vec<_> = bindings.map(|binding| &binding.0).collect();
+        bindings.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        for window in bindings.windows(2) {
+            if window[0].iter().eq(window[1].iter().take(window[0].len())) {
+                return Err(KeyBindingsValidationError::Conflict(
+                    KeyBinding(window[0].clone()),
+                    KeyBinding(window[1].clone()),
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+impl TryFrom<KeyBindingsConfig> for CommandKeyBindings {
+    type Error = KeyBindingsValidationError;
+
+    fn try_from(config: KeyBindingsConfig) -> Result<Self, Self::Error> {
+        let zip = |discriminant, bindings: Vec<KeyBinding>| bindings.into_iter().zip(iter::repeat(discriminant));
+        if !config.go_to_slide.iter().all(|k| k.expects_number()) {
+            return Err(KeyBindingsValidationError::Invalid("go_to_slide", "<number> matcher required"));
+        }
+        let bindings: Vec<_> = iter::empty()
+            .chain(zip(CommandDiscriminants::NextSlide, config.next_slide))
+            .chain(zip(CommandDiscriminants::PreviousSlide, config.previous_slide))
+            .chain(zip(CommandDiscriminants::FirstSlide, config.first_slide))
+            .chain(zip(CommandDiscriminants::LastSlide, config.last_slide))
+            .chain(zip(CommandDiscriminants::GoToSlide, config.go_to_slide))
+            .chain(zip(CommandDiscriminants::Exit, config.exit))
+            .chain(zip(CommandDiscriminants::HardReload, config.hard_reload))
+            .chain(zip(CommandDiscriminants::ToggleSlideIndex, config.toggle_slide_index))
+            .chain(zip(CommandDiscriminants::RenderWidgets, config.render_widgets))
+            .collect();
+        Self::validate_conflicts(bindings.iter().map(|binding| &binding.0))?;
+        Ok(Self { bindings })
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum KeyBindingsValidationError {
+    #[error("invalid binding for {0}: {1}")]
+    Invalid(&'static str, &'static str),
+
+    #[error("conflicting keybindings: {0} and {1}")]
+    Conflict(KeyBinding, KeyBinding),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum BindingMatch {
+    Full(MatchContext),
+    Partial,
+    None,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, DeserializeFromStr)]
+pub struct KeyBinding(Vec<KeyMatcher>);
+
+impl KeyBinding {
+    fn match_events(&self, mut events: &[KeyEvent]) -> BindingMatch {
+        let mut output_context = MatchContext::None;
+        for (index, matcher) in self.0.iter().enumerate() {
+            let Some((context, rest)) = matcher.try_match_events(events) else {
+                return BindingMatch::None;
+            };
+            if !matches!(context, MatchContext::None) {
+                output_context = context;
+            }
+            events = rest;
+
+            // We ran all matchers but we have no events left; this is a partial match.
+            if index != self.0.len() - 1 && events.is_empty() {
+                return BindingMatch::Partial;
+            }
+        }
+        // If there's more events than we need, this is an issue on the caller side.
+        BindingMatch::Full(output_context)
+    }
+
+    fn expects_number(&self) -> bool {
+        self.0.iter().any(|m| matches!(m, KeyMatcher::Number))
+    }
+}
+
+impl FromStr for KeyBinding {
+    type Err = KeyBindingParseError;
+
+    fn from_str(mut input: &str) -> Result<Self, Self::Err> {
+        let mut matchers = Vec::new();
+        let mut has_numbers = false;
+        while !input.is_empty() {
+            let (matcher, rest) = KeyMatcher::parse(input)?;
+            let is_number = matches!(matcher, KeyMatcher::Number);
+            // We don't want more than one <number> matcher
+            if has_numbers && is_number {
+                return Err(KeyBindingParseError::TooManyNumbers);
+            }
+            has_numbers = has_numbers || is_number;
+            matchers.push(matcher);
+            input = rest;
+        }
+        Ok(Self(matchers))
+    }
+}
+
+impl fmt::Display for KeyBinding {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for matcher in &self.0 {
+            write!(f, "{matcher}")?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum KeyBindingParseError {
+    #[error("no input")]
+    NoInput,
+
+    #[error("not a valid key: {0}")]
+    InvalidKey(char),
+
+    #[error("too many number placeholders")]
+    TooManyNumbers,
+
+    #[error("invalid control sequence")]
+    InvalidControlSequence,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd)]
+enum KeyMatcher {
+    Key(KeyCombination),
+    Number,
+}
+
+impl KeyMatcher {
+    fn try_match_events<'a>(&self, events: &'a [KeyEvent]) -> Option<(MatchContext, &'a [KeyEvent])> {
+        match self {
+            Self::Key(combo) => Self::try_match_key(combo, events),
+            Self::Number => Self::try_match_number(events),
+        }
+    }
+
+    fn try_match_key<'a>(combo: &KeyCombination, events: &'a [KeyEvent]) -> Option<(MatchContext, &'a [KeyEvent])> {
+        let event = events.first()?;
+        let is_control = event.modifiers == KeyModifiers::CONTROL;
+        if combo.key == event.code && combo.control == is_control {
+            let rest = &events[1..];
+            Some((MatchContext::None, rest))
+        } else {
+            None
+        }
+    }
+
+    fn try_match_number(mut events: &[KeyEvent]) -> Option<(MatchContext, &[KeyEvent])> {
+        let mut number = None;
+        while let Some((head, rest)) = events.split_first() {
+            let digit = match head.code {
+                KeyCode::Char(c) if c.is_ascii_digit() => c.to_digit(10).expect("not a digit"),
+                _ => break,
+            };
+
+            let next = number.unwrap_or(0u32).checked_mul(10).and_then(|number| number.checked_add(digit));
+            match next {
+                Some(n) => {
+                    number = Some(n);
+                    events = rest;
+                }
+                // if we overflow we're done
+                None => return None,
+            }
+        }
+        number.map(|number| (MatchContext::Number(number), events))
+    }
+
+    fn parse(input: &str) -> Result<(Self, &str), KeyBindingParseError> {
+        if let Some(input) = input.strip_prefix("<number>") {
+            Ok((Self::Number, input))
+        } else if let Some(input) = Self::try_match_input(input, &["<c-", "<C-"]) {
+            let (key, input) = Self::parse_key_code(input)?;
+            let Some(input) = input.strip_prefix('>') else {
+                return Err(KeyBindingParseError::InvalidControlSequence);
+            };
+            let matcher = Self::Key(KeyCombination { key, control: true });
+            Ok((matcher, input))
+        } else {
+            let (key, input) = Self::parse_key_code(input)?;
+            let matcher = Self::Key(KeyCombination { key, control: false });
+            Ok((matcher, input))
+        }
+    }
+
+    fn parse_key_code(input: &str) -> Result<(KeyCode, &str), KeyBindingParseError> {
+        if let Some(input) = Self::try_match_input(input, &["<PageUp>", "<page_up>"]) {
+            Ok((KeyCode::PageUp, input))
+        } else if let Some(input) = Self::try_match_input(input, &["<PageDown>", "<page_down>"]) {
+            Ok((KeyCode::PageDown, input))
+        } else if let Some(input) = Self::try_match_input(input, &["<cr>", "<CR>", "<Enter>", "<enter>"]) {
+            Ok((KeyCode::Enter, input))
+        } else if let Some(input) = Self::try_match_input(input, &["<Home>", "<home>"]) {
+            Ok((KeyCode::Home, input))
+        } else if let Some(input) = Self::try_match_input(input, &["<End>", "<end>"]) {
+            Ok((KeyCode::End, input))
+        } else if let Some(input) = Self::try_match_input(input, &["<Left>", "<left>"]) {
+            Ok((KeyCode::Left, input))
+        } else if let Some(input) = Self::try_match_input(input, &["<Right>", "<right>"]) {
+            Ok((KeyCode::Right, input))
+        } else if let Some(input) = Self::try_match_input(input, &["<Up>", "<up>"]) {
+            Ok((KeyCode::Up, input))
+        } else if let Some(input) = Self::try_match_input(input, &["<Down>", "<down>"]) {
+            Ok((KeyCode::Down, input))
+        } else if let Some(input) = Self::try_match_input(input, &["<Esc>", "<esc>"]) {
+            Ok((KeyCode::Esc, input))
+        } else {
+            let next = input.chars().next().ok_or(KeyBindingParseError::NoInput)?;
+            // don't allow these as they create ambiguity
+            if next == '<' || next == '>' {
+                Err(KeyBindingParseError::InvalidKey(next))
+            } else if next.is_alphanumeric() || next.is_ascii_punctuation() || next == ' ' {
+                let key = KeyCode::Char(next);
+                Ok((key, &input[next.len_utf8()..]))
+            } else {
+                Err(KeyBindingParseError::InvalidKey(next))
+            }
+        }
+    }
+
+    fn try_match_input<'a>(input: &'a str, aliases: &[&str]) -> Option<&'a str> {
+        for alias in aliases {
+            if let Some(input) = input.strip_prefix(alias) {
+                return Some(input);
+            }
+        }
+        None
+    }
+}
+
+impl fmt::Display for KeyMatcher {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Number => write!(f, "<number>"),
+            Self::Key(combo) => {
+                if combo.control {
+                    write!(f, "<c-")?;
+                }
+                match combo.key {
+                    KeyCode::Char(c) => write!(f, "{}", c)?,
+                    other => write!(f, "<{other:?}>")?,
+                };
+                if combo.control {
+                    write!(f, ">")?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum MatchContext {
+    Number(u32),
+    None,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd)]
+struct KeyCombination {
+    key: KeyCode,
+    control: bool,
+}
+
+impl KeyCombination {
+    #[cfg(test)]
+    fn char(c: char) -> Self {
+        Self { key: KeyCode::Char(c), control: false }
+    }
+
+    #[cfg(test)]
+    fn control_char(c: char) -> Self {
+        Self { key: KeyCode::Char(c), control: true }
+    }
+}
+
+impl From<KeyCode> for KeyCombination {
+    fn from(key: KeyCode) -> Self {
+        Self { key, control: false }
+    }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
+    use crossterm::event::KeyEventState;
+    use rstest::rstest;
 
-    #[test]
-    fn lowercase_g() {
-        let state = InputState::Empty;
-        let (command, state) = UserInput::apply_key_event(KeyCode::Char('g').into(), state);
-        assert!(command.is_none());
-
-        let (command, state) = UserInput::apply_key_event(KeyCode::Char('g').into(), state);
-        assert_eq!(command, Some(Command::JumpFirstSlide));
-        assert_eq!(state, InputState::Empty);
+    trait KeyEventSource {
+        fn into_event(self) -> KeyEvent;
     }
 
-    #[test]
-    fn uppercase_g() {
-        let state = InputState::Empty;
-        let (command, state) = UserInput::apply_key_event(KeyCode::Char('G').into(), state);
-        assert_eq!(command, Some(Command::JumpLastSlide));
-        assert_eq!(state, InputState::Empty);
+    impl KeyEventSource for KeyCode {
+        fn into_event(self) -> KeyEvent {
+            KeyEvent {
+                code: self,
+                modifiers: KeyModifiers::empty(),
+                kind: KeyEventKind::Press,
+                state: KeyEventState::NONE,
+            }
+        }
     }
 
-    #[test]
-    fn jump_number() {
-        let state = InputState::Empty;
-        let (command, state) = UserInput::apply_key_event(KeyCode::Char('1').into(), state);
-        assert!(command.is_none());
-        assert_eq!(state, InputState::PendingNumber(1));
+    impl KeyEventSource for char {
+        fn into_event(self) -> KeyEvent {
+            KeyCode::Char(self).into_event()
+        }
+    }
 
-        let (command, state) = UserInput::apply_key_event(KeyCode::Char('2').into(), state);
-        assert!(command.is_none());
-        assert_eq!(state, InputState::PendingNumber(12));
+    trait KeyEventExt {
+        fn with_control(self) -> Self;
+    }
 
-        let (command, state) = UserInput::apply_key_event(KeyCode::Char('G').into(), state);
-        assert_eq!(command, Some(Command::JumpSlide(12)));
-        assert_eq!(state, InputState::Empty);
+    impl KeyEventExt for KeyEvent {
+        fn with_control(mut self) -> Self {
+            self.modifiers = KeyModifiers::CONTROL;
+            self
+        }
+    }
+
+    #[rstest]
+    #[case::number("<number>", vec![KeyMatcher::Number])]
+    #[case::char("w", vec![KeyMatcher::Key(KeyCombination::char('w'))])]
+    #[case::ctrl_char1("<c-w>", vec![KeyMatcher::Key(KeyCombination::control_char('w'))])]
+    #[case::ctrl_char2("<C-w>", vec![KeyMatcher::Key(KeyCombination::control_char('w'))])]
+    #[case::dot(".", vec![KeyMatcher::Key(KeyCombination::char('.'))])]
+    #[case::dot(" ", vec![KeyMatcher::Key(KeyCombination::char(' '))])]
+    #[case::multi("hi", vec![KeyMatcher::Key(KeyCombination::char('h')), KeyMatcher::Key(KeyCombination::char('i'))])]
+    #[case::page_up1("<page_up>", vec![KeyMatcher::Key(KeyCode::PageUp.into())])]
+    #[case::page_up2("<PageUp>", vec![KeyMatcher::Key(KeyCode::PageUp.into())])]
+    #[case::page_down1("<page_down>", vec![KeyMatcher::Key(KeyCode::PageDown.into())])]
+    #[case::page_down2("<PageDown>", vec![KeyMatcher::Key(KeyCode::PageDown.into())])]
+    #[case::enter1("<CR>", vec![KeyMatcher::Key(KeyCode::Enter.into())])]
+    #[case::enter2("<cr>", vec![KeyMatcher::Key(KeyCode::Enter.into())])]
+    #[case::enter3("<enter>", vec![KeyMatcher::Key(KeyCode::Enter.into())])]
+    #[case::home1("<home>", vec![KeyMatcher::Key(KeyCode::Home.into())])]
+    #[case::home2("<Home>", vec![KeyMatcher::Key(KeyCode::Home.into())])]
+    #[case::end1("<End>", vec![KeyMatcher::Key(KeyCode::End.into())])]
+    #[case::end2("<end>", vec![KeyMatcher::Key(KeyCode::End.into())])]
+    #[case::left1("<Left>", vec![KeyMatcher::Key(KeyCode::Left.into())])]
+    #[case::left2("<left>", vec![KeyMatcher::Key(KeyCode::Left.into())])]
+    #[case::right1("<Right>", vec![KeyMatcher::Key(KeyCode::Right.into())])]
+    #[case::right2("<right>", vec![KeyMatcher::Key(KeyCode::Right.into())])]
+    #[case::up1("<Up>", vec![KeyMatcher::Key(KeyCode::Up.into())])]
+    #[case::up2("<up>", vec![KeyMatcher::Key(KeyCode::Up.into())])]
+    #[case::down1("<Down>", vec![KeyMatcher::Key(KeyCode::Down.into())])]
+    #[case::down2("<down>", vec![KeyMatcher::Key(KeyCode::Down.into())])]
+    #[case::esc1("<Esc>", vec![KeyMatcher::Key(KeyCode::Esc.into())])]
+    #[case::esc2("<esc>", vec![KeyMatcher::Key(KeyCode::Esc.into())])]
+    fn parse_key_binding(#[case] pattern: &str, #[case] matchers: Vec<KeyMatcher>) {
+        let binding = KeyBinding::from_str(pattern).expect("failed to parse");
+        let expected = KeyBinding(matchers);
+        assert_eq!(binding, expected);
+    }
+
+    #[rstest]
+    #[case::invalid_tag("<hi>")]
+    #[case::invalid_char("🚀")]
+    #[case::too_many_numbers("<number><number>")]
+    #[case::control_sequence("<C-w")]
+    fn invalid_key_bindings(#[case] input: &str) {
+        let result = KeyBinding::from_str(input);
+        assert!(result.is_err(), "not an error");
+    }
+
+    #[rstest]
+    #[case::single("g", &['g'.into_event()])]
+    #[case::single_uppercase("G", &['G'.into_event()])]
+    #[case::multi("gg", &['g'.into_event(), 'g'.into_event()])]
+    #[case::multi_space(" g", &[' '.into_event(), 'g'.into_event()])]
+    #[case::control("<c-w>", &['w'.into_event().with_control()])]
+    #[case::page_up("<PageUp>", &[KeyCode::PageUp.into_event()])]
+    #[case::page_down("<PageDown>", &[KeyCode::PageDown.into_event()])]
+    #[case::enter("<Enter>", &[KeyCode::Enter.into_event()])]
+    #[case::home("<Home>", &[KeyCode::Home.into_event()])]
+    #[case::end("<End>", &[KeyCode::End.into_event()])]
+    fn matching(#[case] pattern: &str, #[case] events: &[KeyEvent]) {
+        let binding = KeyBinding::from_str(pattern).expect("failed to parse");
+        let result = binding.match_events(events);
+        assert!(matches!(result, BindingMatch::Full(_)), "not full match: {result:?}");
+    }
+
+    #[rstest]
+    #[case::fewer("gg", &['g'.into_event()])]
+    #[case::number_something1("<number>G", &['4'.into_event()])]
+    #[case::number_something2("<number>G", &['4'.into_event(), '2'.into_event()])]
+    #[case::number_something3(":<number><CR>", &[':'.into_event(), '4'.into_event()])]
+    fn partial_matching(#[case] pattern: &str, #[case] events: &[KeyEvent]) {
+        let binding = KeyBinding::from_str(pattern).expect("failed to parse");
+        let result = binding.match_events(events);
+        assert!(matches!(result, BindingMatch::Partial), "not partial match: {result:?}");
+    }
+
+    #[rstest]
+    #[case::number_something("<number>G", &['4'.into_event(), 'K'.into_event()])]
+    fn no_matching(#[case] pattern: &str, #[case] events: &[KeyEvent]) {
+        let binding = KeyBinding::from_str(pattern).expect("failed to parse");
+        let result = binding.match_events(events);
+        assert!(matches!(result, BindingMatch::None), "some match: {result:?}");
+    }
+
+    #[rstest]
+    #[case::number_something("<number>G", &['4'.into_event(), '2'.into_event(), 'G'.into_event()])]
+    #[case::number_something(
+        ":<number><cr>",
+        &[':'.into_event(), '4'.into_event(), '2'.into_event(), KeyCode::Enter.into_event()]
+    )]
+    fn match_number(#[case] pattern: &str, #[case] events: &[KeyEvent]) {
+        let binding = KeyBinding::from_str(pattern).expect("failed to parse");
+        let result = binding.match_events(&events);
+        let BindingMatch::Full(MatchContext::Number(number)) = result else {
+            panic!("unexpected match: {result:?}");
+        };
+        assert_eq!(number, 42);
+    }
+
+    #[rstest]
+    #[case(&["<number>G", "other", "<number>Go"])]
+    #[case(&["<PageUp><PageDown>", "something", "<PageUp>"])]
+    #[case(&["<cr><cr>", "<cr><cr>"])]
+    #[case(&["<c-w>", "<c-w>a"])]
+    #[case(&["<c-w>", "<c-w>"])]
+    #[case(&["<number>", "<number>"])]
+    fn conflicts(#[case] patterns: &[&str]) {
+        let bindings: Vec<_> = patterns.iter().map(|p| KeyBinding::from_str(p).unwrap()).collect();
+        let result = CommandKeyBindings::validate_conflicts(bindings.iter());
+        assert!(result.is_err(), "not an error: {result:?}");
+    }
+
+    #[rstest]
+    #[case(&["<number>Ga", "<number>Go"])]
+    #[case(&["<c-a><number>", "<c-a>hi"])]
+    fn no_conflicts(#[case] patterns: &[&str]) {
+        let bindings: Vec<_> = patterns.iter().map(|p| KeyBinding::from_str(p).unwrap()).collect();
+        let result = CommandKeyBindings::validate_conflicts(bindings.iter());
+        assert!(result.is_ok(), "got error: {result:?}");
+    }
+
+    #[rstest]
+    #[case("<number>G")]
+    #[case("<PageUp>potato")]
+    #[case("<Esc><number><PageUp>")]
+    fn display(#[case] pattern: &str) {
+        let binding = KeyBinding::from_str(pattern).expect("invalid pattern");
+        let rendered = binding.to_string();
+        assert_eq!(rendered, pattern);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,7 +152,7 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             println!("{}", serde_json::to_string_pretty(&meta)?);
         }
     } else {
-        let commands = CommandSource::new(&path);
+        let commands = CommandSource::new(&path, config.bindings)?;
         let options =
             PresenterOptions { builder_options: options, mode, font_size_fallback: config.defaults.terminal_font_size };
         let presenter = Presenter::new(&default_theme, commands, parser, resources, typst, themes, options);

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -84,17 +84,17 @@ impl Presentation {
 
     /// Jump to the first slide.
     pub(crate) fn jump_first_slide(&mut self) -> bool {
-        self.jump_slide(0)
+        self.go_to_slide(0)
     }
 
     /// Jump to the last slide.
     pub(crate) fn jump_last_slide(&mut self) -> bool {
         let last_slide_index = self.slides.len().saturating_sub(1);
-        self.jump_slide(last_slide_index)
+        self.go_to_slide(last_slide_index)
     }
 
     /// Jump to a specific slide.
-    pub(crate) fn jump_slide(&mut self, slide_index: usize) -> bool {
+    pub(crate) fn go_to_slide(&mut self, slide_index: usize) -> bool {
         if slide_index < self.slides.len() {
             self.state.set_current_slide_index(slide_index);
             // Always show only the first slide when jumping to a particular one.
@@ -547,7 +547,7 @@ mod test {
                 Last => presentation.jump_last_slide(),
                 Next => presentation.jump_next_slide(),
                 Previous => presentation.jump_previous_slide(),
-                Specific(index) => presentation.jump_slide(*index),
+                Specific(index) => presentation.go_to_slide(*index),
             };
         }
 
@@ -623,7 +623,7 @@ mod test {
             Slide::new(vec![SlideChunk::from(SlideChunk::default()), SlideChunk::default()], vec![]),
             Slide::new(vec![SlideChunk::from(SlideChunk::default()), SlideChunk::default()], vec![]),
         ]);
-        presentation.jump_slide(from);
+        presentation.go_to_slide(from);
 
         for jump in jumps {
             jump.apply(&mut presentation);
@@ -672,7 +672,7 @@ mod test {
                 ])
                 .build(),
         ]);
-        presentation.jump_slide(from);
+        presentation.go_to_slide(from);
 
         for jump in jumps {
             jump.apply(&mut presentation);

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -158,11 +158,11 @@ impl<'a> Presenter<'a> {
         };
         let needs_redraw = match command {
             Command::Redraw => true,
-            Command::JumpNextSlide => presentation.jump_next_slide(),
-            Command::JumpPreviousSlide => presentation.jump_previous_slide(),
-            Command::JumpFirstSlide => presentation.jump_first_slide(),
-            Command::JumpLastSlide => presentation.jump_last_slide(),
-            Command::JumpSlide(number) => presentation.jump_slide(number.saturating_sub(1) as usize),
+            Command::NextSlide => presentation.jump_next_slide(),
+            Command::PreviousSlide => presentation.jump_previous_slide(),
+            Command::FirstSlide => presentation.jump_first_slide(),
+            Command::LastSlide => presentation.jump_last_slide(),
+            Command::GoToSlide(number) => presentation.go_to_slide(number.saturating_sub(1) as usize),
             Command::RenderWidgets => {
                 if presentation.render_slide_widgets() {
                     self.slides_with_pending_widgets.insert(self.state.presentation().current_slide_index());
@@ -192,10 +192,10 @@ impl<'a> Presenter<'a> {
             Ok(mut presentation) => {
                 let current = self.state.presentation();
                 if let Some(modification) = PresentationDiffer::find_first_modification(current, &presentation) {
-                    presentation.jump_slide(modification.slide_index);
+                    presentation.go_to_slide(modification.slide_index);
                     presentation.jump_chunk(modification.chunk_index);
                 } else {
-                    presentation.jump_slide(current.current_slide_index());
+                    presentation.go_to_slide(current.current_slide_index());
                     presentation.jump_chunk(current.current_chunk());
                 }
                 self.state = PresenterState::Presenting(presentation)


### PR DESCRIPTION
This allows defining custom keybindings in the config file under `~/.config/presenterm/config.yaml`. I will document this along with the next release but you can do things like:

```yaml
bindings:
  next_slide: ["l", "<right>"]
  previous_slide: ["h", "<left>"]
  first_slide: ["1"]
  go_to_slide: [":<number><cr>"]
```

By default all mappings are the same as before, but they can be overridden one by one.

This for now performs only some checks on conflicting keybindings but it won't detect things like "potato" vs "ta" in its current form.