### PR TITLE
Add key bindings modal

### DIFF
--- a/src/custom.rs
+++ b/src/custom.rs
@@ -100,20 +100,23 @@ pub struct KeyBindingsConfig {
     #[serde(default = "default_go_to_slide_bindings")]
     pub(crate) go_to_slide: Vec<KeyBinding>,
 
-    #[serde(default = "default_render_widgets_bindings")]
-    pub(crate) render_widgets: Vec<KeyBinding>,
+    #[serde(default = "default_execute_code_bindings")]
+    pub(crate) execute_code: Vec<KeyBinding>,
 
-    #[serde(default = "default_hard_reload_bindings")]
-    pub(crate) hard_reload: Vec<KeyBinding>,
+    #[serde(default = "default_reload_bindings")]
+    pub(crate) reload: Vec<KeyBinding>,
 
     #[serde(default = "default_toggle_index_bindings")]
     pub(crate) toggle_slide_index: Vec<KeyBinding>,
 
-    #[serde(default = "default_exit_bindings")]
-    pub(crate) exit: Vec<KeyBinding>,
+    #[serde(default = "default_toggle_bindings_modal_bindings")]
+    pub(crate) toggle_bindings: Vec<KeyBinding>,
 
     #[serde(default = "default_close_modal_bindings")]
     pub(crate) close_modal: Vec<KeyBinding>,
+
+    #[serde(default = "default_exit_bindings")]
+    pub(crate) exit: Vec<KeyBinding>,
 }
 
 impl Default for KeyBindingsConfig {
@@ -124,11 +127,12 @@ impl Default for KeyBindingsConfig {
             first_slide: default_first_slide_bindings(),
             last_slide: default_last_slide_bindings(),
             go_to_slide: default_go_to_slide_bindings(),
-            render_widgets: default_render_widgets_bindings(),
-            hard_reload: default_hard_reload_bindings(),
+            execute_code: default_execute_code_bindings(),
+            reload: default_reload_bindings(),
             toggle_slide_index: default_toggle_index_bindings(),
-            exit: default_exit_bindings(),
+            toggle_bindings: default_toggle_bindings_modal_bindings(),
             close_modal: default_close_modal_bindings(),
+            exit: default_exit_bindings(),
         }
     }
 }
@@ -161,11 +165,11 @@ fn default_go_to_slide_bindings() -> Vec<KeyBinding> {
     make_keybindings(["<number>G"])
 }
 
