### PR TITLE
Use synchronized updates to remove flickering

### DIFF
--- a/src/render/engine.rs
+++ b/src/render/engine.rs
@@ -50,9 +50,11 @@ where
     }
 
     pub(crate) fn render<'b>(mut self, operations: impl Iterator<Item = &'b RenderOperation>) -> RenderResult {
+        self.terminal.begin_update()?;
         for operation in operations {
             self.render_one(operation)?;
         }
+        self.terminal.end_update()?;
         self.terminal.flush()?;
         Ok(())
     }

--- a/src/render/terminal.rs
+++ b/src/render/terminal.rs
@@ -27,6 +27,16 @@ impl<W: io::Write> Terminal<W> {
         Ok(Self { writer, cursor_row: 0 })
     }
 
+    pub(crate) fn begin_update(&mut self) -> io::Result<()> {
+        self.writer.queue(terminal::BeginSynchronizedUpdate)?;
+        Ok(())
+    }
+
+    pub(crate) fn end_update(&mut self) -> io::Result<()> {
+        self.writer.queue(terminal::EndSynchronizedUpdate)?;
+        Ok(())
+    }
+
     pub(crate) fn move_to(&mut self, column: u16, row: u16) -> io::Result<()> {
         self.writer.queue(cursor::MoveTo(column, row))?;
         self.cursor_row = row;


### PR DESCRIPTION
This reduces flickering when printing images.