### PR TITLE
Allow setting validate overflows mode in config file

### DIFF
--- a/src/custom.rs
+++ b/src/custom.rs
@@ -55,16 +55,34 @@ pub struct DefaultsConfig {
 
     #[serde(default)]
     pub image_protocol: ImageProtocol,
+
+    #[serde(default)]
+    pub validate_overflows: ValidateOverflows,
 }
 
 impl Default for DefaultsConfig {
     fn default() -> Self {
-        Self { theme: Default::default(), terminal_font_size: default_font_size(), image_protocol: Default::default() }
+        Self {
+            theme: Default::default(),
+            terminal_font_size: default_font_size(),
+            image_protocol: Default::default(),
+            validate_overflows: Default::default(),
+        }
     }
 }
 
 fn default_font_size() -> u8 {
     16
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ValidateOverflows {
+    #[default]
+    Never,
+    Always,
+    WhenPresenting,
+    WhenDeveloping,
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ pub(crate) mod tools;
 pub(crate) mod typst;
 
 pub use crate::{
-    custom::{Config, ImageProtocol},
+    custom::{Config, ImageProtocol, ValidateOverflows},
     demo::ThemesDemo,
     export::{ExportError, Exporter},
     input::source::CommandSource,


### PR DESCRIPTION
This allows configuring the overflow validation mode introduced in #209 in the config file via `defaults.validate_overflows`:
* `always` to always validate.
* `never` to never validate (this is the default).
* `when_presenting` to validate when running in presentation mode (`-p`).
* `when_developing` to validate when running in development mode (the default mode).