### PR TITLE
feat: use a cleaner execution error UI

### DIFF
--- a/src/markdown/elements.rs
+++ b/src/markdown/elements.rs
@@ -93,7 +93,7 @@ pub(crate) enum ParagraphElement {
 /// A block of text.
 ///
 /// Text is represented as a series of chunks, each with their own formatting.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
 pub(crate) struct TextBlock(pub(crate) Vec<Text>);
 
 impl TextBlock {

--- a/src/processing/builder.rs
+++ b/src/processing/builder.rs
@@ -741,6 +741,7 @@ impl<'a> PresentationBuilder<'a> {
             self.code_executor.clone(),
             self.theme.default_style.colors.clone(),
             self.theme.execution_output.colors.clone(),
+            self.theme.execution_output.status.clone(),
         );
         let operation = RenderOperation::RenderOnDemand(Rc::new(operation));
         self.chunk_operations.push(operation);

--- a/src/processing/separator.rs
+++ b/src/processing/separator.rs
@@ -28,10 +28,15 @@ impl AsRenderOperations for RenderSeparator {
         let separator = match self.heading.width() == 0 {
             true => TextBlock::from(character.repeat(dimensions.columns as usize)),
             false => {
-                let dashes_len = (dimensions.columns as usize).saturating_sub(self.heading.width()) / 2;
-                let dashes = character.repeat(dashes_len);
+                let width = (dimensions.columns as usize).saturating_sub(self.heading.width());
+                let (dashes_len, remainder) = (width / 2, width % 2);
+                let mut dashes = character.repeat(dashes_len);
                 let mut line = TextBlock::from(dashes.clone());
                 line.0.extend(self.heading.0.iter().cloned());
+
+                if remainder > 0 {
+                    dashes.push_str(character);
+                }
                 line.0.push(dashes.into());
                 line
             }

--- a/src/processing/separator.rs
+++ b/src/processing/separator.rs
@@ -1,4 +1,5 @@
 use crate::{
+    markdown::elements::TextBlock,
     presentation::{AsRenderOperations, RenderOperation},
     render::properties::WindowSize,
 };
@@ -6,11 +7,11 @@ use std::rc::Rc;
 
 #[derive(Clone, Debug, Default)]
 pub(crate) struct RenderSeparator {
-    heading: String,
+    heading: TextBlock,
 }
 
 impl RenderSeparator {
-    pub(crate) fn new<S: Into<String>>(heading: S) -> Self {
+    pub(crate) fn new<S: Into<TextBlock>>(heading: S) -> Self {
         Self { heading: heading.into() }
     }
 }
@@ -24,13 +25,15 @@ impl From<RenderSeparator> for RenderOperation {
 impl AsRenderOperations for RenderSeparator {
     fn as_render_operations(&self, dimensions: &WindowSize) -> Vec<RenderOperation> {
         let character = "—";
-        let separator = match self.heading.is_empty() {
-            true => character.repeat(dimensions.columns as usize),
+        let separator = match self.heading.width() == 0 {
+            true => TextBlock::from(character.repeat(dimensions.columns as usize)),
             false => {
-                let dashes_len = (dimensions.columns as usize).saturating_sub(self.heading.len()) / 2;
+                let dashes_len = (dimensions.columns as usize).saturating_sub(self.heading.width()) / 2;
                 let dashes = character.repeat(dashes_len);
-                let heading = &self.heading;
-                format!("{dashes}{heading}{dashes}")
+                let mut line = TextBlock::from(dashes.clone());
+                line.0.extend(self.heading.0.iter().cloned());
+                line.0.push(dashes.into());
+                line
             }
         };
         vec![RenderOperation::RenderText { line: separator.into(), alignment: Default::default() }]

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -417,9 +417,29 @@ pub(crate) struct CodeBlockStyle {
 /// The style for the output of a code execution block.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub(crate) struct ExecutionOutputBlockStyle {
-    /// The colors to be used.
+    /// The colors to be used for the output pane.
     #[serde(default)]
     pub(crate) colors: Colors,
+
+    /// The colors to be used for the text that represents the status of the execution block.
+    #[serde(default)]
+    pub(crate) status: ExecutionStatusBlockStyle,
+}
+
+/// The style for the status of a code execution block.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub(crate) struct ExecutionStatusBlockStyle {
+    /// The colors for the "running" status.
+    #[serde(default)]
+    pub(crate) running: Colors,
+
+    /// The colors for the "finished" status.
+    #[serde(default)]
+    pub(crate) success: Colors,
+
+    /// The colors for the "finished with error" status.
+    #[serde(default)]
+    pub(crate) failure: Colors,
 }
 
 /// The style for inline code.

--- a/themes/catppuccin-frappe.yaml
+++ b/themes/catppuccin-frappe.yaml
@@ -27,6 +27,13 @@ execution_output:
   colors:
     foreground: "c6d0f5"
     background: "414559"
+  status:
+    running:
+      foreground: "8caaee"
+    success:
+      foreground: "a6d189"
+    failure:
+      foreground: "e78284"
 
 inline_code:
   colors:

--- a/themes/catppuccin-latte.yaml
+++ b/themes/catppuccin-latte.yaml
@@ -27,6 +27,13 @@ execution_output:
   colors:
     foreground: "4c4f69"
     background: "ccd0da"
+  status:
+    running:
+      foreground: "04a5e5"
+    success:
+      foreground: "40a02b"
+    failure:
+      foreground: "d20f39"
 
 inline_code:
   colors:

--- a/themes/catppuccin-macchiato.yaml
+++ b/themes/catppuccin-macchiato.yaml
@@ -27,6 +27,13 @@ execution_output:
   colors:
     foreground: "cad3f5"
     background: "363a4f"
+  status:
+    running:
+      foreground: "91d7e3"
+    success:
+      foreground: "a6da95"
+    failure:
+      foreground: "ed8796"
 
 inline_code:
   colors:

--- a/themes/catppuccin-mocha.yaml
+++ b/themes/catppuccin-mocha.yaml
@@ -27,6 +27,13 @@ execution_output:
   colors:
     foreground: "cdd6f4"
     background: "313244"
+  status:
+    running:
+      foreground: "89dceb"
+    success:
+      foreground: "a6e3a1"
+    failure:
+      foreground: "f38ba8"
 
 inline_code:
   colors:

--- a/themes/dark.yaml
+++ b/themes/dark.yaml
@@ -27,6 +27,13 @@ execution_output:
   colors:
     foreground: "e6e6e6"
     background: "2d2d2d"
+  status:
+    running:
+      foreground: "b4ccff"
+    success:
+      foreground: "a8df8e"
+    failure:
+      foreground: "f78ca2"
 
 inline_code:
   colors:

--- a/themes/light.yaml
+++ b/themes/light.yaml
@@ -27,6 +27,13 @@ execution_output:
   colors:
     foreground: "212529"
     background: "e9ecef"
+  status:
+    running:
+      foreground: "457b9d"
+    success:
+      foreground: "52b788"
+    failure:
+      foreground: "f07167"
 
 inline_code:
   colors:

--- a/themes/terminal-dark.yaml
+++ b/themes/terminal-dark.yaml
@@ -26,6 +26,13 @@ code:
 execution_output:
   colors:
     background: grey
+  status:
+    running:
+      foreground: "blue"
+    success:
+      foreground: "green"
+    failure:
+      foreground: "red"
 
 inline_code:
   colors:

--- a/themes/terminal-light.yaml
+++ b/themes/terminal-light.yaml
@@ -26,6 +26,13 @@ code:
 execution_output:
   colors:
     background: grey
+  status:
+    running:
+      foreground: "dark_blue"
+    success:
+      foreground: "dark_green"
+    failure:
+      foreground: "dark_red"
 
 inline_code:
   colors:

--- a/themes/tokyonight-storm.yaml
+++ b/themes/tokyonight-storm.yaml
@@ -27,6 +27,13 @@ execution_output:
   colors:
     foreground: "c0caf5"
     background: "2d2d2d"
+  status:
+    running:
+      foreground: "7aa2f7"
+    success:
+      foreground: "9ece6a"
+    failure:
+      foreground: "f7768e"
 
 inline_code:
   colors:


### PR DESCRIPTION
This changes the error reporting when the execution of a code snippet fails so that instead of appending a "[finished with error]" string at the end, we display "finished with error" at the little status box in between the code snippet and the execution output. See screenshot for reference. @dmackdev thoughts on this? I found the current UI kind of annoying when running broken code snippets. Maybe as an addition to this, the "finished with error" could have a red (configurable) color so it's more obvious.

![image](https://github.com/mfontanini/presenterm/assets/969090/63add1cc-e464-46d6-8737-8b0be3b18d46)
