### PR TITLE
Allow setting image protocol in config file

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,14 +20,11 @@ pub(crate) mod tools;
 pub(crate) mod typst;
 
 pub use crate::{
-    custom::Config,
+    custom::{Config, ImageProtocol},
     export::{ExportError, Exporter},
     input::source::CommandSource,
     markdown::parse::MarkdownParser,
-    media::{
-        emulator::TerminalEmulator, graphics::GraphicsMode, kitty::KittyMode, printer::ImagePrinter,
-        register::ImageRegistry,
-    },
+    media::{graphics::GraphicsMode, printer::ImagePrinter, register::ImageRegistry},
     presenter::{PresentMode, Presenter, PresenterOptions},
     processing::builder::{PresentationBuilderOptions, Themes},
     render::highlighting::{CodeHighlighter, HighlightThemeSet},

--- a/src/media/emulator.rs
+++ b/src/media/emulator.rs
@@ -1,5 +1,5 @@
 use super::kitty::local_mode_supported;
-use crate::{GraphicsMode, KittyMode};
+use crate::{media::kitty::KittyMode, GraphicsMode};
 use std::env;
 
 #[derive(Debug)]


### PR DESCRIPTION
This lets you use the `defaults.image_protocol` config to set the preferred image protocol. The cli argument still takes precedence over this. 