### PR TITLE
Add catppuccin-mocha theme

### DIFF
--- a/docs/src/guides/themes.md
+++ b/docs/src/guides/themes.md
@@ -69,6 +69,7 @@ Currently, the following themes are supported:
 * `dark`: A dark theme.
 * `light`: A light theme.
 * `tokyonight-storm`: A theme inspired by the colors used in [toyonight](https://github.com/folke/tokyonight.nvim).
+* `catppuccin-mocha`: A theme based on the [catppuccin](https://github.com/catppuccin/catppuccin) color palette.
 * `terminal-dark`: A theme that uses your terminals color and looks best if your terminal uses a dark color scheme. This 
   means if your terminal background is e.g. transparent, or uses an image, the presentation will inherit that.
 * `terminal-light`: The same as `terminal-dark` but works best if your terminal uses a light color scheme.

--- a/themes/catppuccin-mocha.yaml
+++ b/themes/catppuccin-mocha.yaml
@@ -1,0 +1,93 @@
+default:
+  margin:
+    percent: 8
+  colors:
+    foreground: "cdd6f4"
+    background: "1e1e2e"
+
+slide_title:
+  alignment: center
+  padding_bottom: 1
+  padding_top: 1
+  colors:
+    foreground: "f9e2af"
+
+code:
+  alignment: center
+  minimum_size: 50
+  minimum_margin:
+    percent: 8
+  theme_name: base16-eighties.dark
+  padding:
+    horizontal: 2
+    vertical: 1
+
+execution_output:
+  colors:
+    foreground: "cdd6f4"
+    background: "313244"
+
+inline_code:
+  colors:
+    foreground: "a6e3a1"
+
+intro_slide:
+  title:
+    alignment: center
+    colors:
+      foreground: "a6e3a1"
+  subtitle:
+    alignment: center
+    colors:
+      foreground: "74c7ec"
+  author:
+    alignment: center
+    colors:
+      foreground: "bac2de"
+    positioning: page_bottom
+
+headings:
+  h1:
+    prefix: "██"
+    colors:
+      foreground: "94e2d5"
+  h2:
+    prefix: "▓▓▓"
+    colors:
+      foreground: "cba6f7"
+  h3:
+    prefix: "▒▒▒▒"
+    colors:
+      foreground: "89b4fa"
+  h4:
+    prefix: "░░░░░"
+    colors:
+      foreground: "f38ba8"
+  h5:
+    prefix: "░░░░░░"
+    colors:
+      foreground: "a6e3a1"
+  h6:
+    prefix: "░░░░░░░"
+    colors:
+      foreground: "fab387"
+
+block_quote:
+  prefix: "▍ "
+  colors:
+    foreground: "cdd6f4"
+    background: "313244"
+
+typst:
+  colors:
+    foreground: "cdd6f4"
+    background: "313244"
+
+footer:
+  style: progress_bar
+  colors:
+    foreground: "89b4fa"
+
+modals:
+  selection_colors:
+    foreground: "74c7ec"


### PR DESCRIPTION
This adds a new default color theme based on the [catppuccin-mocha](https://github.com/catppuccin/catppuccin) color palette.
