### PR TITLE
feat: shrink snippet execution output to match code block width

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -72,7 +72,7 @@ impl ContentDiff for RenderOperation {
                 false
             }
             (RenderImage(original, _), RenderImage(updated, _)) if original != updated => true,
-            (RenderPreformattedLine(original), RenderPreformattedLine(updated)) if original != updated => true,
+            (RenderBlockLine(original), RenderBlockLine(updated)) if original != updated => true,
             (InitColumnLayout { columns: original }, InitColumnLayout { columns: updated }) if original != updated => {
                 true
             }
@@ -110,7 +110,9 @@ where
 mod test {
     use super::*;
     use crate::{
-        presentation::{AsRenderOperations, PreformattedLine, RenderAsync, RenderAsyncState, Slide, SlideBuilder},
+        presentation::{
+            AsRenderOperations, BlockLine, BlockLineText, RenderAsync, RenderAsyncState, Slide, SlideBuilder,
+        },
         render::properties::WindowSize,
         style::{Color, Colors},
         theme::{Alignment, Margin},
@@ -148,9 +150,9 @@ mod test {
     #[case(RenderOperation::RenderLineBreak)]
     #[case(RenderOperation::SetColors(Colors{background: None, foreground: None}))]
     #[case(RenderOperation::RenderText{line: String::from("asd").into(), alignment: Default::default()})]
-    #[case(RenderOperation::RenderPreformattedLine(
-        PreformattedLine{
-            text: "asd".into(),
+    #[case(RenderOperation::RenderBlockLine(
+        BlockLine{
+            text: BlockLineText::Preformatted("".into()),
             alignment: Default::default(),
             block_length: 42,
             unformatted_length: 1337

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -504,11 +504,17 @@ pub(crate) struct PresentationThemeMetadata {
 
 /// A line of preformatted text to be rendered.
 #[derive(Clone, Debug, PartialEq)]
-pub(crate) struct PreformattedLine {
-    pub(crate) text: String,
+pub(crate) struct BlockLine {
+    pub(crate) text: BlockLineText,
     pub(crate) unformatted_length: u16,
     pub(crate) block_length: u16,
     pub(crate) alignment: Alignment,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum BlockLineText {
+    Preformatted(String),
+    Weighted(WeightedTextBlock),
 }
 
 /// A render operation.
@@ -545,11 +551,8 @@ pub(crate) enum RenderOperation {
     /// Render an image.
     RenderImage(Image, ImageProperties),
 
-    /// Render a preformatted line.
-    ///
-    /// The line will usually already have terminal escape codes that include colors and formatting
-    /// embedded in it.
-    RenderPreformattedLine(PreformattedLine),
+    /// Render a line.
+    RenderBlockLine(BlockLine),
 
     /// Render a dynamically generated sequence of render operations.
     ///

--- a/src/processing/code.rs
+++ b/src/processing/code.rs
@@ -1,7 +1,7 @@
 use super::padding::NumberPadder;
 use crate::{
     markdown::elements::{HighlightGroup, Snippet},
-    presentation::{AsRenderOperations, ChunkMutator, PreformattedLine, RenderOperation},
+    presentation::{AsRenderOperations, BlockLine, BlockLineText, ChunkMutator, RenderOperation},
     render::{
         highlighting::{LanguageHighlighter, StyledTokens},
         properties::WindowSize,
@@ -115,8 +115,8 @@ impl AsRenderOperations for HighlightedLine {
             false => self.not_highlighted.clone(),
         };
         vec![
-            RenderOperation::RenderPreformattedLine(PreformattedLine {
-                text,
+            RenderOperation::RenderBlockLine(BlockLine {
+                text: BlockLineText::Preformatted(text),
                 unformatted_length: self.width as u16,
                 block_length: context.block_length as u16,
                 alignment: context.alignment.clone(),


### PR DESCRIPTION
This shrinks the snippet execution output so it tries to fit the code snippet size. Without this change the execution output would always fit the width of the entire screen/layout which looked a bit weird if output lines were too short.

![image](https://github.com/user-attachments/assets/e6262660-7182-4b83-9dbc-73085f64bf49)
