### PR TITLE
Add Support for Ruby Code Highlighting

### DIFF
--- a/docs/src/guides/code-highlight.md
+++ b/docs/src/guides/code-highlight.md
@@ -40,6 +40,7 @@ Code highlighting is supported for the following languages:
 * puppet
 * python
 * R
+* ruby
 * rust
 * scala
 * shell

--- a/src/markdown/code.rs
+++ b/src/markdown/code.rs
@@ -65,6 +65,7 @@ impl CodeBlockParser {
             "puppet" => Puppet,
             "python" => Python,
             "r" => R,
+            "ruby" => Ruby,
             "rust" => Rust,
             "scala" => Scala,
             "shell" => Shell("sh".into()),

--- a/src/markdown/elements.rs
+++ b/src/markdown/elements.rs
@@ -226,6 +226,7 @@ pub(crate) enum CodeLanguage {
     Puppet,
     Python,
     R,
+    Ruby,
     Rust,
     Scala,
     Shell(String),

--- a/src/render/highlighting.rs
+++ b/src/render/highlighting.rs
@@ -145,6 +145,7 @@ impl CodeHighlighter {
             Puppet => "pp",
             Python => "py",
             R => "r",
+            Ruby => "rb",
             Rust => "rs",
             Scala => "scala",
             Shell(_) => "sh",


### PR DESCRIPTION
Hi, I've really been enjoying using `presenterm`, thanks to the owners/maintainers of this project for putting in so much hard work! 

Just really needed `ruby` code support so I thought I'd add it. Please feel free to let me know if any further changes are required, I just based my changes off of #82. 