### PR TITLE
Allow having code blocks without background

### DIFF
--- a/src/processing/builder.rs
+++ b/src/processing/builder.rs
@@ -686,9 +686,10 @@ impl<'a> PresentationBuilder<'a> {
         }));
 
         let mut output = Vec::new();
+        let block_style = &self.theme.code;
         for line in lines.into_iter() {
-            let highlighted = line.highlight(&padding_style, &mut code_highlighter);
-            let not_highlighted = line.highlight(&padding_style, &mut empty_highlighter);
+            let highlighted = line.highlight(&padding_style, &mut code_highlighter, block_style);
+            let not_highlighted = line.highlight(&padding_style, &mut empty_highlighter, block_style);
             let width = line.width();
             let line_number = line.line_number;
             let context = context.clone();

--- a/src/processing/code.rs
+++ b/src/processing/code.rs
@@ -6,7 +6,7 @@ use crate::{
         highlighting::{LanguageHighlighter, StyledTokens},
         properties::WindowSize,
     },
-    theme::Alignment,
+    theme::{Alignment, CodeBlockStyle},
     PresentationTheme,
 };
 use std::{cell::RefCell, rc::Rc};
@@ -74,10 +74,15 @@ impl CodeLine {
         self.prefix.width() + self.code.width() + self.suffix.width()
     }
 
-    pub(crate) fn highlight(&self, padding_style: &Style, code_highlighter: &mut LanguageHighlighter) -> String {
-        let mut output = StyledTokens { style: *padding_style, tokens: &self.prefix }.apply_style();
-        output.push_str(&code_highlighter.highlight_line(&self.code));
-        output.push_str(&StyledTokens { style: *padding_style, tokens: &self.suffix }.apply_style());
+    pub(crate) fn highlight(
+        &self,
+        padding_style: &Style,
+        code_highlighter: &mut LanguageHighlighter,
+        block_style: &CodeBlockStyle,
+    ) -> String {
+        let mut output = StyledTokens { style: *padding_style, tokens: &self.prefix }.apply_style(block_style);
+        output.push_str(&code_highlighter.highlight_line(&self.code, block_style));
+        output.push_str(&StyledTokens { style: *padding_style, tokens: &self.suffix }.apply_style(block_style));
         output
     }
 }

--- a/src/render/highlighting.rs
+++ b/src/render/highlighting.rs
@@ -1,4 +1,4 @@
-use crate::markdown::elements::CodeLanguage;
+use crate::{markdown::elements::CodeLanguage, theme::CodeBlockStyle};
 use crossterm::{
     style::{SetBackgroundColor, SetForegroundColor},
     QueueableCommand,
@@ -176,8 +176,8 @@ pub(crate) struct LanguageHighlighter<'a> {
 }
 
 impl<'a> LanguageHighlighter<'a> {
-    pub(crate) fn highlight_line(&mut self, line: &str) -> String {
-        self.style_line(line).map(|s| s.apply_style()).collect()
+    pub(crate) fn highlight_line(&mut self, line: &str, block_style: &CodeBlockStyle) -> String {
+        self.style_line(line).map(|s| s.apply_style(block_style)).collect()
     }
 
     pub(crate) fn style_line<'b>(&mut self, line: &'b str) -> impl Iterator<Item = StyledTokens<'b>> {
@@ -195,8 +195,8 @@ pub(crate) struct StyledTokens<'a> {
 }
 
 impl<'a> StyledTokens<'a> {
-    pub(crate) fn apply_style(&self) -> String {
-        let background = to_ansi_color(self.style.background);
+    pub(crate) fn apply_style(&self, block_style: &CodeBlockStyle) -> String {
+        let background = block_style.background.then_some(to_ansi_color(self.style.background)).flatten();
         let foreground = to_ansi_color(self.style.foreground);
 
         // We do this conversion manually as crossterm will reset the color after styling, and we

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -394,6 +394,10 @@ pub(crate) struct CodeBlockStyle {
     /// The syntect theme name to use.
     #[serde(default)]
     pub(crate) theme_name: Option<String>,
+
+    /// Whether to use the theme's background color.
+    #[serde(default = "default_true")]
+    pub(crate) background: bool,
 }
 
 /// The style for the output of a code execution block.
@@ -523,6 +527,10 @@ pub enum LoadThemeError {
 
     #[error("duplicate custom theme '{0}'")]
     Duplicate(String),
+}
+
+fn default_true() -> bool {
+    true
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This allows setting the theme key `code.background` (defaults to `true`) which controls whether code blocks have a background color. Note that the background color comes from the code highlighting theme being used, this only controls whether that background is visible or not.

Enabling this (the default):
![image](https://github.com/mfontanini/presenterm/assets/969090/df34776b-7b64-4685-99be-08936d6ac28c)

Disabling this:
![image](https://github.com/mfontanini/presenterm/assets/969090/470f9f6b-a0c2-4cf0-9d99-4850de5d2249)
