### PR TITLE
feat(config): add JSON schema for validation,completion,documentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,6 +448,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
+
+[[package]]
 name = "either"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -896,6 +902,7 @@ dependencies = [
  "once_cell",
  "rand",
  "rstest",
+ "schemars",
  "semver",
  "serde",
  "serde_json",
@@ -1118,6 +1125,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45a28f4c49489add4ce10783f7911893516f15afe45d015608d41faca6bc4d29"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c767fd6fa65d9ccf9cf026122c1b555f2ef9a4f0cea69da4d7dbc3e258d30967"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1147,6 +1178,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.49",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ merge-struct = "0.1.0"
 itertools = "0.12"
 once_cell = "1.19"
 rand = "0.8.5"
+schemars = "0.8.16"
 semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -1,9 +1,10 @@
+# yaml-language-server: $schema=./schema.json
 defaults:
   # override the terminal font size when in windows or when using sixel.
   terminal_font_size: 16
 
   # the theme to use by default in every presentation unless overridden.
-  theme: dark 
+  theme: dark
 
   # the image protocol to use.
   image_protocol: kitty-local
@@ -53,10 +54,10 @@ bindings:
   reload: ["<c-r>"]
 
   # the key binding to toggle the slide index modal.
-  toggle_slide_index: ["<c-p>"] 
+  toggle_slide_index: ["<c-p>"]
 
   # the key binding to toggle the key bindings modal.
-  toggle_bindings: ["?"] 
+  toggle_bindings: ["?"]
 
   # the key binding to close the currently open modal.
   close_modal: ["<esc>"]

--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,263 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Config",
+  "type": "object",
+  "properties": {
+    "bindings": {
+      "$ref": "#/definitions/KeyBindingsConfig"
+    },
+    "defaults": {
+      "description": "The default configuration for the presentation.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/DefaultsConfig"
+        }
+      ]
+    },
+    "options": {
+      "$ref": "#/definitions/OptionsConfig"
+    },
+    "typst": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/TypstConfig"
+        }
+      ],
+      "minimum": 1.0
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "DefaultsConfig": {
+      "type": "object",
+      "properties": {
+        "image_protocol": {
+          "description": "The image protocol to use.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ImageProtocol"
+            }
+          ]
+        },
+        "terminal_font_size": {
+          "description": "Override the terminal font size when in windows or when using sixel.",
+          "default": 16,
+          "type": "integer",
+          "format": "uint8",
+          "minimum": 1.0
+        },
+        "theme": {
+          "description": "The theme to use by default in every presentation unless overridden.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "validate_overflows": {
+          "description": "Validate that the presentation does not overflow the terminal screen.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ValidateOverflows"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "ImageProtocol": {
+      "oneOf": [
+        {
+          "description": "Automatically detect the best image protocol to use.",
+          "type": "string",
+          "enum": [
+            "auto"
+          ]
+        },
+        {
+          "description": "Use the iTerm2 image protocol.",
+          "type": "string",
+          "enum": [
+            "iterm2"
+          ]
+        },
+        {
+          "description": "Use the kitty protocol in \"local\" mode, meaning both presenterm and the terminal run in the same host and can share the filesystem to communicate.",
+          "type": "string",
+          "enum": [
+            "kitty-local"
+          ]
+        },
+        {
+          "description": "Use the kitty protocol in \"remote\" mode, meaning presenterm and the terminal run in different hosts and therefore can only communicate via terminal escape codes.",
+          "type": "string",
+          "enum": [
+            "kitty-remote"
+          ]
+        },
+        {
+          "description": "Use the sixel protocol. Note that this requires compiling presenterm using the --features sixel flag.",
+          "type": "string",
+          "enum": [
+            "sixel"
+          ]
+        },
+        {
+          "description": "The default image protocol to use when no other is specified.",
+          "type": "string",
+          "enum": [
+            "ascii-blocks"
+          ]
+        }
+      ]
+    },
+    "KeyBinding": {
+      "type": "string"
+    },
+    "KeyBindingsConfig": {
+      "type": "object",
+      "properties": {
+        "close_modal": {
+          "description": "The key binding to close the currently open modal.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/KeyBinding"
+          }
+        },
+        "execute_code": {
+          "description": "The key binding to execute a piece of shell code.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/KeyBinding"
+          }
+        },
+        "exit": {
+          "description": "The key binding to close the application.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/KeyBinding"
+          }
+        },
+        "first_slide": {
+          "description": "The key binding to jump to the first slide.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/KeyBinding"
+          }
+        },
+        "go_to_slide": {
+          "description": "The key binding to jump to a specific slide.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/KeyBinding"
+          }
+        },
+        "last_slide": {
+          "description": "The key binding to jump to the last slide.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/KeyBinding"
+          }
+        },
+        "next": {
+          "description": "The keys that cause the presentation to move forwards.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/KeyBinding"
+          }
+        },
+        "previous": {
+          "description": "The keys that cause the presentation to move backwards.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/KeyBinding"
+          }
+        },
+        "reload": {
+          "description": "The key binding to reload the presentation.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/KeyBinding"
+          }
+        },
+        "toggle_bindings": {
+          "description": "The key binding to toggle the key bindings modal.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/KeyBinding"
+          }
+        },
+        "toggle_slide_index": {
+          "description": "The key binding to toggle the slide index modal.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/KeyBinding"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "OptionsConfig": {
+      "type": "object",
+      "properties": {
+        "command_prefix": {
+          "description": "The prefix to use for commands.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "end_slide_shorthand": {
+          "description": "Whether to treat a thematic break as a slide end.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "implicit_slide_ends": {
+          "description": "Whether slides are automatically terminated when a slide title is found.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "incremental_lists": {
+          "description": "Show all lists incrementally, by implicitly adding pauses in between elements.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strict_front_matter_parsing": {
+          "description": "Whether to be strict about parsing the presentation's front matter.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "TypstConfig": {
+      "type": "object",
+      "properties": {
+        "ppi": {
+          "description": "The pixels per inch when rendering latex/typst formulas.",
+          "default": 300,
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      },
+      "additionalProperties": false
+    },
+    "ValidateOverflows": {
+      "type": "string",
+      "enum": [
+        "never",
+        "always",
+        "when_presenting",
+        "when_developing"
+      ]
+    }
+  }
+}

--- a/src/input/user.rs
+++ b/src/input/user.rs
@@ -1,6 +1,7 @@
 use super::source::{Command, CommandDiscriminants};
 use crate::custom::KeyBindingsConfig;
 use crossterm::event::{poll, read, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use schemars::JsonSchema;
 use serde_with::DeserializeFromStr;
 use std::{fmt, io, iter, mem, str::FromStr, time::Duration};
 
@@ -155,8 +156,8 @@ enum BindingMatch {
     None,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, DeserializeFromStr)]
-pub struct KeyBinding(Vec<KeyMatcher>);
+#[derive(Clone, Debug, PartialEq, Eq, DeserializeFromStr, JsonSchema)]
+pub struct KeyBinding(#[schemars(with = "String")] Vec<KeyMatcher>);
 
 impl KeyBinding {
     fn match_events(&self, mut events: &[KeyEvent]) -> BindingMatch {

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,10 @@ struct Cli {
     #[clap(long, hide = true)]
     generate_pdf_metadata: bool,
 
+    /// Generate a JSON schema for the configuration file.
+    #[clap(long)]
+    generate_config_file_schema: bool,
+
     /// Run in export mode.
     #[clap(long, hide = true)]
     export: bool,
@@ -164,6 +168,12 @@ fn overflow_validation(mode: &PresentMode, config: &ValidateOverflows) -> bool {
 }
 
 fn run(mut cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
+    if cli.generate_config_file_schema {
+        let schema = schemars::schema_for!(Config);
+        serde_json::to_writer_pretty(io::stdout(), &schema).map_err(|e| format!("failed to write schema: {e}"))?;
+        return Ok(());
+    }
+
     let (config, themes) = load_customizations(cli.config_file.clone().map(PathBuf::from))?;
 
     let default_theme = load_default_theme(&config, &themes, &cli);


### PR DESCRIPTION
# Help users write and maintain their configuration

This change introduces a JSON schema for the configuration file. This schema is used to validate the configuration file and provide feedback to the user if the configuration file is invalid.


https://github.com/mfontanini/presenterm/assets/300791/9b9e7c45-6f2f-4a45-9806-60a8413c2185



To use this schema, the schema must be referenced in the yaml configuration file like this:

```yaml
# yaml-language-server: $schema=./schema.json
```

> See the documentation for this feature here: https://github.com/redhat-developer/yaml-language-server?tab=readme-ov-file#using-inlined-schema

This configures the [yaml-language-server](https://github.com/redhat-developer/yaml-language-server) to use the schema.json file to validate the configuration file. The language server is well supported in editors such as

- Neovim with [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#yamlls). Personally I also use [mason-lspconfig.nvim](https://github.com/williamboman/mason-lspconfig.nvim) to manage my language servers
- Visual Studio Code with the [YAML extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml)
- More supported clients are listed in https://github.com/redhat-developer/yaml-language-server?tab=readme-ov-file#clients

## Supported features

- Autocompletion of keys in the configuration file
- Hover support for keys in the configuration file
- Validation of the configuration file
  - Invalid keys are detected
  - Invalid values are detected for values that are supposed to be of a certain type or numeric range
  - Bundled in themes are suggested but any theme name is accepted (in case the user wants to use a custom theme)
- the top sections of the config have a markdown link to the documentation when hovered

## Testing the feature

To test this feature, you can do the following steps:

- fetch this git branch for testing
- open the configuration file in your editor
- add the magic comment to the top of the file with the path to the schema.json file
  - I used `# yaml-language-server: $schema=./schema.json` to develop this feature
- (restart your yaml-language-server if necessary)
- observe the autocompletion, hover and validation features by making edits in your editor
