### PR TITLE
Stop using viuer for ascii blocks graphics mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,15 +33,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_colours"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a1558bd2075d341b9ca698ec8eb6fcc55a746b1fc4255585aad5b141d918a80"
-dependencies = [
- "rgb",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -965,7 +956,6 @@ dependencies = [
  "tempfile",
  "thiserror",
  "unicode-width",
- "viuer",
 ]
 
 [[package]]
@@ -1114,15 +1104,6 @@ name = "relative-path"
 version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e898588f33fdd5b9420719948f9f2a32c922a246964576f71ba7f24f80610fbc"
-
-[[package]]
-name = "rgb"
-version = "0.8.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05aaa8004b64fd573fc9d002f4e632d51ad4f026c2b5ba95fcb6c2f32c2c47d8"
-dependencies = [
- "bytemuck",
-]
 
 [[package]]
 name = "rstest"
@@ -1448,15 +1429,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1551,22 +1523,6 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
-
-[[package]]
-name = "viuer"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec2ede5c8814363f92f862892dfe71a266f6816b649ca435aed1ff5e2cf3454e"
-dependencies = [
- "ansi_colours",
- "base64",
- "console",
- "crossterm",
- "image",
- "lazy_static",
- "tempfile",
- "termcolor",
-]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ tempfile = "3.9"
 console = "0.15.8"
 thiserror = "1"
 unicode-width = "0.1"
-viuer = "0.7"
 
 [dependencies.syntect]
 version = "5.1"

--- a/src/export.rs
+++ b/src/export.rs
@@ -143,7 +143,7 @@ impl<'a> Exporter<'a> {
                     let mut buffer = Vec::new();
                     let dimensions = image.original.dimensions();
                     let ImageResource::Ascii(resource) = image.original.resource.as_ref() else {
-                        panic!("not in viuer mode")
+                        panic!("not in ascii mode")
                     };
                     PngEncoder::new(&mut buffer).write_image(
                         resource.as_bytes(),

--- a/src/media/ascii.rs
+++ b/src/media/ascii.rs
@@ -1,6 +1,15 @@
 use super::printer::{PrintImage, PrintImageError, PrintOptions, RegisterImageError, ResourceProperties};
-use image::{DynamicImage, GenericImageView};
+use crossterm::{
+    cursor::{MoveRight, MoveToColumn},
+    style::{Color, Stylize},
+    QueueableCommand,
+};
+use image::{imageops::FilterType, DynamicImage, GenericImageView, Rgba};
+use itertools::Itertools;
 use std::{fs, ops::Deref};
+
+const TOP_CHAR: char = '▀';
+const BOTTOM_CHAR: char = '▄';
 
 pub(crate) struct AsciiResource(DynamicImage);
 
@@ -28,6 +37,13 @@ impl Deref for AsciiResource {
 #[derive(Default)]
 pub struct AsciiPrinter;
 
+impl AsciiPrinter {
+    fn pixel_color(pixel: &Rgba<u8>) -> Option<Color> {
+        let [r, g, b, alpha] = pixel.0;
+        if alpha == 0 { None } else { Some(Color::Rgb { r, g, b }) }
+    }
+}
+
 impl PrintImage for AsciiPrinter {
     type Resource = AsciiResource;
 
@@ -41,20 +57,62 @@ impl PrintImage for AsciiPrinter {
         Ok(AsciiResource(image))
     }
 
-    fn print<W>(&self, image: &Self::Resource, options: &PrintOptions, _writer: &mut W) -> Result<(), PrintImageError>
+    fn print<W>(&self, image: &Self::Resource, options: &PrintOptions, writer: &mut W) -> Result<(), PrintImageError>
     where
         W: std::io::Write,
     {
-        let config = viuer::Config {
-            width: Some(options.columns as u32),
-            height: Some(options.rows as u32),
-            use_kitty: false,
-            use_iterm: false,
-            x: options.cursor_position.column,
-            y: options.cursor_position.row as i16,
-            ..Default::default()
-        };
-        viuer::print(&image.0, &config)?;
+        // The strategy here is taken from viuer: use half vertical ascii blocks in combination
+        // with foreground/background colors to fit 2 vertical pixels per cell. That is, cell (x, y)
+        // will contain the pixels at (x, y) and (x, y + 1) combined.
+        let image = image.0.resize_exact(options.columns as u32, 2 * options.rows as u32, FilterType::Triangle);
+        let image = image.into_rgba8();
+        let default_background = options.background_color.map(Color::from);
+
+        // Iterate pixel rows in pairs to be able to merge both pixels in a single iteration.
+        // Note that may not have a second row if there's an odd number of them.
+        for mut rows in &image.rows().chunks(2) {
+            writer.queue(MoveToColumn(options.cursor_position.column))?;
+
+            let top_row = rows.next().unwrap();
+            let mut bottom_row = rows.next();
+            for top_pixel in top_row {
+                let bottom_pixel = bottom_row.as_mut().and_then(|pixels| pixels.next());
+
+                // Get pixel colors for both of these. At this point the special case for the odd
+                // number of rows disappears as we treat a transparent pixel and a non-existent
+                // one the same: they're simply transparent.
+                let top = Self::pixel_color(top_pixel);
+                let bottom = bottom_pixel.and_then(Self::pixel_color);
+                match (top, bottom) {
+                    (Some(top), Some(bottom)) => {
+                        write!(writer, "{}", TOP_CHAR.with(top).on(bottom))?;
+                    }
+                    (Some(top), None) => {
+                        write!(writer, "{}", TOP_CHAR.with(top).maybe_on(default_background))?;
+                    }
+                    (None, Some(bottom)) => {
+                        write!(writer, "{}", BOTTOM_CHAR.with(bottom).maybe_on(default_background))?;
+                    }
+                    (None, None) => {
+                        writer.queue(MoveRight(1))?;
+                    }
+                };
+            }
+            writeln!(writer)?;
+        }
         Ok(())
+    }
+}
+
+trait StylizeExt: Stylize {
+    fn maybe_on(self, color: Option<Color>) -> Self::Styled;
+}
+
+impl<T: Stylize> StylizeExt for T {
+    fn maybe_on(self, color: Option<Color>) -> Self::Styled {
+        match color {
+            Some(background) => self.on(background),
+            None => self.stylize(),
+        }
     }
 }

--- a/src/media/printer.rs
+++ b/src/media/printer.rs
@@ -4,7 +4,7 @@ use super::{
     iterm::{ItermPrinter, ItermResource},
     kitty::{KittyMode, KittyPrinter, KittyResource},
 };
-use crate::render::properties::CursorPosition;
+use crate::{render::properties::CursorPosition, style::Color};
 use image::{DynamicImage, ImageError};
 use std::{borrow::Cow, io, path::Path};
 
@@ -32,6 +32,7 @@ pub(crate) struct PrintOptions {
     pub(crate) rows: u16,
     pub(crate) cursor_position: CursorPosition,
     pub(crate) z_index: i32,
+    pub(crate) background_color: Option<Color>,
     // Width/height in pixels.
     #[allow(dead_code)]
     pub(crate) column_width: u16,
@@ -162,9 +163,6 @@ pub enum PrintImageError {
 
     #[error("image decoding: {0}")]
     Image(#[from] ImageError),
-
-    #[error("viuer: {0}")]
-    Viuer(#[from] viuer::ViuError),
 
     #[error("other: {0}")]
     Other(Cow<'static, str>),

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -3,7 +3,7 @@ use crate::{
     markdown::text::WeightedTextBlock,
     media::image::Image,
     render::properties::WindowSize,
-    style::Colors,
+    style::{Color, Colors},
     theme::{Alignment, Margin, PresentationTheme},
 };
 use serde::Deserialize;
@@ -500,11 +500,12 @@ pub(crate) enum RenderOperation {
 }
 
 /// The properties of an image being rendered.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub(crate) struct ImageProperties {
     pub(crate) z_index: i32,
     pub(crate) size: ImageSize,
     pub(crate) restore_cursor: bool,
+    pub(crate) background_color: Option<Color>,
 }
 
 /// The size used when printing an image.

--- a/src/processing/builder.rs
+++ b/src/processing/builder.rs
@@ -506,7 +506,12 @@ impl<'a> PresentationBuilder<'a> {
     }
 
     fn push_image(&mut self, image: Image) {
-        let properties = ImageProperties { z_index: DEFAULT_Z_INDEX, size: Default::default(), restore_cursor: false };
+        let properties = ImageProperties {
+            z_index: DEFAULT_Z_INDEX,
+            size: Default::default(),
+            restore_cursor: false,
+            background_color: self.theme.default_style.colors.background,
+        };
         self.chunk_operations.extend([
             RenderOperation::RenderImage(image, properties),
             RenderOperation::SetColors(self.theme.default_style.colors.clone()),

--- a/src/processing/modals.rs
+++ b/src/processing/modals.rs
@@ -309,6 +309,7 @@ impl AsRenderOperations for CenterModalContent {
                 z_index: MODAL_Z_INDEX,
                 size: ImageSize::Specific(self.content_width, content_height),
                 restore_cursor: true,
+                background_color: None,
             };
             operations.push(RenderOperation::RenderImage(image.clone(), properties));
         }

--- a/src/render/engine.rs
+++ b/src/render/engine.rs
@@ -168,6 +168,7 @@ where
             z_index: properties.z_index,
             column_width: rect.dimensions.pixels_per_column() as u16,
             row_height: rect.dimensions.pixels_per_row() as u16,
+            background_color: properties.background_color,
         };
         self.terminal.print_image(image, &options)?;
         if properties.restore_cursor {


### PR DESCRIPTION
This removes the `viuer` dependency, which at this point was only being used for ascii-blocks graphics, and replaces it with a hand rolled version. Along with this change, this respects transparency better, as in, rather than printing a chess board pattern where `rgba(0, 0, 0, 0)` pixels show up, it instead uses the theme's background.

This also fixes a problem that viuer seems to have where it sometimes adds an extra line at the bottom in ascii mode.

On the left is the new version, on the right the old one using viuer:

![Untitled](https://github.com/mfontanini/presenterm/assets/969090/945ab3a0-2b11-464d-a8ee-b2994c43cf47)

