### PR TITLE
Allow closing modal using escape

### DIFF
--- a/src/custom.rs
+++ b/src/custom.rs
@@ -108,6 +108,9 @@ pub struct KeyBindingsConfig {
 
     #[serde(default = "default_exit_bindings")]
     pub(crate) exit: Vec<KeyBinding>,
+
+    #[serde(default = "default_close_modal_bindings")]
+    pub(crate) close_modal: Vec<KeyBinding>,
 }
 
 impl Default for KeyBindingsConfig {
@@ -122,6 +125,7 @@ impl Default for KeyBindingsConfig {
             hard_reload: default_hard_reload_bindings(),
             toggle_slide_index: default_toggle_index_bindings(),
             exit: default_exit_bindings(),
+            close_modal: default_close_modal_bindings(),
         }
     }
 }
@@ -168,6 +172,10 @@ fn default_toggle_index_bindings() -> Vec<KeyBinding> {
 
 fn default_exit_bindings() -> Vec<KeyBinding> {
     make_keybindings(["<c-c>"])
+}
+
+fn default_close_modal_bindings() -> Vec<KeyBinding> {
+    make_keybindings(["<esc>"])
 }
 
 #[cfg(test)]

--- a/src/input/source.rs
+++ b/src/input/source.rs
@@ -1,9 +1,8 @@
-use crate::custom::KeyBindingsConfig;
-
 use super::{
     fs::PresentationFileWatcher,
     user::{CommandKeyBindings, KeyBindingsValidationError, UserInput},
 };
+use crate::custom::KeyBindingsConfig;
 use serde::Deserialize;
 use std::{io, path::PathBuf, time::Duration};
 use strum::EnumDiscriminants;
@@ -79,4 +78,7 @@ pub(crate) enum Command {
 
     /// Toggle the slide index view.
     ToggleSlideIndex,
+
+    /// Hide the currently open modal, if any.
+    CloseModal,
 }

--- a/src/input/user.rs
+++ b/src/input/user.rs
@@ -91,6 +91,7 @@ impl CommandKeyBindings {
             Reload => Command::Reload,
             HardReload => Command::HardReload,
             ToggleSlideIndex => Command::ToggleSlideIndex,
+            CloseModal => Command::CloseModal,
         };
         InputAction::Emit(command)
     }
@@ -130,6 +131,7 @@ impl TryFrom<KeyBindingsConfig> for CommandKeyBindings {
             .chain(zip(CommandDiscriminants::HardReload, config.hard_reload))
             .chain(zip(CommandDiscriminants::ToggleSlideIndex, config.toggle_slide_index))
             .chain(zip(CommandDiscriminants::RenderWidgets, config.render_widgets))
+            .chain(zip(CommandDiscriminants::CloseModal, config.close_modal))
             .collect();
         Self::validate_conflicts(bindings.iter().map(|binding| &binding.0))?;
         Ok(Self { bindings })

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -175,6 +175,11 @@ impl<'a> Presenter<'a> {
                 self.toggle_slide_index();
                 true
             }
+            Command::CloseModal => {
+                let presentation = mem::take(&mut self.state).into_presentation();
+                self.state = PresenterState::Presenting(presentation);
+                true
+            }
             // These are handled above as they don't require the presentation
             Command::Reload | Command::HardReload | Command::Exit => {
                 panic!("unreachable commands")


### PR DESCRIPTION
This allows closing the open modal (currently only the slide index) using escape, but can be configured to use some other binding.

Fixes #129