### PR TITLE
Rename next/previous slide bindings to next/previous

### DIFF
--- a/src/custom.rs
+++ b/src/custom.rs
@@ -85,11 +85,11 @@ fn default_typst_ppi() -> u32 {
 #[derive(Clone, Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct KeyBindingsConfig {
-    #[serde(default = "default_next_slide_bindings")]
-    pub(crate) next_slide: Vec<KeyBinding>,
+    #[serde(default = "default_next_bindings")]
+    pub(crate) next: Vec<KeyBinding>,
 
-    #[serde(default = "default_previous_slide_bindings")]
-    pub(crate) previous_slide: Vec<KeyBinding>,
+    #[serde(default = "default_previous_bindings")]
+    pub(crate) previous: Vec<KeyBinding>,
 
     #[serde(default = "default_first_slide_bindings")]
     pub(crate) first_slide: Vec<KeyBinding>,
@@ -122,8 +122,8 @@ pub struct KeyBindingsConfig {
 impl Default for KeyBindingsConfig {
     fn default() -> Self {
         Self {
-            next_slide: default_next_slide_bindings(),
-            previous_slide: default_previous_slide_bindings(),
+            next: default_next_bindings(),
+            previous: default_previous_bindings(),
             first_slide: default_first_slide_bindings(),
             last_slide: default_last_slide_bindings(),
             go_to_slide: default_go_to_slide_bindings(),
@@ -145,11 +145,11 @@ fn make_keybindings<const N: usize>(raw_bindings: [&str; N]) -> Vec<KeyBinding> 
     bindings
 }
 
-fn default_next_slide_bindings() -> Vec<KeyBinding> {
+fn default_next_bindings() -> Vec<KeyBinding> {
     make_keybindings(["l", "j", "<right>", "<page_down>", "<down>", " "])
 }
 
-fn default_previous_slide_bindings() -> Vec<KeyBinding> {
+fn default_previous_bindings() -> Vec<KeyBinding> {
     make_keybindings(["h", "k", "<left>", "<page_up>", "<up>"])
 }
 

--- a/src/export.rs
+++ b/src/export.rs
@@ -112,7 +112,7 @@ impl<'a> Exporter<'a> {
         let mut next_slide = |commands: &mut Vec<CaptureCommand>| {
             commands.push(CaptureCommand::SendKeys { keys: "l" });
             commands.push(CaptureCommand::WaitForChange);
-            presentation.jump_next_slide();
+            presentation.jump_next();
         };
         for chunks in slide_chunks {
             for _ in 0..chunks - 1 {

--- a/src/input/source.rs
+++ b/src/input/source.rs
@@ -47,11 +47,11 @@ pub(crate) enum Command {
     /// This can happen on terminal resize.
     Redraw,
 
-    /// Go to the next slide.
-    NextSlide,
+    /// Move forward in the presentation.
+    Next,
 
-    /// Go to the previous slide.
-    PreviousSlide,
+    /// Move backwards in the presentation.
+    Previous,
 
     /// Go to the first slide.
     FirstSlide,

--- a/src/input/user.rs
+++ b/src/input/user.rs
@@ -74,8 +74,8 @@ impl CommandKeyBindings {
         use CommandDiscriminants::*;
         let command = match discriminant {
             Redraw => Command::Redraw,
-            NextSlide => Command::NextSlide,
-            PreviousSlide => Command::PreviousSlide,
+            Next => Command::Next,
+            Previous => Command::Previous,
             FirstSlide => Command::FirstSlide,
             LastSlide => Command::LastSlide,
             GoToSlide => {
@@ -123,8 +123,8 @@ impl TryFrom<KeyBindingsConfig> for CommandKeyBindings {
             return Err(KeyBindingsValidationError::Invalid("go_to_slide", "<number> matcher required"));
         }
         let bindings: Vec<_> = iter::empty()
-            .chain(zip(CommandDiscriminants::NextSlide, config.next_slide))
-            .chain(zip(CommandDiscriminants::PreviousSlide, config.previous_slide))
+            .chain(zip(CommandDiscriminants::Next, config.next))
+            .chain(zip(CommandDiscriminants::Previous, config.previous))
             .chain(zip(CommandDiscriminants::FirstSlide, config.first_slide))
             .chain(zip(CommandDiscriminants::LastSlide, config.last_slide))
             .chain(zip(CommandDiscriminants::GoToSlide, config.go_to_slide))

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -59,8 +59,8 @@ impl Presentation {
         self.state.current_slide_index()
     }
 
-    /// Jump to the next slide.
-    pub(crate) fn jump_next_slide(&mut self) -> bool {
+    /// Jump forwards.
+    pub(crate) fn jump_next(&mut self) -> bool {
         let current_slide = self.current_slide_mut();
         if current_slide.move_next() {
             return true;
@@ -76,8 +76,8 @@ impl Presentation {
         }
     }
 
-    /// Jump to the previous slide.
-    pub(crate) fn jump_previous_slide(&mut self) -> bool {
+    /// Jump backwards.
+    pub(crate) fn jump_previous(&mut self) -> bool {
         let current_slide = self.current_slide_mut();
         if current_slide.move_previous() {
             return true;
@@ -557,8 +557,8 @@ mod test {
             match self {
                 First => presentation.jump_first_slide(),
                 Last => presentation.jump_last_slide(),
-                Next => presentation.jump_next_slide(),
-                Previous => presentation.jump_previous_slide(),
+                Next => presentation.jump_next(),
+                Previous => presentation.jump_previous(),
                 Specific(index) => presentation.go_to_slide(*index),
             };
         }

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -167,8 +167,8 @@ impl<'a> Presenter<'a> {
         };
         let needs_redraw = match command {
             Command::Redraw => true,
-            Command::NextSlide => presentation.jump_next_slide(),
-            Command::PreviousSlide => presentation.jump_previous_slide(),
+            Command::Next => presentation.jump_next(),
+            Command::Previous => presentation.jump_previous(),
             Command::FirstSlide => presentation.jump_first_slide(),
             Command::LastSlide => presentation.jump_last_slide(),
             Command::GoToSlide(number) => presentation.go_to_slide(number.saturating_sub(1) as usize),

--- a/src/processing/modals.rs
+++ b/src/processing/modals.rs
@@ -90,8 +90,8 @@ impl KeyBindingsModalBuilder {
     pub(crate) fn build(theme: &PresentationTheme, config: &KeyBindingsConfig) -> Vec<RenderOperation> {
         let mut builder = ModalBuilder::new("Key bindings");
         builder.content.extend([
-            Self::build_line("Next slide", &config.next_slide),
-            Self::build_line("Previous slide", &config.previous_slide),
+            Self::build_line("Next", &config.next),
+            Self::build_line("Previous", &config.previous),
             Self::build_line("First slide", &config.first_slide),
             Self::build_line("Last slide", &config.last_slide),
             Self::build_line("Go to slide", &config.go_to_slide),


### PR DESCRIPTION
This allows potentially adding a real "next slide" in the future that skips chunks and mutations and jumps to the true next slide.