### PR TITLE
feat!: force users to explicitly enable code execution

### DIFF
--- a/config-file-schema.json
+++ b/config-file-schema.json
@@ -20,6 +20,9 @@
     "options": {
       "$ref": "#/definitions/OptionsConfig"
     },
+    "snippet": {
+      "$ref": "#/definitions/SnippetConfig"
+    },
     "typst": {
       "$ref": "#/definitions/TypstConfig"
     }
@@ -258,6 +261,33 @@
             "boolean",
             "null"
           ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "SnippetConfig": {
+      "type": "object",
+      "properties": {
+        "exec": {
+          "description": "The properties for snippet execution.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SnippetExecConfig"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "SnippetExecConfig": {
+      "type": "object",
+      "required": [
+        "enable"
+      ],
+      "properties": {
+        "enable": {
+          "description": "Whether to enable snippet execution.",
+          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/src/custom.rs
+++ b/src/custom.rs
@@ -26,6 +26,9 @@ pub struct Config {
 
     #[serde(default)]
     pub bindings: KeyBindingsConfig,
+
+    #[serde(default)]
+    pub snippet: SnippetConfig,
 }
 
 impl Config {
@@ -112,6 +115,21 @@ pub struct OptionsConfig {
 
     /// Whether to be strict about parsing the presentation's front matter.
     pub strict_front_matter_parsing: Option<bool>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct SnippetConfig {
+    /// The properties for snippet execution.
+    #[serde(default)]
+    pub exec: SnippetExecConfig,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct SnippetExecConfig {
+    /// Whether to enable snippet execution.
+    pub enable: bool,
 }
 
 #[derive(Clone, Debug, Deserialize, JsonSchema)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,6 +64,10 @@ struct Cli {
     #[clap(long)]
     validate_overflows: bool,
 
+    /// Enable code snippet execution.
+    #[clap(short = 'x', long)]
+    enable_snippet_execution: bool,
+
     /// The path to the configuration file.
     #[clap(short, long)]
     config_file: Option<String>,
@@ -135,6 +139,7 @@ fn make_builder_options(config: &Config, mode: &PresentMode, force_default_theme
         end_slide_shorthand: config.options.end_slide_shorthand.unwrap_or_default(),
         print_modal_background: false,
         strict_front_matter_parsing: config.options.strict_front_matter_parsing.unwrap_or(true),
+        enable_snippet_execution: config.snippet.exec.enable,
     }
 }
 
@@ -208,6 +213,9 @@ fn run(mut cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
     let validate_overflows = overflow_validation(&mode, &config.defaults.validate_overflows) || cli.validate_overflows;
     let resources_path = path.parent().unwrap_or(Path::new("/"));
     let mut options = make_builder_options(&config, &mode, force_default_theme);
+    if cli.enable_snippet_execution {
+        options.enable_snippet_execution = true;
+    }
     let graphics_mode = select_graphics_mode(&cli, &config);
     let printer = Arc::new(ImagePrinter::new(graphics_mode.clone())?);
     let registry = ImageRegistry(printer.clone());


### PR DESCRIPTION
This changes the code snippet execution so that it is disabled by default and users need to opt in by either:
* Running presenterm with the `-x` flag.
* Set the `snippet.exec.enable` property to true in their config files.

This aims to make running untrusted presentations more secure. You can always set the property in your config file if you only ever run your own presentations, but by default this prevents opening a presentation someone else wrote and accidentally executing code in one of the slides that does something malicious.