### PR TITLE
Allow specifying the preferred image protocol

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ pub use crate::{
     processing::builder::{PresentationBuilderOptions, Themes},
     render::{
         highlighting::{CodeHighlighter, HighlightThemeSet},
-        media::MediaRender,
+        media::{GraphicsMode, MediaRender},
     },
     resource::Resources,
     theme::{LoadThemeError, PresentationTheme, PresentationThemeSet},

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -24,6 +24,7 @@ use std::{
 
 pub struct PresenterOptions {
     pub mode: PresentMode,
+    pub graphics_mode: GraphicsMode,
     pub builder_options: PresentationBuilderOptions,
     pub font_size_fallback: Option<u8>,
 }
@@ -75,7 +76,7 @@ impl<'a> Presenter<'a> {
 
         let graphics_mode = match self.options.mode {
             PresentMode::Export => GraphicsMode::AsciiBlocks,
-            _ => GraphicsMode::default(),
+            _ => self.options.graphics_mode.clone(),
         };
         let mut drawer = TerminalDrawer::new(io::stdout(), graphics_mode, self.options.font_size_fallback)?;
         loop {

--- a/src/render/media.rs
+++ b/src/render/media.rs
@@ -1,9 +1,8 @@
+use super::properties::CursorPosition;
 use crate::render::properties::WindowSize;
 use image::{DynamicImage, ImageError};
 use std::{fmt::Debug, io, ops::Deref, path::PathBuf, rc::Rc};
 use viuer::{get_kitty_support, is_iterm_supported, KittySupport, ViuError};
-
-use super::properties::CursorPosition;
 
 /// An image.
 ///


### PR DESCRIPTION
This lets you specify the preferred image protocol. Note that if that protocol isn't supported, this will fall back to ascii blocks so it's just a hint that's useful in terminal emulators that support more than one mode.