### PR TITLE
Allow making front matter strict parsing optional

### DIFF
--- a/src/custom.rs
+++ b/src/custom.rs
@@ -81,6 +81,9 @@ pub struct OptionsConfig {
 
     /// Whether to treat a thematic break as a slide end.
     pub end_slide_shorthand: Option<bool>,
+
+    /// Whether to be strict about parsing the presentation's front matter.
+    pub strict_front_matter_parsing: Option<bool>,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,6 +111,7 @@ fn make_builder_options(config: &Config, mode: &PresentMode, force_default_theme
         force_default_theme,
         end_slide_shorthand: config.options.end_slide_shorthand.unwrap_or_default(),
         print_modal_background: false,
+        strict_front_matter_parsing: config.options.strict_front_matter_parsing.unwrap_or(true),
     }
 }
 

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -381,7 +381,6 @@ pub(crate) trait ChunkMutator: Debug {
 
 /// The metadata for a presentation.
 #[derive(Clone, Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub(crate) struct PresentationMetadata {
     /// The presentation title.
     pub(crate) title: Option<String>,


### PR DESCRIPTION
This allows setting the `strict_front_matter_parsing` option to false in the config file, which in turn allows unknown fields in the front matter. The solution is kind of crappy as I can't keep this optional without keeping the nice error message in the strict case (e.g. expected one of a, b, c).

Fixes #189