### PR TITLE
Allow having multiple authors

### DIFF
--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -394,6 +394,10 @@ pub(crate) struct PresentationMetadata {
     #[serde(default)]
     pub(crate) author: Option<String>,
 
+    /// The presentation authors.
+    #[serde(default)]
+    pub(crate) authors: Vec<String>,
+
     /// The presentation's theme metadata.
     #[serde(default)]
     pub(crate) theme: PresentationThemeMetadata,


### PR DESCRIPTION
This allows using a new attribute in the front matter: `authors`. This is like `author` but allows specifying a list of authors. Each will be displayed on a separate line.

The following presentation:

```yaml
---
title: From soil to plate
sub_title: A potato story
authors:
    - "bob: potato planter"
    - "mike: crop frier"
    - "jack: french fry eater"
---
```

Looks like this:

![image](https://github.com/mfontanini/presenterm/assets/969090/da5ca6e3-d510-4522-a0d7-5ef2cd03790a)

Fixes #225
