### PR TITLE
feat: avoid re-rendering code output and auto rendered blocks

### DIFF
--- a/src/third_party.rs
+++ b/src/third_party.rs
@@ -345,13 +345,13 @@ impl RenderAsync for RenderThirdParty {
         match mem::take(&mut *self.pending_result.lock().unwrap()) {
             RenderResult::Success(image) => {
                 *contents = Some(image);
-                RenderAsyncState::Rendered
+                RenderAsyncState::JustFinishedRendering
             }
             RenderResult::Failure(error) => {
                 *self.error_holder.lock().unwrap() = Some(AsyncPresentationError { slide: self.slide, error });
-                RenderAsyncState::Rendered
+                RenderAsyncState::JustFinishedRendering
             }
-            RenderResult::Pending => RenderAsyncState::Rendering,
+            RenderResult::Pending => RenderAsyncState::Rendering { modified: false },
         }
     }
 }


### PR DESCRIPTION
This changes the logic that processes the async rendered blocks (code execution output and typst/mermaid/latex `+render` snippets) to avoid re-rendering. Before this was okay as it only affected code execution but now that conversion to images also happens asynchronously this can cause some unnecessary flickering.