### PR TITLE
Use unicode placeholders to print images under kitty+tmux

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -72,8 +72,12 @@ impl TryFrom<&ImageProtocol> for GraphicsMode {
                 emulator.preferred_protocol()
             }
             ImageProtocol::Iterm2 => GraphicsMode::Iterm2,
-            ImageProtocol::KittyLocal => GraphicsMode::Kitty(KittyMode::Local),
-            ImageProtocol::KittyRemote => GraphicsMode::Kitty(KittyMode::Remote),
+            ImageProtocol::KittyLocal => {
+                GraphicsMode::Kitty { mode: KittyMode::Local, inside_tmux: TerminalEmulator::is_inside_tmux() }
+            }
+            ImageProtocol::KittyRemote => {
+                GraphicsMode::Kitty { mode: KittyMode::Remote, inside_tmux: TerminalEmulator::is_inside_tmux() }
+            }
             ImageProtocol::AsciiBlocks => GraphicsMode::AsciiBlocks,
             #[cfg(feature = "sixel")]
             ImageProtocol::Sixel => GraphicsMode::Sixel,
@@ -212,7 +216,7 @@ fn run(mut cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         }
     } else {
         let commands = CommandSource::new(&path, config.bindings.clone())?;
-        options.print_modal_background = matches!(graphics_mode, GraphicsMode::Kitty(_));
+        options.print_modal_background = matches!(graphics_mode, GraphicsMode::Kitty { .. });
 
         let options = PresenterOptions {
             builder_options: options,

--- a/src/media/graphics.rs
+++ b/src/media/graphics.rs
@@ -1,46 +1,18 @@
 use super::kitty::KittyMode;
-use viuer::{get_kitty_support, is_iterm_supported, KittySupport};
 
 #[derive(Clone, Debug)]
 pub enum GraphicsMode {
     Iterm2,
-    Kitty(KittyMode),
+    Kitty {
+        mode: KittyMode,
+        inside_tmux: bool,
+    },
     AsciiBlocks,
     #[cfg(feature = "sixel")]
     Sixel,
 }
 
-impl Default for GraphicsMode {
-    fn default() -> Self {
-        let modes = &[
-            Self::Iterm2,
-            Self::Kitty(KittyMode::Local),
-            Self::Kitty(KittyMode::Remote),
-            #[cfg(feature = "sixel")]
-            Self::Sixel,
-            Self::AsciiBlocks,
-        ];
-        for mode in modes {
-            if mode.is_supported() {
-                return mode.clone();
-            }
-        }
-        Self::AsciiBlocks
-    }
-}
-
 impl GraphicsMode {
-    pub fn is_supported(&self) -> bool {
-        match self {
-            Self::Iterm2 => is_iterm_supported(),
-            Self::Kitty(KittyMode::Local) => get_kitty_support() == KittySupport::Local,
-            Self::Kitty(KittyMode::Remote) => get_kitty_support() == KittySupport::Remote,
-            Self::AsciiBlocks => true,
-            #[cfg(feature = "sixel")]
-            Self::Sixel => viuer::is_sixel_supported(),
-        }
-    }
-
     pub fn detect_graphics_protocol() {
         viuer::is_iterm_supported();
         viuer::get_kitty_support();

--- a/src/media/printer.rs
+++ b/src/media/printer.rs
@@ -27,6 +27,7 @@ pub(crate) trait ResourceProperties {
     fn dimensions(&self) -> (u32, u32);
 }
 
+#[derive(Debug)]
 pub(crate) struct PrintOptions {
     pub(crate) columns: u16,
     pub(crate) rows: u16,
@@ -65,7 +66,7 @@ impl Default for ImagePrinter {
 impl ImagePrinter {
     pub fn new(mode: GraphicsMode) -> io::Result<Self> {
         let printer = match mode {
-            GraphicsMode::Kitty(mode) => Self::new_kitty(mode)?,
+            GraphicsMode::Kitty { mode, inside_tmux } => Self::new_kitty(mode, inside_tmux)?,
             GraphicsMode::Iterm2 => Self::new_iterm(),
             GraphicsMode::AsciiBlocks => Self::new_ascii(),
             #[cfg(feature = "sixel")]
@@ -74,8 +75,8 @@ impl ImagePrinter {
         Ok(printer)
     }
 
-    fn new_kitty(mode: KittyMode) -> io::Result<Self> {
-        Ok(Self::Kitty(KittyPrinter::new(mode)?))
+    fn new_kitty(mode: KittyMode, inside_tmux: bool) -> io::Result<Self> {
+        Ok(Self::Kitty(KittyPrinter::new(mode, inside_tmux)?))
     }
 
     fn new_iterm() -> Self {

--- a/src/media/scale.rs
+++ b/src/media/scale.rs
@@ -28,6 +28,7 @@ pub(crate) fn scale_image(
     // Don't go too far wide.
     let width_in_columns = width_in_columns.min(column_margin);
     let height_in_rows = (width_in_columns as f64 * aspect_ratio / 2.0) as u16;
+    let height_in_rows = height_in_rows.max(1);
 
     // Draw it in the middle
     let start_column = dimensions.columns / 2 - (width_in_columns / 2) as u16;

--- a/src/processing/builder.rs
+++ b/src/processing/builder.rs
@@ -501,8 +501,10 @@ impl<'a> PresentationBuilder<'a> {
 
     fn push_image(&mut self, image: Image) {
         let properties = ImageProperties { z_index: DEFAULT_Z_INDEX, size: Default::default(), restore_cursor: false };
-        self.chunk_operations.push(RenderOperation::RenderImage(image, properties));
-        self.chunk_operations.push(RenderOperation::SetColors(self.theme.default_style.colors.clone()));
+        self.chunk_operations.extend([
+            RenderOperation::RenderImage(image, properties),
+            RenderOperation::SetColors(self.theme.default_style.colors.clone()),
+        ]);
     }
 
     fn push_list(&mut self, list: Vec<ListItem>) {


### PR DESCRIPTION
This uses the [unicode placeholder strategy](https://sw.kovidgoyal.net/kitty/graphics-protocol/#unicode-placeholders) under kitty to get images (including gifs) to work when running under tmux. Caveats:
* Gifs only seem to really work correctly under tmux 3.3a. 3.2a sometimes doesn't display them upon the first try.
* This doesn't currently detect kitty (or wezterm) correctly when running in tmux so if you're using tmux on either of those terminals that support the kitty protocol, you need to pass `--image-protocol kitty-local` (`kitty-remote` seems to not work great). I may add some better detection but at least this currently works.
* I tried to get this to work under the [iterm protocol](https://iterm2.com/documentation-images.html) as well but I'm afraid it won't work. tmux has some buffer of 1MB that kicks in here and because the iterm protocol sends the entire image in a single b64 chunk, that can easily overflow for any non tiny image. If there's some way to send chunked images in iterm, this can be revisited.

Fixes #72