### PR TITLE
Allow using image paths in typst

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -195,7 +195,7 @@ fn run(mut cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
     let printer = Rc::new(ImagePrinter::new(graphics_mode.clone())?);
     let registry = ImageRegistry(printer.clone());
     let resources = Resources::new(resources_path, registry.clone());
-    let typst = TypstRender::new(config.typst.ppi, registry);
+    let typst = TypstRender::new(config.typst.ppi, registry, resources_path);
     if cli.export_pdf || cli.generate_pdf_metadata {
         let mut exporter = Exporter::new(parser, &default_theme, resources, typst, themes, options);
         let mut args = Vec::new();


### PR DESCRIPTION
This allows using images in typst by passing in the `--root` parameter to specify the root path. All images must have an absolute path starting from the directory where the presentation is. So e.g. if you have a layout like

```
foo/presentation.md
foo/image1.png
```

In order to use `image1.png` inside typst in that `presentation.md` file you need to:

~~~markdown
```typst +render
#image("/image1.png")
```
~~~

Fixes #233