### PR TITLE
docs: Update install instructions for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ presenterm
 [nix-package]: https://search.nixos.org/packages?size=1&show=presenterm
 [crates-badge]: https://img.shields.io/crates/v/presenterm
 [crates-package]: https://crates.io/crates/presenterm
-[arch-badge]: https://img.shields.io/aur/version/presenterm-bin
-[arch-package]: https://aur.archlinux.org/packages/presenterm-bin
+[arch-badge]: https://img.shields.io/archlinux/v/extra/x86_64/presenterm
+[arch-package]: https://archlinux.org/packages/extra/x86_64/presenterm/
 [scoop-badge]: https://img.shields.io/scoop/v/presenterm
 [scoop-package]: https://scoop.sh/#/apps?q=presenterm&id=a462290f824b50f180afbaa6d8c7c1e6e0952e3a
 

--- a/docs/src/guides/installation.md
+++ b/docs/src/guides/installation.md
@@ -58,11 +58,17 @@ nix run github:mfontanini/presenterm  # to run from github repo
 For more information see 
 [nixpkgs](https://search.nixos.org/packages?channel=unstable&show=presenterm&from=0&size=50&sort=relevance&type=packages&query=presenterm)
 
-### Arch linux repository (Aur)
+### Arch Linux
 
-_presenterm_ is also available in the AUR. You can use any AUR helper to install:
+_presenterm_ is available in the [official repositories](https://archlinux.org/packages/extra/x86_64/presenterm/). You can use [pacman](https://wiki.archlinux.org/title/pacman) to install as follows:
 
-#### Binary release (recommended)
+```shell
+pacman -S presenterm
+```
+
+#### Binary release
+
+Alternatively, you can use any AUR helper to install the upstream binaries:
 
 ```shell
 paru/yay -S presenterm-bin


### PR DESCRIPTION
`presenterm` is now packaged in the official repositories: <https://archlinux.org/packages/extra/x86_64/presenterm/> 🥳
