### PR TITLE
chore(config): include strict_front_matter_parsing in default config

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -22,6 +22,11 @@ options:
   # show all lists incrementally, by implicitly adding pauses in between elements.
   incremental_lists: false
 
+  # this option tells presenterm you don't care about extra parameters in
+  # presentation's front matter. This can be useful if you're trying to load a
+  # presentation made for another tool
+  strict_front_matter_parsing: true
+
   # whether to treat a thematic break as a slide end.
   end_slide_shorthand: false
 


### PR DESCRIPTION
Hi, noticed this setting is missing from the default config.

I'm not sure if you'd like to include all keys there by default. In case it's not necessary, this change can be discarded 🙂 