### PR TITLE
Allow validating whether presentation overflows terminal

### DIFF
--- a/src/demo.rs
+++ b/src/demo.rs
@@ -6,7 +6,7 @@ use crate::{
     markdown::elements::MarkdownElement,
     presentation::Presentation,
     processing::builder::{BuildError, PresentationBuilder},
-    render::draw::TerminalDrawer,
+    render::{draw::TerminalDrawer, terminal::TerminalWrite},
     ImageRegistry, MarkdownParser, PresentationBuilderOptions, PresentationTheme, Resources, Themes, TypstRender,
 };
 use std::io;
@@ -36,13 +36,13 @@ fn greet(name: &str) -> String {
 <!-- end_slide -->
 "#;
 
-pub struct ThemesDemo<W: io::Write> {
+pub struct ThemesDemo<W: TerminalWrite> {
     themes: Themes,
     input: UserInput,
     drawer: TerminalDrawer<W>,
 }
 
-impl<W: io::Write> ThemesDemo<W> {
+impl<W: TerminalWrite> ThemesDemo<W> {
     pub fn new(themes: Themes, bindings: CommandKeyBindings, writer: W) -> io::Result<Self> {
         let input = UserInput::new(bindings);
         let drawer = TerminalDrawer::new(writer, Default::default(), 1)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ struct Cli {
     #[clap(long, hide = true)]
     export: bool,
 
-    /// Whether to use presentation mode.
+    /// Use presentation mode.
     #[clap(short, long, default_value_t = false)]
     present: bool,
 
@@ -54,6 +54,10 @@ struct Cli {
     /// The image protocol to use.
     #[clap(long)]
     image_protocol: Option<ImageProtocol>,
+
+    /// Validate that the presentation does not overflow the terminal screen.
+    #[clap(long)]
+    validate_overflows: bool,
 
     /// The path to the configuration file.
     #[clap(short, long)]
@@ -205,6 +209,7 @@ fn run(mut cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             mode,
             font_size_fallback: config.defaults.terminal_font_size,
             bindings: config.bindings,
+            validate_overflows: cli.validate_overflows,
         };
         let presenter = Presenter::new(&default_theme, commands, parser, resources, typst, themes, printer, options);
         presenter.present(&path)?;

--- a/src/media/printer.rs
+++ b/src/media/printer.rs
@@ -64,6 +64,7 @@ pub enum ImagePrinter {
     Kitty(KittyPrinter),
     Iterm(ItermPrinter),
     Ascii(AsciiPrinter),
+    Null,
     #[cfg(feature = "sixel")]
     Sixel(super::sixel::SixelPrinter),
 }
@@ -112,6 +113,7 @@ impl PrintImage for ImagePrinter {
             Self::Kitty(printer) => ImageResource::Kitty(printer.register_image(image)?),
             Self::Iterm(printer) => ImageResource::Iterm(printer.register_image(image)?),
             Self::Ascii(printer) => ImageResource::Ascii(printer.register_image(image)?),
+            Self::Null => return Err(RegisterImageError::Unsupported),
             #[cfg(feature = "sixel")]
             Self::Sixel(printer) => ImageResource::Sixel(printer.register_image(image)?),
         };
@@ -123,6 +125,7 @@ impl PrintImage for ImagePrinter {
             Self::Kitty(printer) => ImageResource::Kitty(printer.register_resource(path)?),
             Self::Iterm(printer) => ImageResource::Iterm(printer.register_resource(path)?),
             Self::Ascii(printer) => ImageResource::Ascii(printer.register_resource(path)?),
+            Self::Null => return Err(RegisterImageError::Unsupported),
             #[cfg(feature = "sixel")]
             Self::Sixel(printer) => ImageResource::Sixel(printer.register_resource(path)?),
         };
@@ -137,6 +140,7 @@ impl PrintImage for ImagePrinter {
             (Self::Kitty(printer), ImageResource::Kitty(image)) => printer.print(image, options, writer),
             (Self::Iterm(printer), ImageResource::Iterm(image)) => printer.print(image, options, writer),
             (Self::Ascii(printer), ImageResource::Ascii(image)) => printer.print(image, options, writer),
+            (Self::Null, _) => Ok(()),
             #[cfg(feature = "sixel")]
             (Self::Sixel(printer), ImageResource::Sixel(image)) => printer.print(image, options, writer),
             _ => Err(PrintImageError::Unsupported),
@@ -175,6 +179,9 @@ pub enum RegisterImageError {
 
     #[error("image decoding: {0}")]
     Image(#[from] ImageError),
+
+    #[error("printer can't register resources")]
+    Unsupported,
 }
 
 impl PrintImageError {

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -423,8 +423,8 @@ pub(crate) struct PresentationThemeMetadata {
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct PreformattedLine {
     pub(crate) text: String,
-    pub(crate) unformatted_length: usize,
-    pub(crate) block_length: usize,
+    pub(crate) unformatted_length: u16,
+    pub(crate) block_length: u16,
     pub(crate) alignment: Alignment,
 }
 

--- a/src/processing/builder.rs
+++ b/src/processing/builder.rs
@@ -605,8 +605,8 @@ impl<'a> PresentationBuilder<'a> {
             let line_length = line.width();
             self.chunk_operations.push(RenderOperation::RenderPreformattedLine(PreformattedLine {
                 text: line,
-                unformatted_length: line_length,
-                block_length,
+                unformatted_length: line_length as u16,
+                block_length: block_length as u16,
                 alignment: self.theme.alignment(&ElementType::BlockQuote).clone(),
             }));
             self.push_line_break();

--- a/src/processing/code.rs
+++ b/src/processing/code.rs
@@ -112,8 +112,8 @@ impl AsRenderOperations for HighlightedLine {
         vec![
             RenderOperation::RenderPreformattedLine(PreformattedLine {
                 text,
-                unformatted_length: self.width,
-                block_length: context.block_length,
+                unformatted_length: self.width as u16,
+                block_length: context.block_length as u16,
                 alignment: context.alignment.clone(),
             }),
             RenderOperation::RenderLineBreak,

--- a/src/processing/execution.rs
+++ b/src/processing/execution.rs
@@ -33,7 +33,7 @@ impl RunCodeOperation {
     }
 
     fn render_line(&self, line: String) -> RenderOperation {
-        let line_len = line.len();
+        let line_len = line.len() as u16;
         RenderOperation::RenderPreformattedLine(PreformattedLine {
             text: line,
             unformatted_length: line_len,

--- a/src/render/draw.rs
+++ b/src/render/draw.rs
@@ -82,7 +82,8 @@ where
     }
 
     fn create_engine(&mut self, dimensions: WindowSize) -> RenderEngine<W> {
-        RenderEngine::new(&mut self.terminal, dimensions)
+        let options = Default::default();
+        RenderEngine::new(&mut self.terminal, dimensions, options)
     }
 }
 
@@ -106,6 +107,12 @@ pub enum RenderError {
 
     #[error("printing image: {0}")]
     PrintImage(#[from] PrintImageError),
+
+    #[error("horizontal overflow")]
+    HorizontalOverflow,
+
+    #[error("vertical overflow")]
+    VerticalOverflow,
 
     #[error(transparent)]
     Other(Box<dyn std::error::Error>),

--- a/src/render/draw.rs
+++ b/src/render/draw.rs
@@ -1,4 +1,7 @@
-use super::{engine::RenderEngine, terminal::Terminal};
+use super::{
+    engine::RenderEngine,
+    terminal::{Terminal, TerminalWrite},
+};
 use crate::{
     markdown::{elements::Text, text::WeightedTextBlock},
     media::printer::{ImagePrinter, PrintImageError},
@@ -13,14 +16,14 @@ use std::{io, rc::Rc};
 pub(crate) type RenderResult = Result<(), RenderError>;
 
 /// Allows drawing elements in the terminal.
-pub(crate) struct TerminalDrawer<W: io::Write> {
+pub(crate) struct TerminalDrawer<W: TerminalWrite> {
     terminal: Terminal<W>,
     font_size_fallback: u8,
 }
 
 impl<W> TerminalDrawer<W>
 where
-    W: io::Write,
+    W: TerminalWrite,
 {
     /// Construct a drawer over a [std::io::Write].
     pub(crate) fn new(handle: W, image_printer: Rc<ImagePrinter>, font_size_fallback: u8) -> io::Result<Self> {

--- a/src/render/engine.rs
+++ b/src/render/engine.rs
@@ -2,7 +2,7 @@ use super::{
     draw::{RenderError, RenderResult},
     layout::Layout,
     properties::CursorPosition,
-    terminal::Terminal,
+    terminal::{Terminal, TerminalWrite},
     text::TextDrawer,
 };
 use crate::{
@@ -20,11 +20,11 @@ use crate::{
     style::Colors,
     theme::Alignment,
 };
-use std::{io, mem};
+use std::mem;
 
 pub(crate) struct RenderEngine<'a, W>
 where
-    W: io::Write,
+    W: TerminalWrite,
 {
     terminal: &'a mut Terminal<W>,
     window_rects: Vec<WindowRect>,
@@ -35,7 +35,7 @@ where
 
 impl<'a, W> RenderEngine<'a, W>
 where
-    W: io::Write,
+    W: TerminalWrite,
 {
     pub(crate) fn new(terminal: &'a mut Terminal<W>, window_dimensions: WindowSize) -> Self {
         let max_modified_row = terminal.cursor_row;

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -5,3 +5,4 @@ pub(crate) mod layout;
 pub(crate) mod properties;
 pub(crate) mod terminal;
 pub(crate) mod text;
+pub(crate) mod validate;

--- a/src/render/text.rs
+++ b/src/render/text.rs
@@ -1,4 +1,4 @@
-use super::terminal::Terminal;
+use super::terminal::{Terminal, TerminalWrite};
 use crate::{
     markdown::text::WeightedTextBlock,
     render::{
@@ -8,7 +8,6 @@ use crate::{
     },
     style::{Colors, TextStyle},
 };
-use std::io;
 
 const MINIMUM_LINE_LENGTH: u16 = 10;
 
@@ -43,7 +42,7 @@ impl<'a> TextDrawer<'a> {
     /// This performs word splitting and word wrapping.
     pub(crate) fn draw<W>(self, terminal: &mut Terminal<W>) -> RenderResult
     where
-        W: io::Write,
+        W: TerminalWrite,
     {
         let Positioning { max_line_length, start_column } = self.positioning;
 

--- a/src/render/validate.rs
+++ b/src/render/validate.rs
@@ -1,0 +1,52 @@
+use super::{properties::WindowSize, terminal::TerminalWrite};
+use crate::{
+    presentation::Presentation,
+    render::{
+        draw::RenderError,
+        engine::{RenderEngine, RenderEngineOptions},
+        terminal::Terminal,
+    },
+    ImagePrinter,
+};
+use std::{io, rc::Rc};
+
+pub(crate) struct OverflowValidator;
+
+impl OverflowValidator {
+    pub(crate) fn validate(presentation: &Presentation, dimensions: WindowSize) -> Result<(), OverflowError> {
+        let printer = Rc::new(ImagePrinter::Null);
+        for (index, slide) in presentation.iter_slides().enumerate() {
+            let index = index + 1;
+            let mut terminal = Terminal::new(io::Empty::default(), printer.clone()).map_err(RenderError::from)?;
+            let options = RenderEngineOptions { validate_overflows: true };
+            let engine = RenderEngine::new(&mut terminal, dimensions.clone(), options);
+            match engine.render(slide.iter_operations()) {
+                Ok(()) => (),
+                Err(RenderError::HorizontalOverflow) => return Err(OverflowError::Horizontal(index)),
+                Err(RenderError::VerticalOverflow) => return Err(OverflowError::Vertical(index)),
+                Err(e) => return Err(OverflowError::Render(e)),
+            };
+        }
+        Ok(())
+    }
+}
+
+impl TerminalWrite for io::Empty {
+    fn init(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn deinit(&mut self) {}
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum OverflowError {
+    #[error("presentation overflows horizontally on slide {0}")]
+    Horizontal(usize),
+
+    #[error("presentation overflows vertically on slide {0}")]
+    Vertical(usize),
+
+    #[error(transparent)]
+    Render(#[from] RenderError),
+}


### PR DESCRIPTION
This adds a `--validate-overflows` which, upon loading the presentation or resizing the terminal screen, will run checks to ensure the presentation doesn't:

* Overflow the screen vertically/horizontally. This can happen when you use block quotes or code blocks.
* Overflow a column layout rect. That is, if you use block quotes or code blocks within a column, it can happen that the column is small enough and can't fit its content.

Relates to #61

[![asciicast](https://asciinema.org/a/RguCyLDTDJIzK3lNT4VN3mgID.svg)](https://asciinema.org/a/RguCyLDTDJIzK3lNT4VN3mgID)