### PR TITLE
feat: allow jumping fast between slides

### DIFF
--- a/config-file-schema.json
+++ b/config-file-schema.json
@@ -165,8 +165,22 @@
             "$ref": "#/definitions/KeyBinding"
           }
         },
+        "next_fast": {
+          "description": "The keys that cause the presentation to jump to the next slide \"fast\".\n\n\"fast\" means for slides that contain pauses, we will only jump between the first and last pause rather than going through each individual one.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/KeyBinding"
+          }
+        },
         "previous": {
           "description": "The keys that cause the presentation to move backwards.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/KeyBinding"
+          }
+        },
+        "previous_fast": {
+          "description": "The keys that cause the presentation to move backwards \"fast\".\n\n\"fast\" means for slides that contain pauses, we will only jump between the first and last pause rather than going through each individual one.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/KeyBinding"

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -35,8 +35,14 @@ bindings:
   # the keys that cause the presentation to move forwards.
   next: ["l", "j", "<right>", "<page_down>", "<down>", " "]
 
+  # the keys that cause the presentation to move forwards fast.
+  next_fast: ["n"]
+
   # the keys that cause the presentation to move backwards.
   previous: ["h", "k", "<left>", "<page_up>", "<up>"]
+
+  # the keys that cause the presentation to move backwards fast
+  previous_fast: ["p"]
 
   # the key binding to jump to the first slide.
   first_slide: ["gg"]

--- a/src/custom.rs
+++ b/src/custom.rs
@@ -191,9 +191,23 @@ pub struct KeyBindingsConfig {
     #[serde(default = "default_next_bindings")]
     pub(crate) next: Vec<KeyBinding>,
 
+    /// The keys that cause the presentation to jump to the next slide "fast".
+    ///
+    /// "fast" means for slides that contain pauses, we will only jump between the first and last
+    /// pause rather than going through each individual one.
+    #[serde(default = "default_next_fast_bindings")]
+    pub(crate) next_fast: Vec<KeyBinding>,
+
     /// The keys that cause the presentation to move backwards.
     #[serde(default = "default_previous_bindings")]
     pub(crate) previous: Vec<KeyBinding>,
+
+    /// The keys that cause the presentation to move backwards "fast".
+    ///
+    /// "fast" means for slides that contain pauses, we will only jump between the first and last
+    /// pause rather than going through each individual one.
+    #[serde(default = "default_previous_fast_bindings")]
+    pub(crate) previous_fast: Vec<KeyBinding>,
 
     /// The key binding to jump to the first slide.
     #[serde(default = "default_first_slide_bindings")]
@@ -236,7 +250,9 @@ impl Default for KeyBindingsConfig {
     fn default() -> Self {
         Self {
             next: default_next_bindings(),
+            next_fast: default_next_fast_bindings(),
             previous: default_previous_bindings(),
+            previous_fast: default_previous_fast_bindings(),
             first_slide: default_first_slide_bindings(),
             last_slide: default_last_slide_bindings(),
             go_to_slide: default_go_to_slide_bindings(),
@@ -262,8 +278,16 @@ fn default_next_bindings() -> Vec<KeyBinding> {
     make_keybindings(["l", "j", "<right>", "<page_down>", "<down>", " "])
 }
 
+fn default_next_fast_bindings() -> Vec<KeyBinding> {
+    make_keybindings(["n"])
+}
+
 fn default_previous_bindings() -> Vec<KeyBinding> {
     make_keybindings(["h", "k", "<left>", "<page_up>", "<up>"])
+}
+
+fn default_previous_fast_bindings() -> Vec<KeyBinding> {
+    make_keybindings(["p"])
 }
 
 fn default_first_slide_bindings() -> Vec<KeyBinding> {

--- a/src/input/source.rs
+++ b/src/input/source.rs
@@ -50,8 +50,14 @@ pub(crate) enum Command {
     /// Move forward in the presentation.
     Next,
 
+    /// Move to the next slide fast.
+    NextFast,
+
     /// Move backwards in the presentation.
     Previous,
+
+    /// Move to the previous slide fast.
+    PreviousFast,
 
     /// Go to the first slide.
     FirstSlide,

--- a/src/input/user.rs
+++ b/src/input/user.rs
@@ -75,7 +75,9 @@ impl CommandKeyBindings {
         let command = match discriminant {
             Redraw => Command::Redraw,
             Next => Command::Next,
+            NextFast => Command::NextFast,
             Previous => Command::Previous,
+            PreviousFast => Command::PreviousFast,
             FirstSlide => Command::FirstSlide,
             LastSlide => Command::LastSlide,
             GoToSlide => {
@@ -124,7 +126,9 @@ impl TryFrom<KeyBindingsConfig> for CommandKeyBindings {
         }
         let bindings: Vec<_> = iter::empty()
             .chain(zip(CommandDiscriminants::Next, config.next))
+            .chain(zip(CommandDiscriminants::NextFast, config.next_fast))
             .chain(zip(CommandDiscriminants::Previous, config.previous))
+            .chain(zip(CommandDiscriminants::PreviousFast, config.previous_fast))
             .chain(zip(CommandDiscriminants::FirstSlide, config.first_slide))
             .chain(zip(CommandDiscriminants::LastSlide, config.last_slide))
             .chain(zip(CommandDiscriminants::GoToSlide, config.go_to_slide))

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -175,7 +175,9 @@ impl<'a> Presenter<'a> {
         };
         let needs_redraw = match command {
             Command::Next => presentation.jump_next(),
+            Command::NextFast => presentation.jump_next_fast(),
             Command::Previous => presentation.jump_previous(),
+            Command::PreviousFast => presentation.jump_previous_fast(),
             Command::FirstSlide => presentation.jump_first_slide(),
             Command::LastSlide => presentation.jump_last_slide(),
             Command::GoToSlide(number) => presentation.go_to_slide(number.saturating_sub(1) as usize),

--- a/src/processing/modals.rs
+++ b/src/processing/modals.rs
@@ -117,7 +117,9 @@ impl KeyBindingsModalBuilder {
         let mut builder = ModalBuilder::new("Key bindings");
         builder.content.extend([
             Self::build_line("Next", &config.next),
+            Self::build_line("Next (fast)", &config.next_fast),
             Self::build_line("Previous", &config.previous),
+            Self::build_line("Previous (fast)", &config.previous_fast),
             Self::build_line("First slide", &config.first_slide),
             Self::build_line("Last slide", &config.last_slide),
             Self::build_line("Go to slide", &config.go_to_slide),


### PR DESCRIPTION
This introduces 2 new keybindings: `next_fast` and `previous_fast`. These behave like `next`/`fast` except they don't go through intermediate pause states in a slide and instead just jump between no pauses shown and all pauses shown in a slide.

Fixes #241