### PR TITLE
refactor: fix all clippy warnings

### DIFF
--- a/src/input/user.rs
+++ b/src/input/user.rs
@@ -532,7 +532,7 @@ mod test {
     )]
     fn match_number(#[case] pattern: &str, #[case] events: &[KeyEvent]) {
         let binding = KeyBinding::from_str(pattern).expect("failed to parse");
-        let result = binding.match_events(&events);
+        let result = binding.match_events(events);
         let BindingMatch::Full(MatchContext::Number(number)) = result else {
             panic!("unexpected match: {result:?}");
         };

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -257,7 +257,7 @@ impl Slide {
 
     #[cfg(test)]
     pub(crate) fn into_operations(self) -> Vec<RenderOperation> {
-        self.chunks.into_iter().flat_map(|chunk| chunk.operations.into_iter()).chain(self.footer.into_iter()).collect()
+        self.chunks.into_iter().flat_map(|chunk| chunk.operations.into_iter()).chain(self.footer).collect()
     }
 
     fn jump_chunk(&mut self, chunk_index: usize) {
@@ -653,9 +653,9 @@ mod test {
         #[case] expected_chunk: usize,
     ) {
         let mut presentation = Presentation::from(vec![
-            Slide::new(vec![SlideChunk::from(SlideChunk::default()), SlideChunk::default()], vec![]),
-            Slide::new(vec![SlideChunk::from(SlideChunk::default()), SlideChunk::default()], vec![]),
-            Slide::new(vec![SlideChunk::from(SlideChunk::default()), SlideChunk::default()], vec![]),
+            Slide::new(vec![SlideChunk::default(), SlideChunk::default()], vec![]),
+            Slide::new(vec![SlideChunk::default(), SlideChunk::default()], vec![]),
+            Slide::new(vec![SlideChunk::default(), SlideChunk::default()], vec![]),
         ]);
         presentation.go_to_slide(from);
 
@@ -692,18 +692,12 @@ mod test {
         let mut presentation = Presentation::from(vec![
             SlideBuilder::default()
                 .chunks(vec![
-                    SlideChunk::from(SlideChunk::new(
-                        vec![],
-                        vec![Box::new(DummyMutator::new(1)), Box::new(DummyMutator::new(2))],
-                    )),
+                    SlideChunk::new(vec![], vec![Box::new(DummyMutator::new(1)), Box::new(DummyMutator::new(2))]),
                     SlideChunk::default(),
                 ])
                 .build(),
             SlideBuilder::default()
-                .chunks(vec![
-                    SlideChunk::from(SlideChunk::new(vec![], vec![Box::new(DummyMutator::new(2))])),
-                    SlideChunk::default(),
-                ])
+                .chunks(vec![SlideChunk::new(vec![], vec![Box::new(DummyMutator::new(2))]), SlideChunk::default()])
                 .build(),
         ]);
         presentation.go_to_slide(from);

--- a/src/processing/builder.rs
+++ b/src/processing/builder.rs
@@ -1113,7 +1113,7 @@ mod test {
     }
 
     fn extract_slide_text_lines(slide: Slide) -> Vec<String> {
-        let operations: Vec<_> = slide.into_operations().into_iter().filter(|op| is_visible(op)).collect();
+        let operations: Vec<_> = slide.into_operations().into_iter().filter(is_visible).collect();
         extract_text_lines(&operations)
     }
 
@@ -1126,7 +1126,7 @@ mod test {
             MarkdownElement::Heading { text: TextBlock::from("bye"), level: 1 },
         ];
         let presentation = build_presentation(elements);
-        for (index, slide) in presentation.iter_slides().into_iter().enumerate() {
+        for (index, slide) in presentation.iter_slides().enumerate() {
             let clear_screen_count =
                 slide.iter_operations().filter(|op| matches!(op, RenderOperation::ClearScreen)).count();
             let set_colors_count =
@@ -1417,7 +1417,7 @@ mod test {
         let presentation = build_presentation_with_options(elements, options);
         assert_eq!(presentation.iter_slides().count(), 2);
 
-        let second = presentation.iter_slides().skip(1).next().unwrap();
+        let second = presentation.iter_slides().nth(1).unwrap();
         let before_text = second.iter_operations().take_while(|e| !matches!(e, RenderOperation::RenderText { .. }));
         let break_count = before_text.filter(|e| matches!(e, RenderOperation::RenderLineBreak)).count();
         assert_eq!(break_count, 1);

--- a/src/render/highlighting.rs
+++ b/src/render/highlighting.rs
@@ -290,7 +290,7 @@ mod test {
         </dict>
     </array>
 </dict>"#;
-        fs::write(directory.path().join("potato.tmTheme"), &theme).expect("writing theme");
+        fs::write(directory.path().join("potato.tmTheme"), theme).expect("writing theme");
 
         let mut themes = HighlightThemeSet::default();
         themes.register_from_directory(directory.path()).expect("loading themes");

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -561,7 +561,7 @@ mod test {
     fn load_custom() {
         let directory = tempdir().expect("creating tempdir");
         let theme = serde_yaml::to_string(&PresentationTheme::default()).unwrap();
-        fs::write(directory.path().join("potato.yaml"), &theme).expect("writing theme");
+        fs::write(directory.path().join("potato.yaml"), theme).expect("writing theme");
 
         let mut themes = PresentationThemeSet::default();
         themes.register_from_directory(directory.path()).expect("loading themes");


### PR DESCRIPTION
The warnings became visible in rust-analyzer. I could also see the warnings on the command line by executing

`cargo clippy --all-targets`

I fixed all the warnings using rust-analyzer's LSP code actions.

The full list of warnings:

<details><summary>Details</summary>
<p>

```rust
    Checking presenterm v0.7.0 (/Users/mikavilpas/git/presenterm)
warning: this expression creates a reference which is immediately dereferenced by the compiler
   --> src/input/user.rs:535:43
    |
535 |         let result = binding.match_events(&events);
    |                                           ^^^^^^^ help: change this to: `events`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
    = note: `#[warn(clippy::needless_borrow)]` on by default

warning: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
   --> src/presentation.rs:260:86
    |
260 |         self.chunks.into_iter().flat_map(|chunk| chunk.operations.into_iter()).chain(self.footer.into_iter()).collect()
    |                                                                                      ^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing the `.into_iter()`: `self.footer`
    |
note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
   --> /private/tmp/rust-20240215-5649-scngkd/rustc-1.76.0-src/library/core/src/iter/traits/iterator.rs:524:12
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion
    = note: `#[warn(clippy::useless_conversion)]` on by default

warning: useless conversion to the same type: `presentation::SlideChunk`
   --> src/presentation.rs:656:29
    |
656 |             Slide::new(vec![SlideChunk::from(SlideChunk::default()), SlideChunk::default()], vec![]),
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `SlideChunk::from()`: `SlideChunk::default()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion

warning: useless conversion to the same type: `presentation::SlideChunk`
   --> src/presentation.rs:657:29
    |
657 |             Slide::new(vec![SlideChunk::from(SlideChunk::default()), SlideChunk::default()], vec![]),
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `SlideChunk::from()`: `SlideChunk::default()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion

warning: useless conversion to the same type: `presentation::SlideChunk`
   --> src/presentation.rs:658:29
    |
658 |             Slide::new(vec![SlideChunk::from(SlideChunk::default()), SlideChunk::default()], vec![]),
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `SlideChunk::from()`: `SlideChunk::default()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion

warning: useless conversion to the same type: `presentation::SlideChunk`
   --> src/presentation.rs:695:21
    |
695 | /                     SlideChunk::from(SlideChunk::new(
696 | |                         vec![],
697 | |                         vec![Box::new(DummyMutator::new(1)), Box::new(DummyMutator::new(2))],
698 | |                     )),
    | |______________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion
help: consider removing `SlideChunk::from()`
    |
695 ~                     SlideChunk::new(
696 +                         vec![],
697 +                         vec![Box::new(DummyMutator::new(1)), Box::new(DummyMutator::new(2))],
698 ~                     ),
    |

warning: useless conversion to the same type: `presentation::SlideChunk`
   --> src/presentation.rs:704:21
    |
704 |                     SlideChunk::from(SlideChunk::new(vec![], vec![Box::new(DummyMutator::new(2))])),
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `SlideChunk::from()`: `SlideChunk::new(vec![], vec![Box::new(DummyMutator::new(2))])`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion

warning: redundant closure
    --> src/processing/builder.rs:1116:77
     |
1116 |         let operations: Vec<_> = slide.into_operations().into_iter().filter(|op| is_visible(op)).collect();
     |                                                                             ^^^^^^^^^^^^^^^^^^^ help: replace the closure with the function itself: `is_visible`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_closure
     = note: `#[warn(clippy::redundant_closure)]` on by default

warning: useless conversion to the same type: `impl std::iter::Iterator<Item = &presentation::Slide>`
    --> src/processing/builder.rs:1129:31
     |
1129 |         for (index, slide) in presentation.iter_slides().into_iter().enumerate() {
     |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into_iter()`: `presentation.iter_slides()`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion

warning: called `skip(..).next()` on an iterator
    --> src/processing/builder.rs:1420:48
     |
1420 |         let second = presentation.iter_slides().skip(1).next().unwrap();
     |                                                ^^^^^^^^^^^^^^^ help: use `nth` instead: `.nth(1)`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#iter_skip_next
     = note: `#[warn(clippy::iter_skip_next)]` on by default

warning: the borrowed expression implements the required traits
   --> src/render/highlighting.rs:293:60
    |
293 |         fs::write(directory.path().join("potato.tmTheme"), &theme).expect("writing theme");
    |                                                            ^^^^^^ help: change this to: `theme`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrows_for_generic_args
    = note: `#[warn(clippy::needless_borrows_for_generic_args)]` on by default

warning: the borrowed expression implements the required traits
   --> src/theme.rs:564:57
    |
564 |         fs::write(directory.path().join("potato.yaml"), &theme).expect("writing theme");
    |                                                         ^^^^^^ help: change this to: `theme`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrows_for_generic_args

warning: `presenterm` (lib test) generated 12 warnings (run `cargo clippy --fix --lib -p presenterm --tests` to apply 12 suggestions)
    Finished dev [unoptimized + debuginfo] target(s) in 2.73s

```

</p>
</details> 

---

I have to admit I'm not experienced with rust and I don't quite understand why all the warnings were not visible with `cargo clippy`. Could there be some weirdness in the project configuration / build system?