### PR TITLE
Move cursor to right row after printing image

### DIFF
--- a/src/render/engine.rs
+++ b/src/render/engine.rs
@@ -165,6 +165,8 @@ where
         self.terminal.print_image(image, &options)?;
         if properties.restore_cursor {
             self.terminal.move_to(starting_position.column, starting_position.row)?;
+        } else {
+            self.terminal.move_to_column(starting_position.row + height as u16)?;
         }
         Ok(())
     }


### PR DESCRIPTION
It looks like after the changes in #157 cause wezterm **only in windows** to not move the cursor to right after the image so any text after it gets printed on top of it.