### PR TITLE
Sort input file list

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -14,8 +14,9 @@ fn main() -> io::Result<()> {
     output_file.write_all(b"use once_cell::sync::Lazy;\n")?;
     output_file
         .write_all(b"static THEMES: Lazy<HashMap<&'static str, &'static [u8]>> = Lazy::new(|| HashMap::from([\n")?;
-    for theme_file in fs::read_dir("themes")? {
-        let theme_file = theme_file?;
+    let mut paths = fs::read_dir("themes")?.collect::<io::Result<Vec<_>>>()?;
+    paths.sort_by_key(|e| e.path());
+    for theme_file in paths {
         let metadata = theme_file.metadata()?;
         if !metadata.is_file() {
             panic!("found non file in themes directory");


### PR DESCRIPTION
Sort input file list
so that `themes.rs` builds in a reproducible way
in spite of non-deterministic filesystem readdir order.

See https://reproducible-builds.org/ for why this is good.

Without this patch, `themes.rs` and the resulting `presenterm` binary would differ thusly:
```diff
-  theme_name: base16-eighties.dark
+  theme_name: GitHub
```

This patch was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).