### PR TITLE
Unescape escaped symbols in block quotes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -174,7 +174,7 @@ fn run(mut cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             args.extend(["--theme", theme]);
         }
         if let Some(path) = cli.config_file.as_ref() {
-            args.extend(["--config-file", &path]);
+            args.extend(["--config-file", path]);
         }
         if cli.export_pdf {
             exporter.export_pdf(&path, &args)?;


### PR DESCRIPTION
The content of block quotes is turned back into commonmark via comrak, but it seems as part of that symbols that have a meaning in markdown (e.g. `!` or `[`) are escaped. This fixes that by unescaping them back into their original form.

Fixes #194