### PR TITLE
feat: add kotlin script executor

### DIFF
--- a/executors/Kotlin.sh
+++ b/executors/Kotlin.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+tempdir=$(mktemp -d)
+cd "$tempdir"
+cp "$1" script.kts
+kotlinc -script script.kts
+rm -rf "$tempdir"


### PR DESCRIPTION
Adds `Kotlin.sh` to execute Kotlin scripts - see https://kotlinlang.org/docs/command-line.html#run-scripts.

Using Kotlin scripts instead of compiling to a `jar` first and then running it with `java` means that the `main` function boilerplate does not need to be included in the snippet.