### PR TITLE
Add frappe, latte and macchiato catppuccin themes

### DIFF
--- a/themes/catppuccin-frappe.yaml
+++ b/themes/catppuccin-frappe.yaml
@@ -1,0 +1,94 @@
+default:
+  margin:
+    percent: 8
+  colors:
+    foreground: "c6d0f5"
+    background: "303446"
+
+slide_title:
+  alignment: center
+  padding_bottom: 1
+  padding_top: 1
+  colors:
+    foreground: "e5c890"
+  bold: true
+
+code:
+  alignment: center
+  minimum_size: 50
+  minimum_margin:
+    percent: 8
+  theme_name: base16-eighties.dark
+  padding:
+    horizontal: 2
+    vertical: 1
+
+execution_output:
+  colors:
+    foreground: "c6d0f5"
+    background: "414559"
+
+inline_code:
+  colors:
+    foreground: "a6d189"
+
+intro_slide:
+  title:
+    alignment: center
+    colors:
+      foreground: "a6d189"
+  subtitle:
+    alignment: center
+    colors:
+      foreground: "85c1dc"
+  author:
+    alignment: center
+    colors:
+      foreground: "b5bfe2"
+    positioning: page_bottom
+
+headings:
+  h1:
+    prefix: "██"
+    colors:
+      foreground: "81c8be"
+  h2:
+    prefix: "▓▓▓"
+    colors:
+      foreground: "ca9ee6"
+  h3:
+    prefix: "▒▒▒▒"
+    colors:
+      background: "8caaee"
+  h4:
+    prefix: "░░░░░"
+    colors:
+      foreground: "e78284"
+  h5:
+    prefix: "░░░░░░"
+    colors:
+      foreground: "a6d189"
+  h6:
+    prefix: "░░░░░░░"
+    colors:
+      foreground: "ef9f76"
+
+block_quote:
+  prefix: "▍ "
+  colors:
+    foreground: "c6d0f5"
+    background: "414559"
+
+typst:
+  colors:
+    foreground: "c6d0f5"
+    background: "414559"
+
+footer:
+  style: progress_bar
+  colors:
+    background: "8caaee"
+
+modals:
+  selection_colors:
+    foreground: "85c1dc"

--- a/themes/catppuccin-latte.yaml
+++ b/themes/catppuccin-latte.yaml
@@ -1,0 +1,94 @@
+default:
+  margin:
+    percent: 8
+  colors:
+    foreground: "4c4f69"
+    background: "eff1f5"
+
+slide_title:
+  alignment: center
+  padding_bottom: 1
+  padding_top: 1
+  colors:
+    foreground: "df8e1d"
+  bold: true
+
+code:
+  alignment: center
+  minimum_size: 50
+  minimum_margin:
+    percent: 8
+  theme_name: GitHub
+  padding:
+    horizontal: 2
+    vertical: 1
+
+execution_output:
+  colors:
+    foreground: "4c4f69"
+    background: "ccd0da"
+
+inline_code:
+  colors:
+    foreground: "40a02b"
+
+intro_slide:
+  title:
+    alignment: center
+    colors:
+      foreground: "40a02b"
+  subtitle:
+    alignment: center
+    colors:
+      foreground: "209fb5"
+  author:
+    alignment: center
+    colors:
+      foreground: "5c5f77"
+    positioning: page_bottom
+
+headings:
+  h1:
+    prefix: "██"
+    colors:
+      foreground: "179299"
+  h2:
+    prefix: "▓▓▓"
+    colors:
+      foreground: "8839ef"
+  h3:
+    prefix: "▒▒▒▒"
+    colors:
+      background: "1e66f5"
+  h4:
+    prefix: "░░░░░"
+    colors:
+      foreground: "d20f39"
+  h5:
+    prefix: "░░░░░░"
+    colors:
+      foreground: "40a02b"
+  h6:
+    prefix: "░░░░░░░"
+    colors:
+      foreground: "fe640b"
+
+block_quote:
+  prefix: "▍ "
+  colors:
+    foreground: "4c4f69"
+    background: "ccd0da"
+
+typst:
+  colors:
+    foreground: "4c4f69"
+    background: "ccd0da"
+
+footer:
+  style: progress_bar
+  colors:
+    background: "1e66f5"
+
+modals:
+  selection_colors:
+    foreground: "209fb5"

--- a/themes/catppuccin-macchiato.yaml
+++ b/themes/catppuccin-macchiato.yaml
@@ -1,0 +1,94 @@
+default:
+  margin:
+    percent: 8
+  colors:
+    foreground: "cad3f5"
+    background: "24273a"
+
+slide_title:
+  alignment: center
+  padding_bottom: 1
+  padding_top: 1
+  colors:
+    foreground: "eed49f"
+  bold: true
+
+code:
+  alignment: center
+  minimum_size: 50
+  minimum_margin:
+    percent: 8
+  theme_name: base16-eighties.dark
+  padding:
+    horizontal: 2
+    vertical: 1
+
+execution_output:
+  colors:
+    foreground: "cad3f5"
+    background: "363a4f"
+
+inline_code:
+  colors:
+    foreground: "a6da95"
+
+intro_slide:
+  title:
+    alignment: center
+    colors:
+      foreground: "a6da95"
+  subtitle:
+    alignment: center
+    colors:
+      foreground: "7dc4e4"
+  author:
+    alignment: center
+    colors:
+      foreground: "b8c0e0"
+    positioning: page_bottom
+
+headings:
+  h1:
+    prefix: "██"
+    colors:
+      foreground: "8bd5ca"
+  h2:
+    prefix: "▓▓▓"
+    colors:
+      foreground: "c6a0f6"
+  h3:
+    prefix: "▒▒▒▒"
+    colors:
+      background: "8aadf4"
+  h4:
+    prefix: "░░░░░"
+    colors:
+      foreground: "ed8796"
+  h5:
+    prefix: "░░░░░░"
+    colors:
+      foreground: "a6da95"
+  h6:
+    prefix: "░░░░░░░"
+    colors:
+      foreground: "f5a97f"
+
+block_quote:
+  prefix: "▍ "
+  colors:
+    foreground: "cad3f5"
+    background: "363a4f"
+
+typst:
+  colors:
+    foreground: "cad3f5"
+    background: "363a4f"
+
+footer:
+  style: progress_bar
+  colors:
+    background: "8aadf4"
+
+modals:
+  selection_colors:
+    foreground: "7dc4e4"


### PR DESCRIPTION
Closes [#203](https://github.com/mfontanini/presenterm/issues/203)

This adds the remaining [catppuccin](https://github.com/catppuccin/catppuccin) color schemes as default themes.

Hope you don't mind I stole your thunder @sp3ctum !
