### PR TITLE
Allow configuring modals styles

### DIFF
--- a/src/markdown/text.rs
+++ b/src/markdown/text.rs
@@ -24,13 +24,6 @@ impl WeightedLine {
     pub(crate) fn iter_texts(&self) -> impl Iterator<Item = &WeightedText> {
         self.0.iter()
     }
-
-    /// Apply a style to all text chunks in this line.
-    pub(crate) fn apply_style(&mut self, style: TextStyle) {
-        for text in &mut self.0 {
-            text.text.style = style.clone();
-        }
-    }
 }
 
 impl From<Vec<WeightedText>> for WeightedLine {

--- a/src/processing/builder.rs
+++ b/src/processing/builder.rs
@@ -155,7 +155,7 @@ impl<'a> PresentationBuilder<'a> {
 
         // TODO consider a separate color palette
         let presentation_state = PresentationState::default();
-        let index = self.index_builder.build(self.theme.default_style.colors.clone(), presentation_state.clone());
+        let index = self.index_builder.build(&self.theme, presentation_state.clone());
         let presentation = Presentation::new(self.slides, index, presentation_state);
         Ok(presentation)
     }

--- a/src/style.rs
+++ b/src/style.rs
@@ -206,6 +206,14 @@ pub(crate) struct Colors {
     pub(crate) foreground: Option<Color>,
 }
 
+impl Colors {
+    pub(crate) fn merge(&self, other: &Colors) -> Self {
+        let background = self.background.or(other.background);
+        let foreground = self.foreground.or(other.foreground);
+        Self { background, foreground }
+    }
+}
+
 impl From<Colors> for crossterm::style::Colors {
     fn from(value: Colors) -> Self {
         let foreground = value.foreground.map(Color::into);

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -100,6 +100,10 @@ pub struct PresentationTheme {
     /// The style for typst auto-rendered code blocks.
     #[serde(default)]
     pub(crate) typst: TypstStyle,
+
+    /// The style for typst auto-rendered code blocks.
+    #[serde(default)]
+    pub(crate) modals: ModalStyle,
 }
 
 impl PresentationTheme {
@@ -480,7 +484,20 @@ pub(crate) struct TypstStyle {
     pub(crate) vertical_margin: Option<u16>,
 
     /// The colors to be used.
+    #[serde(default)]
     pub(crate) colors: Colors,
+}
+
+/// Modals style.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub(crate) struct ModalStyle {
+    /// The default colors to use for everything in the modal.
+    #[serde(default)]
+    pub(crate) colors: Colors,
+
+    /// The colors to use for selected lines.
+    #[serde(default)]
+    pub(crate) selection_colors: Colors,
 }
 
 /// An error loading a presentation theme.

--- a/themes/dark.yaml
+++ b/themes/dark.yaml
@@ -89,3 +89,6 @@ footer:
   colors:
     foreground: "7aa2f7"
 
+modals:
+  selection_colors:
+    foreground: "ee9322"

--- a/themes/light.yaml
+++ b/themes/light.yaml
@@ -88,3 +88,7 @@ footer:
   style: progress_bar
   colors:
     foreground: "7aa2f7"
+
+modals:
+  selection_colors:
+    foreground: "f77f00"

--- a/themes/terminal-dark.yaml
+++ b/themes/terminal-dark.yaml
@@ -87,3 +87,6 @@ footer:
   colors:
     foreground: blue
 
+modals:
+  selection_colors:
+    foreground: yellow

--- a/themes/terminal-light.yaml
+++ b/themes/terminal-light.yaml
@@ -87,3 +87,6 @@ footer:
   colors:
     foreground: dark_blue
 
+modals:
+  selection_colors:
+    foreground: dark_yellow

--- a/themes/tokyonight-storm.yaml
+++ b/themes/tokyonight-storm.yaml
@@ -89,3 +89,6 @@ footer:
   colors:
     foreground: "7aa2f7"
 
+modals:
+  selection_colors:
+    foreground: "e0af68"


### PR DESCRIPTION
The colors for modals (currently only the slide index) can now be configured via `modals.colors`. Also, the selected line in the slide index modal can be configured via `modals.selection_colors`. 

Fixes #130