### PR TITLE
chore: remove nix cache in CI

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -58,8 +58,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install nix
         uses: DeterminateSystems/nix-installer-action@v4
-      - name: Magic nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@v2
       - name: Build
         run: nix build .#dev.presenterm
 


### PR DESCRIPTION
The nix flake build step is getting stuck for 50 minutes on the nix cache. This removes the cache altogether as it seems like it's slowing build times rather than improving them.