### PR TITLE
Refactor text types

### DIFF
--- a/src/markdown/elements.rs
+++ b/src/markdown/elements.rs
@@ -94,20 +94,17 @@ pub(crate) enum ParagraphElement {
 ///
 /// Text is represented as a series of chunks, each with their own formatting.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct TextBlock {
-    /// The chunks that make up this text.
-    pub(crate) chunks: Vec<Text>,
-}
+pub(crate) struct TextBlock(pub(crate) Vec<Text>);
 
 impl TextBlock {
     /// Get the total width for this text.
     pub(crate) fn width(&self) -> usize {
-        self.chunks.iter().map(|text| text.content.width()).sum()
+        self.0.iter().map(|text| text.content.width()).sum()
     }
 
     /// Applies the given style to this text.
     pub(crate) fn apply_style(&mut self, style: &TextStyle) {
-        for text in &mut self.chunks {
+        for text in &mut self.0 {
             text.style.merge(style);
         }
     }
@@ -115,7 +112,7 @@ impl TextBlock {
 
 impl<T: Into<Text>> From<T> for TextBlock {
     fn from(text: T) -> Self {
-        Self { chunks: vec![text.into()] }
+        Self(vec![text.into()])
     }
 }
 

--- a/src/markdown/parse.rs
+++ b/src/markdown/parse.rs
@@ -191,14 +191,14 @@ impl<'a> MarkdownParser<'a> {
         let mut chunks = Vec::new();
         for inline in inlines {
             match inline {
-                Inline::Text(text) => chunks.extend(text.chunks),
+                Inline::Text(text) => chunks.extend(text.0),
                 other => {
                     return Err(ParseErrorKind::UnsupportedStructure { container: "text", element: other.kind() }
                         .with_sourcepos(node.data.borrow().sourcepos));
                 }
             };
         }
-        Ok(TextBlock { chunks })
+        Ok(TextBlock(chunks))
     }
 
     fn parse_list(root: &'a AstNode<'a>, depth: u8) -> ParseResult<Vec<ListItem>> {
@@ -306,7 +306,7 @@ impl InlinesParser {
     fn store_pending_text(&mut self) {
         let chunks = mem::take(&mut self.pending_text);
         if !chunks.is_empty() {
-            self.inlines.push(Inline::Text(TextBlock { chunks }));
+            self.inlines.push(Inline::Text(TextBlock(chunks)));
         }
     }
 
@@ -517,7 +517,7 @@ boop
             Text::new("strikethrough", TextStyle::default().strikethrough()),
         ];
 
-        let expected_elements = &[ParagraphElement::Text(TextBlock { chunks: expected_chunks })];
+        let expected_elements = &[ParagraphElement::Text(TextBlock(expected_chunks))];
         assert_eq!(elements, expected_elements);
     }
 
@@ -527,7 +527,7 @@ boop
         let MarkdownElement::Paragraph(elements) = parsed else { panic!("not a paragraph: {parsed:?}") };
         let expected_chunks = vec![Text::from("my "), Text::new("https://example.com", TextStyle::default().link())];
 
-        let expected_elements = &[ParagraphElement::Text(TextBlock { chunks: expected_chunks })];
+        let expected_elements = &[ParagraphElement::Text(TextBlock(expected_chunks))];
         assert_eq!(elements, expected_elements);
     }
 
@@ -558,7 +558,7 @@ Title
         );
         let MarkdownElement::SetexHeading { text } = parsed else { panic!("not a slide title: {parsed:?}") };
         let expected_chunks = [Text::from("Title")];
-        assert_eq!(text.chunks, expected_chunks);
+        assert_eq!(text.0, expected_chunks);
     }
 
     #[test]
@@ -568,7 +568,7 @@ Title
         let expected_chunks = vec![Text::from("Title "), Text::new("with bold", TextStyle::default().bold())];
 
         assert_eq!(level, 1);
-        assert_eq!(text.chunks, expected_chunks);
+        assert_eq!(text.0, expected_chunks);
     }
 
     #[test]
@@ -609,7 +609,7 @@ another",
 
         let expected_chunks = &[Text::from("some text"), Text::from(" "), Text::from("with line breaks")];
         let ParagraphElement::Text(text) = &elements[0] else { panic!("non-text in paragraph") };
