### PR TITLE
feat: allow configuring snippet rendering threads

### DIFF
--- a/config-file-schema.json
+++ b/config-file-schema.json
@@ -275,6 +275,14 @@
               "$ref": "#/definitions/SnippetExecConfig"
             }
           ]
+        },
+        "render": {
+          "description": "The properties for snippet auto rendering.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SnippetRenderConfig"
+            }
+          ]
         }
       },
       "additionalProperties": false
@@ -288,6 +296,19 @@
         "enable": {
           "description": "Whether to enable snippet execution.",
           "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "SnippetRenderConfig": {
+      "type": "object",
+      "properties": {
+        "threads": {
+          "description": "The number of threads to use when rendering.",
+          "default": 2,
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
         }
       },
       "additionalProperties": false

--- a/src/custom.rs
+++ b/src/custom.rs
@@ -123,6 +123,10 @@ pub struct SnippetConfig {
     /// The properties for snippet execution.
     #[serde(default)]
     pub exec: SnippetExecConfig,
+
+    /// The properties for snippet auto rendering.
+    #[serde(default)]
+    pub render: SnippetRenderConfig,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, JsonSchema)]
@@ -130,6 +134,24 @@ pub struct SnippetConfig {
 pub struct SnippetExecConfig {
     /// Whether to enable snippet execution.
     pub enable: bool,
+}
+
+#[derive(Clone, Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct SnippetRenderConfig {
+    /// The number of threads to use when rendering.
+    #[serde(default = "default_snippet_render_threads")]
+    pub threads: usize,
+}
+
+impl Default for SnippetRenderConfig {
+    fn default() -> Self {
+        Self { threads: default_snippet_render_threads() }
+    }
+}
+
+pub(crate) fn default_snippet_render_threads() -> usize {
+    2
 }
 
 #[derive(Clone, Debug, Deserialize, JsonSchema)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -220,8 +220,11 @@ fn run(mut cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
     let printer = Arc::new(ImagePrinter::new(graphics_mode.clone())?);
     let registry = ImageRegistry(printer.clone());
     let resources = Resources::new(resources_path, registry.clone());
-    let third_party_config =
-        ThirdPartyConfigs { typst_ppi: config.typst.ppi.to_string(), mermaid_scale: config.mermaid.scale.to_string() };
+    let third_party_config = ThirdPartyConfigs {
+        typst_ppi: config.typst.ppi.to_string(),
+        mermaid_scale: config.mermaid.scale.to_string(),
+        threads: config.snippet.render.threads,
+    };
     let third_party = ThirdPartyRender::new(third_party_config, registry, resources_path);
     let code_executor = Rc::new(code_executor);
     if cli.export_pdf || cli.generate_pdf_metadata {


### PR DESCRIPTION
The `snippet.render.threads` config key now allows configuring how many threads you want to have. The default is 2.