### PR TITLE
ci: cargo clippy checks all targets for errors

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -49,7 +49,7 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Run cargo clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --all-targets -- -D warnings
 
   nix-flake:
     name: Validate nix flake


### PR DESCRIPTION
This is a continuation of https://github.com/mfontanini/presenterm/pull/231 and should help in keeping all targets linted in the future. That PR only fixed the current situation - this one should make sure things stay clean in the future as well.