### PR TITLE
Print an image as background for modals when using kitty

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -71,7 +71,7 @@ impl ContentDiff for RenderOperation {
             (RenderText { alignment: original, .. }, RenderText { alignment: updated, .. }) if original != updated => {
                 false
             }
-            (RenderImage(original), RenderImage(updated)) if original != updated => true,
+            (RenderImage(original, _), RenderImage(updated, _)) if original != updated => true,
             (RenderPreformattedLine(original), RenderPreformattedLine(updated)) if original != updated => true,
             (InitColumnLayout { columns: original }, InitColumnLayout { columns: updated }) if original != updated => {
                 true

--- a/src/export.rs
+++ b/src/export.rs
@@ -85,6 +85,7 @@ impl<'a> Exporter<'a> {
             &mut self.resources,
             &mut self.typst,
             &self.themes,
+            Default::default(),
             KeyBindingsConfig::default(),
             self.options.clone(),
         )
@@ -245,11 +246,11 @@ pub(crate) struct ImageReplacer {
 impl ImageReplacer {
     pub(crate) fn replace_presentation_images(&mut self, presentation: &mut Presentation) {
         let callback = |operation: &mut RenderOperation| {
-            let RenderOperation::RenderImage(image) = operation else {
+            let RenderOperation::RenderImage(image, properties) = operation else {
                 return;
             };
             let replacement = self.replace_image(image.clone());
-            *operation = RenderOperation::RenderImage(replacement);
+            *operation = RenderOperation::RenderImage(replacement, properties.clone());
         };
 
         presentation.mutate_operations(callback);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ pub use crate::{
     export::{ExportError, Exporter},
     input::source::CommandSource,
     markdown::parse::MarkdownParser,
-    media::{graphics::GraphicsMode, kitty::KittyMode, printer::ImagePrinter},
+    media::{graphics::GraphicsMode, kitty::KittyMode, printer::ImagePrinter, register::ImageRegistry},
     presenter::{PresentMode, Presenter, PresenterOptions},
     processing::builder::{PresentationBuilderOptions, Themes},
     render::highlighting::{CodeHighlighter, HighlightThemeSet},

--- a/src/media/kitty.rs
+++ b/src/media/kitty.rs
@@ -54,6 +54,14 @@ enum KittyBuffer {
     Memory(Vec<u8>),
 }
 
+impl Drop for KittyBuffer {
+    fn drop(&mut self) {
+        if let Self::Filesystem(path) = self {
+            let _ = fs::remove_file(path);
+        }
+    }
+}
+
 struct GifFrame<T> {
     delay: Delay,
     buffer: T,

--- a/src/media/kitty.rs
+++ b/src/media/kitty.rs
@@ -123,6 +123,7 @@ impl KittyPrinter {
             ControlOption::Height(dimensions.1),
             ControlOption::Columns(print_options.columns),
             ControlOption::Rows(print_options.rows),
+            ControlOption::ZIndex(print_options.z_index),
         ];
 
         match &buffer {
@@ -151,6 +152,7 @@ impl KittyPrinter {
                 ControlOption::ImageId(image_id),
                 ControlOption::Width(dimensions.0),
                 ControlOption::Height(dimensions.1),
+                ControlOption::ZIndex(print_options.z_index),
             ];
             if frame_id == 0 {
                 options.extend([
@@ -343,6 +345,7 @@ enum ControlOption {
     AnimationState(u32),
     Loops(u32),
     Quiet(u32),
+    ZIndex(i32),
 }
 
 impl fmt::Display for ControlOption {
@@ -364,6 +367,7 @@ impl fmt::Display for ControlOption {
             AnimationState(state) => write!(f, "s={state}"),
             Loops(count) => write!(f, "v={count}"),
             Quiet(option) => write!(f, "q={option}"),
+            ZIndex(index) => write!(f, "z={index}"),
         }
     }
 }

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -3,5 +3,6 @@ pub(crate) mod image;
 mod iterm;
 pub(crate) mod kitty;
 pub(crate) mod printer;
+pub(crate) mod register;
 pub(crate) mod scale;
 mod viuer;

--- a/src/media/printer.rs
+++ b/src/media/printer.rs
@@ -31,6 +31,7 @@ pub(crate) struct PrintOptions {
     pub(crate) columns: u16,
     pub(crate) rows: u16,
     pub(crate) cursor_position: CursorPosition,
+    pub(crate) z_index: i32,
 }
 
 pub(crate) enum ImageResource {

--- a/src/media/register.rs
+++ b/src/media/register.rs
@@ -1,0 +1,24 @@
+use super::{
+    image::{Image, ImageSource},
+    printer::{PrintImage, RegisterImageError},
+};
+use crate::ImagePrinter;
+use image::DynamicImage;
+use std::{path::PathBuf, rc::Rc};
+
+#[derive(Clone, Default)]
+pub struct ImageRegistry(pub Rc<ImagePrinter>);
+
+impl ImageRegistry {
+    pub(crate) fn register_image(&self, image: DynamicImage) -> Result<Image, RegisterImageError> {
+        let resource = self.0.register_image(image)?;
+        let image = Image::new(resource, ImageSource::Generated);
+        Ok(image)
+    }
+
+    pub(crate) fn register_resource(&self, path: PathBuf) -> Result<Image, RegisterImageError> {
+        let resource = self.0.register_resource(&path)?;
+        let image = Image::new(resource, ImageSource::Filesystem(path));
+        Ok(image)
+    }
+}

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -460,7 +460,7 @@ pub(crate) enum RenderOperation {
     RenderLineBreak,
 
     /// Render an image.
-    RenderImage(Image),
+    RenderImage(Image, ImageProperties),
 
     /// Render a preformatted line.
     ///
@@ -497,6 +497,22 @@ pub(crate) enum RenderOperation {
 
     /// Pop an `ApplyMargin` operation.
     PopMargin,
+}
+
+/// The properties of an image being rendered.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct ImageProperties {
+    pub(crate) z_index: i32,
+    pub(crate) size: ImageSize,
+    pub(crate) restore_cursor: bool,
+}
+
+/// The size used when printing an image.
+#[derive(Clone, Debug, Default)]
+pub(crate) enum ImageSize {
+    #[default]
+    Scaled,
+    Specific(u16, u16),
 }
 
 /// Slide properties, set on initialization.

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -4,7 +4,7 @@ use crate::{
     export::ImageReplacer,
     input::source::{Command, CommandSource},
     markdown::parse::{MarkdownParser, ParseError},
-    media::printer::ImagePrinter,
+    media::{printer::ImagePrinter, register::ImageRegistry},
     presentation::Presentation,
     processing::builder::{BuildError, PresentationBuilder, PresentationBuilderOptions, Themes},
     render::{
@@ -235,6 +235,7 @@ impl<'a> Presenter<'a> {
             &mut self.resources,
             &mut self.typst,
             &self.themes,
+            ImageRegistry(self.image_printer.clone()),
             self.options.bindings.clone(),
             self.options.builder_options.clone(),
         )

--- a/src/render/terminal.rs
+++ b/src/render/terminal.rs
@@ -107,6 +107,7 @@ impl<W: io::Write> Terminal<W> {
     }
 
     pub(crate) fn print_image(&mut self, image: &Image, options: &PrintOptions) -> Result<(), PrintImageError> {
+        self.move_to_column(options.cursor_position.column)?;
         self.image_printer.print(&image.resource, options, &mut self.writer)?;
         self.cursor_row += options.rows;
         Ok(())

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -1,16 +1,11 @@
 use crate::{
-    media::{
-        image::{Image, ImageSource},
-        printer::{PrintImage, RegisterImageError},
-    },
+    media::{image::Image, printer::RegisterImageError, register::ImageRegistry},
     theme::{LoadThemeError, PresentationTheme},
-    ImagePrinter,
 };
 use std::{
     collections::HashMap,
     io,
     path::{Path, PathBuf},
-    rc::Rc,
 };
 
 /// Manages resources pulled from the filesystem such as images.
@@ -21,15 +16,15 @@ pub struct Resources {
     base_path: PathBuf,
     images: HashMap<PathBuf, Image>,
     themes: HashMap<PathBuf, PresentationTheme>,
-    printer: Rc<ImagePrinter>,
+    image_registry: ImageRegistry,
 }
 
 impl Resources {
     /// Construct a new resource manager over the provided based path.
     ///
     /// Any relative paths will be assumed to be relative to the given base.
-    pub fn new<P: Into<PathBuf>>(base_path: P, printer: Rc<ImagePrinter>) -> Self {
-        Self { base_path: base_path.into(), images: Default::default(), themes: Default::default(), printer }
+    pub fn new<P: Into<PathBuf>>(base_path: P, image_registry: ImageRegistry) -> Self {
+        Self { base_path: base_path.into(), images: Default::default(), themes: Default::default(), image_registry }
     }
 
     /// Get the image at the given path.
@@ -39,8 +34,7 @@ impl Resources {
             return Ok(image.clone());
         }
 
-        let resource = self.printer.register_resource(&path)?;
-        let image = Image::new(resource, ImageSource::Filesystem(path.clone()));
+        let image = self.image_registry.register_resource(path.clone())?;
         self.images.insert(path, image.clone());
         Ok(image)
     }

--- a/src/typst.rs
+++ b/src/typst.rs
@@ -1,18 +1,14 @@
 use crate::{
-    media::{
-        image::{Image, ImageSource},
-        printer::{PrintImage, RegisterImageError},
-    },
+    media::{image::Image, printer::RegisterImageError},
     style::Color,
     theme::TypstStyle,
     tools::{ExecutionError, ThirdPartyTools},
-    ImagePrinter,
+    ImageRegistry,
 };
 use std::{
     fs,
     io::{self},
     path::Path,
-    rc::Rc,
 };
 use tempfile::tempdir;
 
@@ -22,12 +18,12 @@ const DEFAULT_VERTICAL_MARGIN: u16 = 7;
 
 pub struct TypstRender {
     ppi: String,
-    printer: Rc<ImagePrinter>,
+    image_registry: ImageRegistry,
 }
 
 impl TypstRender {
-    pub fn new(ppi: u32, printer: Rc<ImagePrinter>) -> Self {
-        Self { ppi: ppi.to_string(), printer }
+    pub fn new(ppi: u32, image_registry: ImageRegistry) -> Self {
+        Self { ppi: ppi.to_string(), image_registry }
     }
 
     pub(crate) fn render_typst(&self, input: &str, style: &TypstStyle) -> Result<Image, TypstRenderError> {
@@ -64,8 +60,7 @@ impl TypstRender {
 
         let png_contents = fs::read(&output_path)?;
         let image = image::load_from_memory(&png_contents)?;
-        let resource = self.printer.register_image(image)?;
-        let image = Image::new(resource, ImageSource::Generated);
+        let image = self.image_registry.register_image(image)?;
         Ok(image)
     }
 


### PR DESCRIPTION
This creates a background image for every modal when using kitty. This is necessary as kitty does not use a "last write wins" policy when writing images over text, so without this the modals show up behind images in slides.

Fixes #153