### PR TITLE
Allow overriding `code.background`

### DIFF
--- a/src/render/highlighting.rs
+++ b/src/render/highlighting.rs
@@ -196,7 +196,8 @@ pub(crate) struct StyledTokens<'a> {
 
 impl<'a> StyledTokens<'a> {
     pub(crate) fn apply_style(&self, block_style: &CodeBlockStyle) -> String {
-        let background = block_style.background.then_some(to_ansi_color(self.style.background)).flatten();
+        let has_background = block_style.background.unwrap_or(true);
+        let background = has_background.then_some(to_ansi_color(self.style.background)).flatten();
         let foreground = to_ansi_color(self.style.foreground);
 
         // We do this conversion manually as crossterm will reset the color after styling, and we

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -396,8 +396,7 @@ pub(crate) struct CodeBlockStyle {
     pub(crate) theme_name: Option<String>,
 
     /// Whether to use the theme's background color.
-    #[serde(default = "default_true")]
-    pub(crate) background: bool,
+    pub(crate) background: Option<bool>,
 }
 
 /// The style for the output of a code execution block.
@@ -527,10 +526,6 @@ pub enum LoadThemeError {
 
     #[error("duplicate custom theme '{0}'")]
     Duplicate(String),
-}
-
-fn default_true() -> bool {
-    true
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Allow re-enabling a disabled `code.background` (follow up on #215).