### PR TITLE
Allow customizing slide title style

### DIFF
--- a/src/processing/builder.rs
+++ b/src/processing/builder.rs
@@ -443,7 +443,17 @@ impl<'a> PresentationBuilder<'a> {
         }
 
         let style = self.theme.slide_title.clone();
-        text.apply_style(&TextStyle::default().bold().colors(style.colors.clone()));
+        let mut text_style = TextStyle::default().colors(style.colors.clone());
+        if style.bold {
+            text_style = text_style.bold();
+        }
+        if style.italics {
+            text_style = text_style.italics();
+        }
+        if style.underlined {
+            text_style = text_style.underlined();
+        }
+        text.apply_style(&text_style);
 
         for _ in 0..style.padding_top.unwrap_or(0) {
             self.push_line_break();

--- a/src/style.rs
+++ b/src/style.rs
@@ -16,33 +16,33 @@ pub(crate) struct TextStyle {
 
 impl TextStyle {
     /// Add bold to this style.
-    pub(crate) fn bold(mut self) -> Self {
-        self.flags |= TextFormatFlags::Bold as u8;
-        self
+    pub(crate) fn bold(self) -> Self {
+        self.add_flag(TextFormatFlags::Bold)
     }
 
     /// Add italics to this style.
-    pub(crate) fn italics(mut self) -> Self {
-        self.flags |= TextFormatFlags::Italics as u8;
-        self
+    pub(crate) fn italics(self) -> Self {
+        self.add_flag(TextFormatFlags::Italics)
     }
 
     /// Indicate this text is a piece of inline code.
-    pub(crate) fn code(mut self) -> Self {
-        self.flags |= TextFormatFlags::Code as u8;
-        self
+    pub(crate) fn code(self) -> Self {
+        self.add_flag(TextFormatFlags::Code)
     }
 
     /// Add strikethrough to this style.
-    pub(crate) fn strikethrough(mut self) -> Self {
-        self.flags |= TextFormatFlags::Strikethrough as u8;
-        self
+    pub(crate) fn strikethrough(self) -> Self {
+        self.add_flag(TextFormatFlags::Strikethrough)
+    }
+
+    /// Add underline to this style.
+    pub(crate) fn underlined(self) -> Self {
+        self.add_flag(TextFormatFlags::Underlined)
     }
 
     /// Indicate this is a link.
-    pub(crate) fn link(mut self) -> Self {
-        self.flags |= TextFormatFlags::Link as u8;
-        self
+    pub(crate) fn link(self) -> Self {
+        self.italics().underlined()
     }
 
     /// Set the colors for this text style.
@@ -53,27 +53,27 @@ impl TextStyle {
 
     /// Check whether this text style is bold.
     pub(crate) fn is_bold(&self) -> bool {
-        self.flags & TextFormatFlags::Bold as u8 != 0
+        self.has_flag(TextFormatFlags::Bold)
     }
 
     /// Check whether this text style has italics.
     pub(crate) fn is_italics(&self) -> bool {
-        self.flags & TextFormatFlags::Italics as u8 != 0
+        self.has_flag(TextFormatFlags::Italics)
     }
 
     /// Check whether this text is code.
     pub(crate) fn is_code(&self) -> bool {
-        self.flags & TextFormatFlags::Code as u8 != 0
+        self.has_flag(TextFormatFlags::Code)
     }
 
     /// Check whether this text style is strikethrough.
     pub(crate) fn is_strikethrough(&self) -> bool {
-        self.flags & TextFormatFlags::Strikethrough as u8 != 0
+        self.has_flag(TextFormatFlags::Strikethrough)
     }
 
-    /// Check whether this text is a link.
-    pub(crate) fn is_link(&self) -> bool {
-        self.flags & TextFormatFlags::Link as u8 != 0
+    /// Check whether this text style is underlined.
+    pub(crate) fn is_underlined(&self) -> bool {
+        self.has_flag(TextFormatFlags::Underlined)
     }
 
     /// Merge this style with another one.
@@ -96,8 +96,8 @@ impl TextStyle {
         if self.is_strikethrough() {
             styled = styled.crossed_out();
         }
-        if self.is_link() {
-            styled = styled.italic().underlined();
+        if self.is_underlined() {
+            styled = styled.underlined();
         }
         if let Some(color) = self.colors.background {
             styled = styled.on(color.into());
@@ -107,6 +107,15 @@ impl TextStyle {
         }
         styled
     }
+
+    fn add_flag(mut self, flag: TextFormatFlags) -> Self {
+        self.flags |= flag as u8;
+        self
+    }
+
+    fn has_flag(&self, flag: TextFormatFlags) -> bool {
+        self.flags & flag as u8 != 0
+    }
 }
 
 #[derive(Debug)]
@@ -115,7 +124,7 @@ enum TextFormatFlags {
     Italics = 2,
     Code = 4,
     Strikethrough = 8,
-    Link = 16,
+    Underlined = 16,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, SerializeDisplay, DeserializeFromStr)]

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -163,6 +163,18 @@ pub(crate) struct SlideTitleStyle {
     /// The colors to be used.
     #[serde(default)]
     pub(crate) colors: Colors,
+
+    /// Whether to use bold font for slide titles.
+    #[serde(default)]
+    pub(crate) bold: bool,
+
+    /// Whether to use italics font for slide titles.
+    #[serde(default)]
+    pub(crate) italics: bool,
+
+    /// Whether to use underlined font for slide titles.
+    #[serde(default)]
+    pub(crate) underlined: bool,
 }
 
 /// The style for all headings.

--- a/themes/catppuccin-mocha.yaml
+++ b/themes/catppuccin-mocha.yaml
@@ -11,6 +11,7 @@ slide_title:
   padding_top: 1
   colors:
     foreground: "f9e2af"
+  bold: true
 
 code:
   alignment: center

--- a/themes/dark.yaml
+++ b/themes/dark.yaml
@@ -11,6 +11,7 @@ slide_title:
   padding_top: 1
   colors:
     foreground: "ee9322"
+  bold: true
 
 code:
   alignment: center

--- a/themes/light.yaml
+++ b/themes/light.yaml
@@ -11,6 +11,7 @@ slide_title:
   padding_top: 1
   colors:
     foreground: "f77f00"
+  bold: true
 
 code:
   alignment: center

--- a/themes/terminal-dark.yaml
+++ b/themes/terminal-dark.yaml
@@ -11,6 +11,7 @@ slide_title:
   padding_top: 1
   colors:
     foreground: yellow
+  bold: true
 
 code:
   alignment: center

--- a/themes/terminal-light.yaml
+++ b/themes/terminal-light.yaml
@@ -11,6 +11,7 @@ slide_title:
   padding_top: 1
   colors:
     foreground: dark_yellow
+  bold: true
 
 code:
   alignment: center

--- a/themes/tokyonight-storm.yaml
+++ b/themes/tokyonight-storm.yaml
@@ -11,6 +11,7 @@ slide_title:
   padding_top: 1
   colors:
     foreground: "e0af68"
+  bold: true
 
 code:
   alignment: center


### PR DESCRIPTION
This allows configuring slide titles by using the `bold`, `italics`, and `underlined` properties under `slide_title` in the theme definition. Before this change, slide titles were always bold, whereas now they are non-bold by default, but built-in themes all set `slide_titled.bold` to `true` so the behavior is preserved for those. This means any custom themes will no longer have bold slide titles unless they do the same.