### PR TITLE
Allow using thematic breaks to end slides

### DIFF
--- a/src/custom.rs
+++ b/src/custom.rs
@@ -60,6 +60,9 @@ pub struct OptionsConfig {
 
     /// Show all lists incrementally, by implicitly adding pauses in between elements.
     pub incremental_lists: Option<bool>,
+
+    /// Whether to treat a thematic break as a slide end.
+    pub end_slide_shorthand: Option<bool>,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -131,6 +131,7 @@ fn make_builder_options(config: &Config, mode: &PresentMode, force_default_theme
         command_prefix: config.options.command_prefix.clone().unwrap_or_default(),
         incremental_lists: config.options.incremental_lists.unwrap_or_default(),
         force_default_theme,
+        end_slide_shorthand: config.options.end_slide_shorthand.unwrap_or_default(),
     }
 }
 


### PR DESCRIPTION
This allows using the `options.end_slide_shorthand` key in the front matter and/or config file under `~/.config/presenterm/config.yaml` to turn thematic breaks (`---`) into the delimiter between slides. The original `<!-- end_slide -->` notation can still be used when this is enabled, this only allows opting into this extra behavior.

Fixes #137