### PR TITLE
fix(code-exec): wait for code execution process to exit completely

### DIFF
--- a/src/execute.rs
+++ b/src/execute.rs
@@ -100,8 +100,8 @@ impl ProcessReader {
         let stdout = self.handle.stdout.take().expect("no stdout");
         let stdout = BufReader::new(stdout);
         let _ = Self::process_output(self.state.clone(), stdout);
-        let success = match self.handle.try_wait() {
-            Ok(Some(code)) => code.success(),
+        let success = match self.handle.wait() {
+            Ok(code) => code.success(),
             _ => false,
         };
         let status = match success {


### PR DESCRIPTION
Fixes https://github.com/mfontanini/presenterm/issues/247.

This PR ensures we wait for the code execution process to completely exit, when determining its exit status. This way, we do not erroneously show the `[finished with error]` output when the process had not exited yet.