### PR TITLE
Add color to prefix in block quote

### DIFF
--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,4 +1,4 @@
-use crate::style::Colors;
+use crate::style::{Color, Colors};
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, fs, io, path::Path};
 
@@ -238,7 +238,18 @@ pub(crate) struct BlockQuoteStyle {
 
     /// The colors to be used.
     #[serde(default)]
-    pub(crate) colors: Colors,
+    pub(crate) colors: BlockQuoteColors,
+}
+
+/// The colors of a block quote.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub(crate) struct BlockQuoteColors {
+    /// The foreground/background colors.
+    #[serde(flatten)]
+    pub(crate) base: Colors,
+
+    /// The color of the vertical bar that prefixes each line in the quote.
+    pub(crate) prefix: Option<Color>,
 }
 
 /// The style for the presentation introduction slide.

--- a/themes/catppuccin-frappe.yaml
+++ b/themes/catppuccin-frappe.yaml
@@ -78,6 +78,7 @@ block_quote:
   colors:
     foreground: "c6d0f5"
     background: "414559"
+    prefix: "e5c890"
 
 typst:
   colors:

--- a/themes/catppuccin-latte.yaml
+++ b/themes/catppuccin-latte.yaml
@@ -78,6 +78,7 @@ block_quote:
   colors:
     foreground: "4c4f69"
     background: "ccd0da"
+    prefix: "df8e1d"
 
 typst:
   colors:

--- a/themes/catppuccin-macchiato.yaml
+++ b/themes/catppuccin-macchiato.yaml
@@ -78,6 +78,7 @@ block_quote:
   colors:
     foreground: "cad3f5"
     background: "363a4f"
+    prefix: "eed49f"
 
 typst:
   colors:

--- a/themes/catppuccin-mocha.yaml
+++ b/themes/catppuccin-mocha.yaml
@@ -78,6 +78,7 @@ block_quote:
   colors:
     foreground: "cdd6f4"
     background: "313244"
+    prefix: "f9e2af"
 
 typst:
   colors:

--- a/themes/dark.yaml
+++ b/themes/dark.yaml
@@ -79,6 +79,7 @@ block_quote:
   colors:
     foreground: "f0f0f0"
     background: "292e42"
+    prefix: "ee9322"
 
 typst:
   colors:

--- a/themes/light.yaml
+++ b/themes/light.yaml
@@ -79,6 +79,7 @@ block_quote:
   colors:
     foreground: "212529"
     background: "e9ecef"
+    prefix: "f77f00"
 
 typst:
   colors:

--- a/themes/terminal-dark.yaml
+++ b/themes/terminal-dark.yaml
@@ -77,6 +77,7 @@ block_quote:
   colors:
     foreground: white
     background: black
+    prefix: yellow
 
 typst:
   colors:

--- a/themes/terminal-light.yaml
+++ b/themes/terminal-light.yaml
@@ -77,6 +77,7 @@ block_quote:
   colors:
     foreground: black
     background: grey
+    prefix: dark_red
 
 typst:
   colors:

--- a/themes/tokyonight-storm.yaml
+++ b/themes/tokyonight-storm.yaml
@@ -79,6 +79,7 @@ block_quote:
   colors:
     foreground: "f0f0f0"
     background: "545c7e"
+    prefix: "e0af68"
 
 typst:
   colors:


### PR DESCRIPTION
This allows configuring the `block_quote.colors.prefix` attribute to configure the color of the block quote prefix (which defaults to a vertical line). If this key is absent, the color will be the same as the `block_quote.colors.foreground` one.

Along with this change I changed all the built in themes to have a prefix of the same color as the slide title except for a couple of light themes where I had to pick a different one.

![image](https://github.com/mfontanini/presenterm/assets/969090/32488d8f-3a26-4cac-b6d2-bce2cf0252c8)