-        assert_eq!(text.chunks, expected_chunks);
+        assert_eq!(text.0, expected_chunks);
         assert!(matches!(&elements[1], ParagraphElement::LineBreak));
         assert!(matches!(&elements[2], ParagraphElement::Text(_)));
     }
@@ -651,7 +651,7 @@ echo hi mom
         assert_eq!(elements.len(), 1);
 
         let ParagraphElement::Text(text) = &elements[0] else { panic!("non-text in paragraph") };
-        assert_eq!(text.chunks, expected_chunks);
+        assert_eq!(text.0, expected_chunks);
     }
 
     #[test]

--- a/src/markdown/text.rs
+++ b/src/markdown/text.rs
@@ -29,7 +29,7 @@ impl WeightedTextBlock {
 
 impl From<TextBlock> for WeightedTextBlock {
     fn from(block: TextBlock) -> Self {
-        block.chunks.into()
+        block.0.into()
     }
 }
 

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -1,6 +1,6 @@
 use crate::{
     custom::OptionsConfig,
-    markdown::text::WeightedLine,
+    markdown::text::WeightedTextBlock,
     render::{media::Image, properties::WindowSize},
     style::Colors,
     theme::{Alignment, Margin, PresentationTheme},
@@ -441,7 +441,7 @@ pub(crate) enum RenderOperation {
     JumpToBottomRow { index: u16 },
 
     /// Render text.
-    RenderText { line: WeightedLine, alignment: Alignment },
+    RenderText { line: WeightedTextBlock, alignment: Alignment },
 
     /// Render a line break.
     RenderLineBreak,

--- a/src/processing/builder.rs
+++ b/src/processing/builder.rs
@@ -5,7 +5,7 @@ use crate::{
             Code, CodeLanguage, Highlight, HighlightGroup, ListItem, ListItemType, MarkdownElement, ParagraphElement,
             SourcePosition, Table, TableRow, Text, TextBlock,
         },
-        text::{WeightedText, WeightedTextBlock},
+        text::WeightedTextBlock,
     },
     presentation::{
         ChunkMutator, MarginProperties, PreformattedLine, Presentation, PresentationMetadata, PresentationState,
@@ -548,17 +548,15 @@ impl<'a> PresentationBuilder<'a> {
         self.push_aligned_text(text, alignment);
     }
 
-    fn push_aligned_text(&mut self, text: TextBlock, alignment: Alignment) {
-        let mut texts: Vec<WeightedText> = Vec::new();
-        for mut chunk in text.chunks {
+    fn push_aligned_text(&mut self, mut block: TextBlock, alignment: Alignment) {
+        for chunk in &mut block.chunks {
             if chunk.style.is_code() {
                 chunk.style.colors = self.theme.inline_code.colors.clone();
             }
-            texts.push(chunk.into());
         }
-        if !texts.is_empty() {
+        if !block.chunks.is_empty() {
             self.chunk_operations.push(RenderOperation::RenderText {
-                line: WeightedTextBlock::from(texts),
+                line: WeightedTextBlock::from(block),
                 alignment: alignment.clone(),
             });
         }

--- a/src/processing/builder.rs
+++ b/src/processing/builder.rs
@@ -421,7 +421,7 @@ impl<'a> PresentationBuilder<'a> {
         if let Some(prefix) = &style.prefix {
             let mut prefix = prefix.clone();
             prefix.push(' ');
-            text.chunks.insert(0, Text::from(prefix));
+            text.0.insert(0, Text::from(prefix));
         }
         let text_style = TextStyle::default().bold().colors(style.colors.clone());
         text.apply_style(&text_style);
@@ -549,12 +549,12 @@ impl<'a> PresentationBuilder<'a> {
     }
 
     fn push_aligned_text(&mut self, mut block: TextBlock, alignment: Alignment) {
-        for chunk in &mut block.chunks {
+        for chunk in &mut block.0 {
             if chunk.style.is_code() {
                 chunk.style.colors = self.theme.inline_code.colors.clone();
             }
         }
-        if !block.chunks.is_empty() {
+        if !block.0.is_empty() {
             self.chunk_operations.push(RenderOperation::RenderText {
                 line: WeightedTextBlock::from(block),
                 alignment: alignment.clone(),
@@ -676,7 +676,7 @@ impl<'a> PresentationBuilder<'a> {
         self.push_text(flattened_header, ElementType::Table);
         self.push_line_break();
 
-        let mut separator = TextBlock { chunks: Vec::new() };
+        let mut separator = TextBlock(Vec::new());
         for (index, width) in widths.iter().enumerate() {
             let mut contents = String::new();
             let mut margin = 1;
@@ -688,7 +688,7 @@ impl<'a> PresentationBuilder<'a> {
                 }
             }
             contents.extend(iter::repeat("─").take(*width + margin));
-            separator.chunks.push(Text::from(contents));
+            separator.0.push(Text::from(contents));
         }
 
         self.push_text(separator, ElementType::Table);
@@ -702,18 +702,18 @@ impl<'a> PresentationBuilder<'a> {
     }
 
     fn prepare_table_row(row: TableRow, widths: &[usize]) -> TextBlock {
-        let mut flattened_row = TextBlock { chunks: Vec::new() };
+        let mut flattened_row = TextBlock(Vec::new());
         for (column, text) in row.0.into_iter().enumerate() {
             if column > 0 {
-                flattened_row.chunks.push(Text::from(" │ "));
+                flattened_row.0.push(Text::from(" │ "));
             }
             let text_length = text.width();
-            flattened_row.chunks.extend(text.chunks.into_iter());
+            flattened_row.0.extend(text.0.into_iter());
 
             let cell_width = widths[column];
             if text_length < cell_width {
                 let padding = " ".repeat(cell_width - text_length);
-                flattened_row.chunks.push(Text::from(padding));
+                flattened_row.0.push(Text::from(padding));
             }
         }
         flattened_row

--- a/src/processing/builder.rs
+++ b/src/processing/builder.rs
@@ -3,9 +3,9 @@ use crate::{
     markdown::{
         elements::{
             Code, CodeLanguage, Highlight, HighlightGroup, ListItem, ListItemType, MarkdownElement, ParagraphElement,
-            SourcePosition, StyledText, Table, TableRow, Text,
+            SourcePosition, Table, TableRow, Text, TextBlock,
         },
-        text::{WeightedLine, WeightedText},
+        text::{WeightedText, WeightedTextBlock},
     },
     presentation::{
         ChunkMutator, MarginProperties, PreformattedLine, Presentation, PresentationMetadata, PresentationState,
@@ -267,23 +267,23 @@ impl<'a> PresentationBuilder<'a> {
 
     fn push_intro_slide(&mut self, metadata: PresentationMetadata) {
         let styles = &self.theme.intro_slide;
-        let title = StyledText::new(
+        let title = Text::new(
             metadata.title.unwrap_or_default().clone(),
             TextStyle::default().bold().colors(styles.title.colors.clone()),
         );
         let sub_title = metadata
             .sub_title
             .as_ref()
-            .map(|text| StyledText::new(text.clone(), TextStyle::default().colors(styles.subtitle.colors.clone())));
+            .map(|text| Text::new(text.clone(), TextStyle::default().colors(styles.subtitle.colors.clone())));
         let author = metadata
             .author
             .as_ref()
-            .map(|text| StyledText::new(text.clone(), TextStyle::default().colors(styles.author.colors.clone())));
+            .map(|text| Text::new(text.clone(), TextStyle::default().colors(styles.author.colors.clone())));
         self.chunk_operations.push(RenderOperation::JumpToVerticalCenter);
-        self.push_text(Text::from(title), ElementType::PresentationTitle);
+        self.push_text(TextBlock::from(title), ElementType::PresentationTitle);
         self.push_line_break();
         if let Some(text) = sub_title {
-            self.push_text(Text::from(text), ElementType::PresentationSubTitle);
+            self.push_text(TextBlock::from(text), ElementType::PresentationSubTitle);
             self.push_line_break();
         }
         if let Some(text) = author {
@@ -297,9 +297,9 @@ impl<'a> PresentationBuilder<'a> {
                     self.chunk_operations.push(RenderOperation::JumpToBottomRow { index: 0 });
                 }
             };
-            self.push_text(Text::from(text), ElementType::PresentationAuthor);
+            self.push_text(TextBlock::from(text), ElementType::PresentationAuthor);
         }
-        self.slide_state.title = Some(Text::from("[Introduction]"));
+        self.slide_state.title = Some(TextBlock::from("[Introduction]"));
         self.terminate_slide();
     }
 
@@ -380,7 +380,7 @@ impl<'a> PresentationBuilder<'a> {
         self.slide_chunks.push(SlideChunk::new(chunk_operations, mutators));
     }
 
-    fn push_slide_title(&mut self, mut text: Text) {
+    fn push_slide_title(&mut self, mut text: TextBlock) {
         if self.options.implicit_slide_ends && !matches!(self.slide_state.last_element, LastElement::None) {
             self.terminate_slide();
         }
@@ -408,7 +408,7 @@ impl<'a> PresentationBuilder<'a> {
         self.slide_state.ignore_element_line_break = true;
     }
 
-    fn push_heading(&mut self, level: u8, mut text: Text) {
+    fn push_heading(&mut self, level: u8, mut text: TextBlock) {
         let (element_type, style) = match level {
             1 => (ElementType::Heading1, &self.theme.headings.h1),
             2 => (ElementType::Heading2, &self.theme.headings.h2),
@@ -421,7 +421,7 @@ impl<'a> PresentationBuilder<'a> {
         if let Some(prefix) = &style.prefix {
             let mut prefix = prefix.clone();
             prefix.push(' ');
-            text.chunks.insert(0, StyledText::from(prefix));
+            text.chunks.insert(0, Text::from(prefix));
         }
         let text_style = TextStyle::default().bold().colors(style.colors.clone());
         text.apply_style(&text_style);
@@ -543,12 +543,12 @@ impl<'a> PresentationBuilder<'a> {
         self.chunk_operations.push(RenderOperation::SetColors(self.theme.default_style.colors.clone()));
     }
 
-    fn push_text(&mut self, text: Text, element_type: ElementType) {
+    fn push_text(&mut self, text: TextBlock, element_type: ElementType) {
         let alignment = self.theme.alignment(&element_type);
         self.push_aligned_text(text, alignment);
     }
 
-    fn push_aligned_text(&mut self, text: Text, alignment: Alignment) {
+    fn push_aligned_text(&mut self, text: TextBlock, alignment: Alignment) {
         let mut texts: Vec<WeightedText> = Vec::new();
         for mut chunk in text.chunks {
             if chunk.style.is_code() {
@@ -557,8 +557,10 @@ impl<'a> PresentationBuilder<'a> {
             texts.push(chunk.into());
         }
         if !texts.is_empty() {
-            self.chunk_operations
-                .push(RenderOperation::RenderText { line: WeightedLine::from(texts), alignment: alignment.clone() });
+            self.chunk_operations.push(RenderOperation::RenderText {
+                line: WeightedTextBlock::from(texts),
+                alignment: alignment.clone(),
+            });
         }
     }
 
@@ -645,8 +647,7 @@ impl<'a> PresentationBuilder<'a> {
 
         let chunks = mem::take(&mut self.slide_chunks);
         let slide = SlideBuilder::default().chunks(chunks).footer(footer).build();
-        self.index_builder
-            .add_title(self.slide_state.title.take().unwrap_or_else(|| StyledText::from("<no title>").into()));
+        self.index_builder.add_title(self.slide_state.title.take().unwrap_or_else(|| Text::from("<no title>").into()));
         self.slides.push(slide);
 
         self.push_slide_prelude();
@@ -677,7 +678,7 @@ impl<'a> PresentationBuilder<'a> {
         self.push_text(flattened_header, ElementType::Table);
         self.push_line_break();
 
-        let mut separator = Text { chunks: Vec::new() };
+        let mut separator = TextBlock { chunks: Vec::new() };
         for (index, width) in widths.iter().enumerate() {
             let mut contents = String::new();
             let mut margin = 1;
@@ -689,7 +690,7 @@ impl<'a> PresentationBuilder<'a> {
                 }
             }
             contents.extend(iter::repeat("─").take(*width + margin));
-            separator.chunks.push(StyledText::from(contents));
+            separator.chunks.push(Text::from(contents));
         }
 
         self.push_text(separator, ElementType::Table);
@@ -702,11 +703,11 @@ impl<'a> PresentationBuilder<'a> {
         }
     }
 
-    fn prepare_table_row(row: TableRow, widths: &[usize]) -> Text {
-        let mut flattened_row = Text { chunks: Vec::new() };
+    fn prepare_table_row(row: TableRow, widths: &[usize]) -> TextBlock {
+        let mut flattened_row = TextBlock { chunks: Vec::new() };
         for (column, text) in row.0.into_iter().enumerate() {
             if column > 0 {
-                flattened_row.chunks.push(StyledText::from(" │ "));
+                flattened_row.chunks.push(Text::from(" │ "));
             }
             let text_length = text.width();
             flattened_row.chunks.extend(text.chunks.into_iter());
@@ -714,7 +715,7 @@ impl<'a> PresentationBuilder<'a> {
             let cell_width = widths[column];
             if text_length < cell_width {
                 let padding = " ".repeat(cell_width - text_length);
-                flattened_row.chunks.push(StyledText::from(padding));
+                flattened_row.chunks.push(Text::from(padding));
             }
         }
         flattened_row
@@ -729,7 +730,7 @@ struct SlideState {
     last_element: LastElement,
     incremental_lists: Option<bool>,
     layout: LayoutState,
-    title: Option<Text>,
+    title: Option<TextBlock>,
 }
 
 #[derive(Debug, Default)]
@@ -958,7 +959,7 @@ mod test {
         for operation in operations {
             match operation {
                 RenderOperation::RenderText { line, .. } => {
-                    let texts: Vec<_> = line.iter_texts().map(|text| text.text.text.clone()).collect();
+                    let texts: Vec<_> = line.iter_texts().map(|text| text.text().content.clone()).collect();
                     current_line.push_str(&texts.join(""));
                 }
                 RenderOperation::RenderLineBreak if !current_line.is_empty() => {
@@ -982,9 +983,9 @@ mod test {
     fn prelude_appears_once() {
         let elements = vec![
             MarkdownElement::FrontMatter("author: bob".to_string()),
-            MarkdownElement::Heading { text: Text::from("hello"), level: 1 },
+            MarkdownElement::Heading { text: TextBlock::from("hello"), level: 1 },
             build_end_slide(),
-            MarkdownElement::Heading { text: Text::from("bye"), level: 1 },
+            MarkdownElement::Heading { text: TextBlock::from("bye"), level: 1 },
         ];
         let presentation = build_presentation(elements);
         for (index, slide) in presentation.iter_slides().into_iter().enumerate() {
@@ -1001,9 +1002,9 @@ mod test {
     fn slides_start_with_one_newline() {
         let elements = vec![
             MarkdownElement::FrontMatter("author: bob".to_string()),
-            MarkdownElement::Heading { text: Text::from("hello"), level: 1 },
+            MarkdownElement::Heading { text: TextBlock::from("hello"), level: 1 },
             build_end_slide(),
-            MarkdownElement::Heading { text: Text::from("bye"), level: 1 },
+            MarkdownElement::Heading { text: TextBlock::from("bye"), level: 1 },
         ];
         let presentation = build_presentation(elements);
         assert_eq!(presentation.iter_slides().count(), 3);
@@ -1022,8 +1023,8 @@ mod test {
     #[test]
     fn table() {
         let elements = vec![MarkdownElement::Table(Table {
-            header: TableRow(vec![Text::from("key"), Text::from("value"), Text::from("other")]),
-            rows: vec![TableRow(vec![Text::from("potato"), Text::from("bar"), Text::from("yes")])],
+            header: TableRow(vec![TextBlock::from("key"), TextBlock::from("value"), TextBlock::from("other")]),
+            rows: vec![TableRow(vec![TextBlock::from("potato"), TextBlock::from("bar"), TextBlock::from("yes")])],
         })];
         let slides = build_presentation(elements).into_slides();
         let lines = extract_slide_text_lines(slides.into_iter().next().unwrap());

--- a/src/processing/footer.rs
+++ b/src/processing/footer.rs
@@ -1,5 +1,5 @@
 use crate::{
-    markdown::{elements::Text, text::WeightedText},
+    markdown::elements::Text,
     presentation::{AsRenderOperations, RenderOperation},
     render::properties::WindowSize,
     style::{Colors, TextStyle},
@@ -33,7 +33,7 @@ impl FooterGenerator {
             .replace("{current_slide}", current_slide)
             .replace("{total_slides}", &context.total_slides.to_string())
             .replace("{author}", &context.author);
-        let text = WeightedText::from(Text::new(contents, TextStyle::default().colors(colors)));
+        let text = Text::new(contents, TextStyle::default().colors(colors));
         RenderOperation::RenderText { line: vec![text].into(), alignment }
     }
 }
@@ -71,11 +71,11 @@ impl AsRenderOperations for FooterGenerator {
                 let progress_ratio = (self.current_slide + 1) as f64 / context.total_slides as f64;
                 let columns_ratio = (total_columns as f64 * progress_ratio).ceil();
                 let bar = character.repeat(columns_ratio as usize);
-                let bar = vec![WeightedText::from(Text::new(bar, TextStyle::default().colors(colors.clone())))];
+                let bar = Text::new(bar, TextStyle::default().colors(colors.clone()));
                 vec![
                     RenderOperation::JumpToBottomRow { index: 0 },
                     RenderOperation::RenderText {
-                        line: bar.into(),
+                        line: vec![bar].into(),
                         alignment: Alignment::Left { margin: Margin::Fixed(0) },
                     },
                 ]

--- a/src/processing/footer.rs
+++ b/src/processing/footer.rs
@@ -1,5 +1,5 @@
 use crate::{
-    markdown::{elements::StyledText, text::WeightedText},
+    markdown::{elements::Text, text::WeightedText},
     presentation::{AsRenderOperations, RenderOperation},
     render::properties::WindowSize,
     style::{Colors, TextStyle},
@@ -33,7 +33,7 @@ impl FooterGenerator {
             .replace("{current_slide}", current_slide)
             .replace("{total_slides}", &context.total_slides.to_string())
             .replace("{author}", &context.author);
-        let text = WeightedText::from(StyledText::new(contents, TextStyle::default().colors(colors)));
+        let text = WeightedText::from(Text::new(contents, TextStyle::default().colors(colors)));
         RenderOperation::RenderText { line: vec![text].into(), alignment }
     }
 }
@@ -71,7 +71,7 @@ impl AsRenderOperations for FooterGenerator {
                 let progress_ratio = (self.current_slide + 1) as f64 / context.total_slides as f64;
                 let columns_ratio = (total_columns as f64 * progress_ratio).ceil();
                 let bar = character.repeat(columns_ratio as usize);
-                let bar = vec![WeightedText::from(StyledText::new(bar, TextStyle::default().colors(colors.clone())))];
+                let bar = vec![WeightedText::from(Text::new(bar, TextStyle::default().colors(colors.clone())))];
                 vec![
                     RenderOperation::JumpToBottomRow { index: 0 },
                     RenderOperation::RenderText {

--- a/src/processing/modals.rs
+++ b/src/processing/modals.rs
@@ -28,7 +28,7 @@ impl IndexBuilder {
         let padder = NumberPadder::new(self.titles.len());
         for (index, mut title) in self.titles.into_iter().enumerate() {
             let index = padder.pad_right(index + 1);
-            title.chunks.insert(0, format!("{index}: ").into());
+            title.0.insert(0, format!("{index}: ").into());
             builder.content.push(title);
         }
         let base_color = theme.modals.colors.merge(&theme.default_style.colors);
@@ -124,7 +124,7 @@ impl ModalBuilder {
         prefix.extend(Border::Separator.render_line(content_width));
         let mut content = Vec::new();
         for title in self.content {
-            content.push(Self::build_line(title.chunks, content_width));
+            content.push(Self::build_line(title.0, content_width));
         }
         let suffix = Border::Bottom.render_line(content_width).into_iter().collect();
         ModalContent { prefix, content, suffix, content_width }

--- a/src/render/draw.rs
+++ b/src/render/draw.rs
@@ -1,8 +1,8 @@
 use super::{engine::RenderEngine, media::GraphicsMode, terminal::Terminal};
 use crate::{
     markdown::{
-        elements::StyledText,
-        text::{WeightedLine, WeightedText},
+        elements::Text,
+        text::{WeightedText, WeightedTextBlock},
     },
     presentation::{Presentation, RenderOperation},
     render::properties::WindowSize,
@@ -44,7 +44,7 @@ where
     pub(crate) fn render_error(&mut self, message: &str) -> RenderResult {
         let dimensions = WindowSize::current(self.font_size_fallback)?;
         let heading = vec![
-            WeightedText::from(StyledText::new("Error loading presentation", TextStyle::default().bold())),
+            WeightedText::from(Text::new("Error loading presentation", TextStyle::default().bold())),
             WeightedText::from(": "),
         ];
 
@@ -56,13 +56,13 @@ where
                 background: Some(Color::new(0, 0, 0)),
             }),
             RenderOperation::JumpToVerticalCenter,
-            RenderOperation::RenderText { line: WeightedLine::from(heading), alignment: alignment.clone() },
+            RenderOperation::RenderText { line: WeightedTextBlock::from(heading), alignment: alignment.clone() },
             RenderOperation::RenderLineBreak,
             RenderOperation::RenderLineBreak,
         ];
         for line in message.lines() {
             let error = vec![WeightedText::from(line)];
-            let op = RenderOperation::RenderText { line: WeightedLine::from(error), alignment: alignment.clone() };
+            let op = RenderOperation::RenderText { line: WeightedTextBlock::from(error), alignment: alignment.clone() };
             operations.extend([op, RenderOperation::RenderLineBreak]);
         }
         let engine = self.create_engine(dimensions);

--- a/src/render/draw.rs
+++ b/src/render/draw.rs
@@ -1,9 +1,6 @@
 use super::{engine::RenderEngine, media::GraphicsMode, terminal::Terminal};
 use crate::{
-    markdown::{
-        elements::Text,
-        text::{WeightedText, WeightedTextBlock},
-    },
+    markdown::{elements::Text, text::WeightedTextBlock},
     presentation::{Presentation, RenderOperation},
     render::properties::WindowSize,
     style::{Color, Colors, TextStyle},
@@ -43,10 +40,7 @@ where
     /// Render an error.
     pub(crate) fn render_error(&mut self, message: &str) -> RenderResult {
         let dimensions = WindowSize::current(self.font_size_fallback)?;
-        let heading = vec![
-            WeightedText::from(Text::new("Error loading presentation", TextStyle::default().bold())),
-            WeightedText::from(": "),
-        ];
+        let heading = vec![Text::new("Error loading presentation", TextStyle::default().bold()), Text::from(": ")];
 
         let alignment = Alignment::Center { minimum_size: 0, minimum_margin: Margin::Percent(8) };
         let mut operations = vec![
@@ -61,7 +55,7 @@ where
             RenderOperation::RenderLineBreak,
         ];
         for line in message.lines() {
-            let error = vec![WeightedText::from(line)];
+            let error = vec![Text::from(line)];
             let op = RenderOperation::RenderText { line: WeightedTextBlock::from(error), alignment: alignment.clone() };
             operations.extend([op, RenderOperation::RenderLineBreak]);
         }

--- a/src/render/engine.rs
+++ b/src/render/engine.rs
@@ -7,7 +7,7 @@ use super::{
     text::TextDrawer,
 };
 use crate::{
-    markdown::text::WeightedLine,
+    markdown::text::WeightedTextBlock,
     presentation::{AsRenderOperations, MarginProperties, PreformattedLine, RenderOnDemand, RenderOperation},
     render::{layout::Positioning, properties::WindowSize},
     style::Colors,
@@ -140,7 +140,7 @@ where
         Ok(())
     }
 
-    fn render_text(&mut self, text: &WeightedLine, alignment: &Alignment) -> RenderResult {
+    fn render_text(&mut self, text: &WeightedTextBlock, alignment: &Alignment) -> RenderResult {
         let layout = self.build_layout(alignment.clone());
         let text_drawer = TextDrawer::new(&layout, text, self.current_dimensions(), &self.colors)?;
         text_drawer.draw(self.terminal)

--- a/src/render/text.rs
+++ b/src/render/text.rs
@@ -1,6 +1,6 @@
 use super::terminal::Terminal;
 use crate::{
-    markdown::text::WeightedLine,
+    markdown::text::WeightedTextBlock,
     render::{
         draw::{RenderError, RenderResult},
         layout::{Layout, Positioning},
@@ -16,7 +16,7 @@ const MINIMUM_LINE_LENGTH: u16 = 10;
 ///
 /// This deals with splitting words and doing word wrapping based on the given positioning.
 pub(crate) struct TextDrawer<'a> {
-    line: &'a WeightedLine,
+    line: &'a WeightedTextBlock,
     positioning: Positioning,
     default_colors: &'a Colors,
 }
@@ -24,7 +24,7 @@ pub(crate) struct TextDrawer<'a> {
 impl<'a> TextDrawer<'a> {
     pub(crate) fn new(
         layout: &Layout,
-        line: &'a WeightedLine,
+        line: &'a WeightedTextBlock,
         dimensions: &WindowSize,
         default_colors: &'a Colors,
     ) -> Result<Self, RenderError> {


### PR DESCRIPTION
This PR:
* Renames the text related types to have more sensible names. 
* Changes the `WeightedTextBlock` (former `WeightedLine`) so that when it's constructed from text chunks it collapses consecutive text chunks that use the same style into the same block. This helped reduce memory usage slightly and should make the rendering slightly faster as there's fewer blocks to be traversed.