### PR TITLE
fix: display background color behind '\t' in code exec output

### DIFF
--- a/src/processing/execution.rs
+++ b/src/processing/execution.rs
@@ -32,7 +32,10 @@ impl RunCodeOperation {
         Self { code, default_colors, block_colors, inner: Rc::new(RefCell::new(inner)) }
     }
 
-    fn render_line(&self, line: String) -> RenderOperation {
+    fn render_line(&self, mut line: String) -> RenderOperation {
+        if line.contains('\t') {
+            line = line.replace('\t', "    ");
+        }
         let line_len = line.len() as u16;
         RenderOperation::RenderPreformattedLine(PreformattedLine {
             text: line,


### PR DESCRIPTION
This transforms tabs into spaces so we can highlight them properly. This defaults to 4 tabs per space but if someone complains we can make it configurable.

Fixes #240