### PR TITLE
feat: add nushell code execution

### DIFF
--- a/executors/nushell.sh
+++ b/executors/nushell.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+nu "$1"

--- a/src/markdown/elements.rs
+++ b/src/markdown/elements.rs
@@ -220,6 +220,7 @@ pub enum CodeLanguage {
     Mermaid,
     Markdown,
     Nix,
+    Nushell,
     OCaml,
     Perl,
     Php,

--- a/src/render/highlighting.rs
+++ b/src/render/highlighting.rs
@@ -139,6 +139,7 @@ impl CodeHighlighter {
             Markdown => "md",
             Mermaid => "txt",
             Nix => "nix",
+            Nushell => "nix",
             OCaml => "ml",
             Perl => "pl",
             Php => "php",


### PR DESCRIPTION
This adds nushell code execution. Code highlighting is not supported yet as `bat` doesn't support it, so nushell snippets won't have any highlighting but can be executed.

Relates to #271