### PR TITLE
Use `directories` to find config directory path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,6 +448,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ae2a35373c5c74340b79ae6780b498b2b183915ec5dacf263aac5a099bf485a"
 
 [[package]]
+name = "directories"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -718,6 +739,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 
 [[package]]
+name = "libredox"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
+dependencies = [
+ "bitflags 2.4.2",
+ "libc",
+ "redox_syscall",
+]
+
+[[package]]
 name = "line-wrap"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -830,6 +862,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -907,6 +945,7 @@ dependencies = [
  "comrak",
  "console",
  "crossterm",
+ "directories",
  "flate2",
  "hex",
  "image",
@@ -1022,6 +1061,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ bincode = "1.3"
 clap = { version = "4.4", features = ["derive", "string"] }
 comrak = { version = "0.20", default-features = false }
 crossterm = { version = "0.27", features = ["serde"] }
+directories = "5.0"
 hex = "0.4"
 flate2 = "1.0"
 image = "0.24"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use clap::{error::ErrorKind, CommandFactory, Parser};
 use comrak::Arena;
+use directories::ProjectDirs;
 use presenterm::{
     CommandSource, Config, Exporter, GraphicsMode, HighlightThemeSet, ImagePrinter, ImageProtocol, ImageRegistry,
     LoadThemeError, MarkdownParser, PresentMode, PresentationBuilderOptions, PresentationTheme, PresentationThemeSet,
@@ -70,12 +71,11 @@ fn create_splash() -> String {
 }
 
 fn load_customizations(config_file_path: Option<PathBuf>) -> Result<(Config, Themes), Box<dyn std::error::Error>> {
-    let Ok(home_path) = env::var("HOME") else {
+    let Some(project_dirs) = ProjectDirs::from_path("presenterm".into()) else {
         return Ok(Default::default());
     };
-    let home_path = PathBuf::from(home_path);
-    let configs_path = home_path.join(".config/presenterm");
-    let themes = load_themes(&configs_path)?;
+    let configs_path = project_dirs.config_dir();
+    let themes = load_themes(configs_path)?;
     let config_file_path = config_file_path.unwrap_or_else(|| configs_path.join("config.yaml"));
     let config = Config::load(&config_file_path)?;
     Ok((config, themes))


### PR DESCRIPTION
The config file is now on:

* `~/.config/presenterm/config.yaml` on linux (this is unchanged).
* `~/Library/Application Support/presenterm/config.yaml` in macOS.
* `~/AppData/Roaming/presenterm/config/config.yaml` in windows.

Fixes #180 