### PR TITLE
Add parameter to list themes

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -10,10 +10,9 @@ fn main() -> io::Result<()> {
     let out_dir = env::var("OUT_DIR").unwrap();
     let output_path = format!("{out_dir}/themes.rs");
     let mut output_file = BufWriter::new(File::create(output_path)?);
-    output_file.write_all(b"use std::collections::HashMap;\n")?;
+    output_file.write_all(b"use std::collections::BTreeMap as Map;\n")?;
     output_file.write_all(b"use once_cell::sync::Lazy;\n")?;
-    output_file
-        .write_all(b"static THEMES: Lazy<HashMap<&'static str, &'static [u8]>> = Lazy::new(|| HashMap::from([\n")?;
+    output_file.write_all(b"static THEMES: Lazy<Map<&'static str, &'static [u8]>> = Lazy::new(|| Map::from([\n")?;
     let mut paths = fs::read_dir("themes")?.collect::<io::Result<Vec<_>>>()?;
     paths.sort_by_key(|e| e.path());
     for theme_file in paths {

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -1,0 +1,138 @@
+use crate::{
+    input::{
+        source::Command,
+        user::{CommandKeyBindings, UserInput},
+    },
+    markdown::elements::MarkdownElement,
+    presentation::Presentation,
+    processing::builder::{BuildError, PresentationBuilder},
+    render::draw::TerminalDrawer,
+    ImageRegistry, MarkdownParser, PresentationBuilderOptions, PresentationTheme, Resources, Themes, TypstRender,
+};
+use std::io;
+
+const PRESENTATION: &str = r#"
+# Header 1
+## Header 2
+### Header 3
+#### Header 4
+##### Header 5
+###### Header 6
+
+```rust
+fn greet(name: &str) -> String {
+    format!("hi {name}")
+}
+````
+
+* **bold text**
+* _italics_
+    * `some inline code`
+    * ~strikethrough~
+
+> a block quote
+
+<!-- end_slide -->
+<!-- end_slide -->
+"#;
+
+pub struct ThemesDemo<W: io::Write> {
+    themes: Themes,
+    input: UserInput,
+    drawer: TerminalDrawer<W>,
+}
+
+impl<W: io::Write> ThemesDemo<W> {
+    pub fn new(themes: Themes, bindings: CommandKeyBindings, writer: W) -> io::Result<Self> {
+        let input = UserInput::new(bindings);
+        let drawer = TerminalDrawer::new(writer, Default::default(), 1)?;
+        Ok(Self { themes, input, drawer })
+    }
+
+    pub fn run(mut self) -> Result<(), Box<dyn std::error::Error>> {
+        let arena = Default::default();
+        let parser = MarkdownParser::new(&arena);
+        let elements = parser.parse(PRESENTATION).expect("broken demo presentation");
+        let mut presentations = Vec::new();
+        for theme_name in self.themes.presentation.theme_names() {
+            let theme = self.themes.presentation.load_by_name(&theme_name).expect("theme not found");
+            let presentation = self.build(&elements, &theme_name, &theme)?;
+            presentations.push(presentation);
+        }
+        let mut current = 0;
+        loop {
+            self.drawer.render_slide(&presentations[current])?;
+
+            let command = self.next_command()?;
+            match command {
+                DemoCommand::Next => current = (current + 1).min(presentations.len() - 1),
+                DemoCommand::Previous => current = current.saturating_sub(1),
+                DemoCommand::First => current = 0,
+                DemoCommand::Last => current = presentations.len() - 1,
+                DemoCommand::Exit => return Ok(()),
+            };
+        }
+    }
+
+    fn next_command(&mut self) -> io::Result<DemoCommand> {
+        loop {
+            let mut command = self.input.next_command()?;
+            while command.is_none() {
+                command = self.input.next_command()?;
+            }
+            match command.unwrap() {
+                Command::Next => return Ok(DemoCommand::Next),
+                Command::Previous => return Ok(DemoCommand::Previous),
+                Command::FirstSlide => return Ok(DemoCommand::First),
+                Command::LastSlide => return Ok(DemoCommand::Last),
+                Command::Exit => return Ok(DemoCommand::Exit),
+                _ => continue,
+            }
+        }
+    }
+
+    fn build(
+        &self,
+        base_elements: &[MarkdownElement],
+        theme_name: &str,
+        theme: &PresentationTheme,
+    ) -> Result<Presentation, BuildError> {
+        let image_registry = ImageRegistry::default();
+        let mut resources = Resources::new("non_existent", image_registry.clone());
+        let mut typst = TypstRender::default();
+        let options = PresentationBuilderOptions::default();
+        let bindings_config = Default::default();
+        let builder = PresentationBuilder::new(
+            theme,
+            &mut resources,
+            &mut typst,
+            &self.themes,
+            image_registry,
+            bindings_config,
+            options,
+        );
+        let mut elements = vec![MarkdownElement::SetexHeading { text: format!("theme: {theme_name}").into() }];
+        elements.extend(base_elements.iter().cloned());
+        builder.build(elements)
+    }
+}
+
+enum DemoCommand {
+    Next,
+    Previous,
+    First,
+    Last,
+    Exit,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn demo_presentation() {
+        let arena = Default::default();
+        let parser = MarkdownParser::new(&arena);
+        parser.parse(PRESENTATION).expect("broken demo presentation");
+    }
+}

--- a/src/export.rs
+++ b/src/export.rs
@@ -9,7 +9,7 @@ use crate::{
     processing::builder::{BuildError, PresentationBuilder, PresentationBuilderOptions, Themes},
     tools::{ExecutionError, ThirdPartyTools},
     typst::TypstRender,
-    CodeHighlighter, MarkdownParser, PresentationTheme, Resources,
+    MarkdownParser, PresentationTheme, Resources,
 };
 use base64::{engine::general_purpose::STANDARD, Engine};
 use image::{codecs::png::PngEncoder, DynamicImage, ImageEncoder, ImageError};
@@ -80,7 +80,6 @@ impl<'a> Exporter<'a> {
         let elements = self.parser.parse(content)?;
         let path = path.canonicalize().expect("canonicalize");
         let mut presentation = PresentationBuilder::new(
-            CodeHighlighter::default(),
             self.default_theme,
             &mut self.resources,
             &mut self.typst,

--- a/src/input/user.rs
+++ b/src/input/user.rs
@@ -5,13 +5,13 @@ use serde_with::DeserializeFromStr;
 use std::{fmt, io, iter, mem, str::FromStr, time::Duration};
 
 /// A user input handler.
-pub(crate) struct UserInput {
+pub struct UserInput {
     bindings: CommandKeyBindings,
     events: Vec<KeyEvent>,
 }
 
 impl UserInput {
-    pub(crate) fn new(bindings: CommandKeyBindings) -> Self {
+    pub fn new(bindings: CommandKeyBindings) -> Self {
         Self { bindings, events: Vec::new() }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 //! This is not meant to be used as a crate!
 
 pub(crate) mod custom;
+pub(crate) mod demo;
 pub(crate) mod diff;
 pub(crate) mod execute;
 pub(crate) mod export;
@@ -21,6 +22,7 @@ pub(crate) mod typst;
 
 pub use crate::{
     custom::{Config, ImageProtocol},
+    demo::ThemesDemo,
     export::{ExportError, Exporter},
     input::source::CommandSource,
     markdown::parse::MarkdownParser,

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,10 +4,10 @@ use directories::ProjectDirs;
 use presenterm::{
     CommandSource, Config, Exporter, GraphicsMode, HighlightThemeSet, ImagePrinter, ImageProtocol, ImageRegistry,
     LoadThemeError, MarkdownParser, PresentMode, PresentationBuilderOptions, PresentationTheme, PresentationThemeSet,
-    Presenter, PresenterOptions, Resources, Themes, TypstRender,
+    Presenter, PresenterOptions, Resources, Themes, ThemesDemo, TypstRender,
 };
 use std::{
-    env,
+    env, io,
     path::{Path, PathBuf},
     rc::Rc,
 };
@@ -42,6 +42,10 @@ struct Cli {
     /// The theme to use.
     #[clap(short, long)]
     theme: Option<String>,
+
+    /// List all supported themes.
+    #[clap(long)]
+    list_themes: bool,
 
     /// Display acknowledgements.
     #[clap(long, group = "target")]
@@ -159,6 +163,11 @@ fn run(mut cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
     let parser = MarkdownParser::new(&arena);
     if cli.acknowledgements {
         display_acknowledgements();
+        return Ok(());
+    } else if cli.list_themes {
+        let bindings = config.bindings.try_into()?;
+        let demo = ThemesDemo::new(themes, bindings, io::stdout())?;
+        demo.run()?;
         return Ok(());
     }
 

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -7,10 +7,7 @@ use crate::{
     media::{printer::ImagePrinter, register::ImageRegistry},
     presentation::Presentation,
     processing::builder::{BuildError, PresentationBuilder, PresentationBuilderOptions, Themes},
-    render::{
-        draw::{RenderError, RenderResult, TerminalDrawer},
-        highlighting::CodeHighlighter,
-    },
+    render::draw::{RenderError, RenderResult, TerminalDrawer},
     resource::Resources,
     theme::PresentationTheme,
     typst::TypstRender,
@@ -230,7 +227,6 @@ impl<'a> Presenter<'a> {
         let elements = self.parser.parse(&content)?;
         let export_mode = matches!(self.options.mode, PresentMode::Export);
         let mut presentation = PresentationBuilder::new(
-            CodeHighlighter::default(),
             self.default_theme,
             &mut self.resources,
             &mut self.typst,

--- a/src/processing/builder.rs
+++ b/src/processing/builder.rs
@@ -110,7 +110,6 @@ impl<'a> PresentationBuilder<'a> {
     /// Construct a new builder.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
-        default_highlighter: CodeHighlighter,
         default_theme: &'a PresentationTheme,
         resources: &'a mut Resources,
         typst: &'a mut TypstRender,
@@ -124,7 +123,7 @@ impl<'a> PresentationBuilder<'a> {
             chunk_operations: Vec::new(),
             chunk_mutators: Vec::new(),
             slides: Vec::new(),
-            highlighter: default_highlighter,
+            highlighter: CodeHighlighter::default(),
             theme: Cow::Borrowed(default_theme),
             resources,
             typst,
@@ -1009,14 +1008,12 @@ mod test {
         elements: Vec<MarkdownElement>,
         options: PresentationBuilderOptions,
     ) -> Result<Presentation, BuildError> {
-        let highlighter = CodeHighlighter::default();
         let theme = PresentationTheme::default();
         let mut resources = Resources::new("/tmp", Default::default());
         let mut typst = TypstRender::default();
         let themes = Themes::default();
         let bindings = KeyBindingsConfig::default();
         let builder = PresentationBuilder::new(
-            highlighter,
             &theme,
             &mut resources,
             &mut typst,

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,12 +1,12 @@
 use crate::style::Colors;
 use serde::{Deserialize, Serialize};
-use std::{fs, io, path::Path};
+use std::{collections::BTreeMap, fs, io, path::Path};
 
 include!(concat!(env!("OUT_DIR"), "/themes.rs"));
 
 #[derive(Default)]
 pub struct PresentationThemeSet {
-    custom_themes: HashMap<String, PresentationTheme>,
+    custom_themes: BTreeMap<String, PresentationTheme>,
 }
 
 impl PresentationThemeSet {

--- a/themes/catppuccin-frappe.yaml
+++ b/themes/catppuccin-frappe.yaml
@@ -59,7 +59,7 @@ headings:
   h3:
     prefix: "▒▒▒▒"
     colors:
-      background: "8caaee"
+      foreground: "8caaee"
   h4:
     prefix: "░░░░░"
     colors:

--- a/themes/catppuccin-latte.yaml
+++ b/themes/catppuccin-latte.yaml
@@ -59,7 +59,7 @@ headings:
   h3:
     prefix: "▒▒▒▒"
     colors:
-      background: "1e66f5"
+      foreground: "1e66f5"
   h4:
     prefix: "░░░░░"
     colors:

--- a/themes/catppuccin-macchiato.yaml
+++ b/themes/catppuccin-macchiato.yaml
@@ -59,7 +59,7 @@ headings:
   h3:
     prefix: "▒▒▒▒"
     colors:
-      background: "8aadf4"
+      foreground: "8aadf4"
   h4:
     prefix: "░░░░░"
     colors:


### PR DESCRIPTION
This adds a `--list-themes` parameter that showcases a single demo slide on all available themes. This includes built-in as well as your own ones under `$CONFIG/themes/`:

[![asciicast](https://asciinema.org/a/zeV1QloyrLkfBp6rNltvX7Lle.svg)](https://asciinema.org/a/zeV1QloyrLkfBp6rNltvX7Lle)