### PR TITLE
Detect image protocol instead of relying on viuer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,6 +254,7 @@ dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
+ "unicode-width",
  "windows-sys 0.52.0",
 ]
 
@@ -904,6 +905,7 @@ dependencies = [
  "bincode",
  "clap",
  "comrak",
+ "console",
  "crossterm",
  "flate2",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ serde_json = "1.0"
 serde_with = "3.4"
 strum = { version = "0.25", features = ["derive"] }
 tempfile = "3.9"
+console = "0.15.8"
 thiserror = "1"
 unicode-width = "0.1"
 viuer = "0.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,10 @@ pub use crate::{
     export::{ExportError, Exporter},
     input::source::CommandSource,
     markdown::parse::MarkdownParser,
-    media::{graphics::GraphicsMode, kitty::KittyMode, printer::ImagePrinter, register::ImageRegistry},
+    media::{
+        emulator::TerminalEmulator, graphics::GraphicsMode, kitty::KittyMode, printer::ImagePrinter,
+        register::ImageRegistry,
+    },
     presenter::{PresentMode, Presenter, PresenterOptions},
     processing::builder::{PresentationBuilderOptions, Themes},
     render::highlighting::{CodeHighlighter, HighlightThemeSet},

--- a/src/media/emulator.rs
+++ b/src/media/emulator.rs
@@ -1,0 +1,82 @@
+use crate::{GraphicsMode, KittyMode};
+use std::env;
+
+use super::kitty::local_mode_supported;
+
+pub enum TerminalEmulator {
+    Kitty,
+    Iterm2,
+    WezTerm,
+    Mintty,
+    Unknown,
+}
+
+impl TerminalEmulator {
+    pub fn detect() -> Self {
+        if Self::is_kitty() {
+            Self::Kitty
+        } else if Self::is_iterm2() {
+            Self::Iterm2
+        } else if Self::is_wezterm() {
+            Self::WezTerm
+        } else if Self::is_mintty() {
+            Self::Mintty
+        } else {
+            Self::Unknown
+        }
+    }
+
+    pub fn preferred_protocol(&self) -> GraphicsMode {
+        let modes = [
+            GraphicsMode::Iterm2,
+            GraphicsMode::Kitty(KittyMode::Local),
+            GraphicsMode::Kitty(KittyMode::Remote),
+            #[cfg(feature = "sixel")]
+            GraphicsMode::Sixel,
+            GraphicsMode::AsciiBlocks,
+        ];
+        for mode in modes {
+            if self.supports_graphics_mode(&mode) {
+                return mode;
+            }
+        }
+        unreachable!("ascii blocks is always supported")
+    }
+
+    fn supports_graphics_mode(&self, mode: &GraphicsMode) -> bool {
+        match (mode, self) {
+            (GraphicsMode::Kitty(mode), Self::Kitty | Self::WezTerm) => match mode {
+                KittyMode::Local => local_mode_supported().unwrap_or_default(),
+                KittyMode::Remote => true,
+            },
+            (GraphicsMode::Iterm2, Self::Iterm2 | Self::WezTerm | Self::Mintty) => true,
+            (GraphicsMode::AsciiBlocks, _) => true,
+            #[cfg(feature = "sixel")]
+            (GraphicsMode::Sixel, _) => viuer::is_sixel_supported(),
+            _ => false,
+        }
+    }
+
+    fn is_kitty() -> bool {
+        let Ok(term) = env::var("TERM") else {
+            return false;
+        };
+        term.contains("kitty")
+    }
+
+    fn is_iterm2() -> bool {
+        Self::load_term_program().map(|term| term.contains("iTerm")).unwrap_or_default()
+    }
+
+    fn is_wezterm() -> bool {
+        Self::load_term_program().as_deref() == Some("WezTerm")
+    }
+
+    fn is_mintty() -> bool {
+        Self::load_term_program().map(|term| term.contains("mintty")).unwrap_or_default()
+    }
+
+    fn load_term_program() -> Option<String> {
+        env::var("TERM_PROGRAM").ok()
+    }
+}

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod emulator;
 pub(crate) mod graphics;
 pub(crate) mod image;
 mod iterm;


### PR DESCRIPTION
This PR:
* Detects the terminal emulator we're using.
* Figures out which image protocol to use.
* Turns the `--image-protocol` cli arg from a hint into a respected value, at least for the kitty and iterm protocols.

The main motivation for this is that `viuer` has limited detection, e.g. it doesn't know wezterm supports the kitty protocol so now, while it still uses the iterm one by default, you can pass in `--image-protocol kitty-local` when using wezterm and it will be respected. This is also some ground work to be able to work on #72 next.