-fn default_render_widgets_bindings() -> Vec<KeyBinding> {
+fn default_execute_code_bindings() -> Vec<KeyBinding> {
     make_keybindings(["<c-e>"])
 }
 
-fn default_hard_reload_bindings() -> Vec<KeyBinding> {
+fn default_reload_bindings() -> Vec<KeyBinding> {
     make_keybindings(["<c-r>"])
 }
 
@@ -173,12 +177,16 @@ fn default_toggle_index_bindings() -> Vec<KeyBinding> {
     make_keybindings(["<c-p>"])
 }
 
-fn default_exit_bindings() -> Vec<KeyBinding> {
-    make_keybindings(["<c-c>"])
+fn default_toggle_bindings_modal_bindings() -> Vec<KeyBinding> {
+    make_keybindings(["?"])
 }
 
 fn default_close_modal_bindings() -> Vec<KeyBinding> {
     make_keybindings(["<esc>"])
+}
+
+fn default_exit_bindings() -> Vec<KeyBinding> {
+    make_keybindings(["<c-c>"])
 }
 
 #[cfg(test)]

--- a/src/export.rs
+++ b/src/export.rs
@@ -1,4 +1,5 @@
 use crate::{
+    custom::KeyBindingsConfig,
     markdown::parse::ParseError,
     presentation::{Presentation, RenderOperation},
     processing::builder::{BuildError, PresentationBuilder, PresentationBuilderOptions, Themes},
@@ -81,6 +82,7 @@ impl<'a> Exporter<'a> {
             &mut self.resources,
             &mut self.typst,
             &self.themes,
+            KeyBindingsConfig::default(),
             self.options.clone(),
         )
         .build(elements)?;

--- a/src/input/source.rs
+++ b/src/input/source.rs
@@ -79,6 +79,9 @@ pub(crate) enum Command {
     /// Toggle the slide index view.
     ToggleSlideIndex,
 
+    /// Toggle the key bindings config view.
+    ToggleKeyBindingsConfig,
+
     /// Hide the currently open modal, if any.
     CloseModal,
 }

--- a/src/input/user.rs
+++ b/src/input/user.rs
@@ -91,6 +91,7 @@ impl CommandKeyBindings {
             Reload => Command::Reload,
             HardReload => Command::HardReload,
             ToggleSlideIndex => Command::ToggleSlideIndex,
+            ToggleKeyBindingsConfig => Command::ToggleKeyBindingsConfig,
             CloseModal => Command::CloseModal,
         };
         InputAction::Emit(command)
@@ -128,9 +129,10 @@ impl TryFrom<KeyBindingsConfig> for CommandKeyBindings {
             .chain(zip(CommandDiscriminants::LastSlide, config.last_slide))
             .chain(zip(CommandDiscriminants::GoToSlide, config.go_to_slide))
             .chain(zip(CommandDiscriminants::Exit, config.exit))
-            .chain(zip(CommandDiscriminants::HardReload, config.hard_reload))
+            .chain(zip(CommandDiscriminants::HardReload, config.reload))
             .chain(zip(CommandDiscriminants::ToggleSlideIndex, config.toggle_slide_index))
-            .chain(zip(CommandDiscriminants::RenderWidgets, config.render_widgets))
+            .chain(zip(CommandDiscriminants::ToggleKeyBindingsConfig, config.toggle_bindings))
+            .chain(zip(CommandDiscriminants::RenderWidgets, config.execute_code))
             .chain(zip(CommandDiscriminants::CloseModal, config.close_modal))
             .collect();
         Self::validate_conflicts(bindings.iter().map(|binding| &binding.0))?;
@@ -345,6 +347,7 @@ impl fmt::Display for KeyMatcher {
                     write!(f, "<c-")?;
                 }
                 match combo.key {
+                    KeyCode::Char(' ') => write!(f, "' '")?,
                     KeyCode::Char(c) => write!(f, "{}", c)?,
                     other => write!(f, "<{other:?}>")?,
                 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -185,7 +185,7 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             println!("{}", serde_json::to_string_pretty(&meta)?);
         }
     } else {
-        let commands = CommandSource::new(&path, config.bindings)?;
+        let commands = CommandSource::new(&path, config.bindings.clone())?;
         let graphics_mode = match cli.image_protocol.map(GraphicsMode::try_from) {
             Some(Ok(mode)) => mode,
             Some(Err(_)) => {
@@ -200,6 +200,7 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             mode,
             graphics_mode,
             font_size_fallback: config.defaults.terminal_font_size,
+            bindings: config.bindings,
         };
         let presenter = Presenter::new(&default_theme, commands, parser, resources, typst, themes, options);
         presenter.present(&path)?;

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -8,18 +8,24 @@ use crate::{
 use serde::Deserialize;
 use std::{cell::RefCell, fmt::Debug, ops::Deref, rc::Rc};
 
+#[derive(Debug)]
+pub(crate) struct Modals {
+    pub(crate) slide_index: Vec<RenderOperation>,
+    pub(crate) bindings: Vec<RenderOperation>,
+}
+
 /// A presentation.
 #[derive(Debug)]
 pub(crate) struct Presentation {
     slides: Vec<Slide>,
-    slide_index: Vec<RenderOperation>,
+    modals: Modals,
     state: PresentationState,
 }
 
 impl Presentation {
     /// Construct a new presentation.
-    pub(crate) fn new(slides: Vec<Slide>, slide_index: Vec<RenderOperation>, state: PresentationState) -> Self {
-        Self { slides, slide_index, state }
+    pub(crate) fn new(slides: Vec<Slide>, modals: Modals, state: PresentationState) -> Self {
+        Self { slides, modals, state }
     }
 
     /// Iterate the slides in this presentation.
@@ -28,8 +34,13 @@ impl Presentation {
     }
 
     /// Iterate the operations that render the slide index.
-    pub(crate) fn iter_index_operations(&self) -> impl Iterator<Item = &RenderOperation> {
-        self.slide_index.iter()
+    pub(crate) fn iter_slide_index_operations(&self) -> impl Iterator<Item = &RenderOperation> {
+        self.modals.slide_index.iter()
+    }
+
+    /// Iterate the operations that render the key bindings modal.
+    pub(crate) fn iter_bindings_operations(&self) -> impl Iterator<Item = &RenderOperation> {
+        self.modals.bindings.iter()
     }
 
     /// Consume this presentation and return its slides.
@@ -163,7 +174,8 @@ impl Presentation {
 
 impl From<Vec<Slide>> for Presentation {
     fn from(slides: Vec<Slide>) -> Self {
-        Self::new(slides, vec![], Default::default())
+        let modals = Modals { slide_index: vec![], bindings: vec![] };
+        Self::new(slides, modals, Default::default())
     }
 }
 

--- a/src/render/draw.rs
+++ b/src/render/draw.rs
@@ -67,7 +67,14 @@ where
     pub(crate) fn render_slide_index(&mut self, presentation: &Presentation) -> RenderResult {
         let dimensions = WindowSize::current(self.font_size_fallback)?;
         let engine = self.create_engine(dimensions);
-        engine.render(presentation.iter_index_operations())?;
+        engine.render(presentation.iter_slide_index_operations())?;
+        Ok(())
+    }
+
+    pub(crate) fn render_key_bindings(&mut self, presentation: &Presentation) -> RenderResult {
+        let dimensions = WindowSize::current(self.font_size_fallback)?;
+        let engine = self.create_engine(dimensions);
+        engine.render(presentation.iter_bindings_operations())?;
         Ok(())
     }
 


### PR DESCRIPTION
This adds a modal, bound to `?` by default, that displays a list of all key bindings.