### PR TITLE
feat: dim non-highlighted code snippet lines

### DIFF
--- a/src/processing/builder.rs
+++ b/src/processing/builder.rs
@@ -725,9 +725,8 @@ impl<'a> PresentationBuilder<'a> {
         lines: Vec<CodeLine>,
         block_length: usize,
     ) -> (Vec<HighlightedLine>, Rc<RefCell<HighlightContext>>) {
-        let mut empty_highlighter = self.highlighter.language_highlighter(&SnippetLanguage::Unknown(String::new()));
         let mut code_highlighter = self.highlighter.language_highlighter(&code.language);
-        let padding_style = {
+        let dim_style = {
             let mut highlighter = self.highlighter.language_highlighter(&SnippetLanguage::Rust);
             highlighter.style_line("//").next().expect("no styles").style
         };
@@ -745,8 +744,8 @@ impl<'a> PresentationBuilder<'a> {
         let mut output = Vec::new();
         let block_style = &self.theme.code;
         for line in lines.into_iter() {
-            let highlighted = line.highlight(&padding_style, &mut code_highlighter, block_style);
-            let not_highlighted = line.highlight(&padding_style, &mut empty_highlighter, block_style);
+            let highlighted = line.highlight(&dim_style, &mut code_highlighter, block_style);
+            let not_highlighted = line.dim(&dim_style, block_style);
             let width = line.width();
             let line_number = line.line_number;
             let context = context.clone();

--- a/src/processing/code.rs
+++ b/src/processing/code.rs
@@ -76,13 +76,21 @@ impl CodeLine {
 
     pub(crate) fn highlight(
         &self,
-        padding_style: &Style,
+        dim_style: &Style,
         code_highlighter: &mut LanguageHighlighter,
         block_style: &CodeBlockStyle,
     ) -> String {
-        let mut output = StyledTokens { style: *padding_style, tokens: &self.prefix }.apply_style(block_style);
+        let mut output = StyledTokens { style: *dim_style, tokens: &self.prefix }.apply_style(block_style);
         output.push_str(&code_highlighter.highlight_line(&self.code, block_style));
-        output.push_str(&StyledTokens { style: *padding_style, tokens: &self.suffix }.apply_style(block_style));
+        output.push_str(&StyledTokens { style: *dim_style, tokens: &self.suffix }.apply_style(block_style));
+        output
+    }
+
+    pub(crate) fn dim(&self, padding_style: &Style, block_style: &CodeBlockStyle) -> String {
+        let mut output = String::new();
+        for chunk in [&self.prefix, &self.code, &self.suffix] {
+            output.push_str(&StyledTokens { style: *padding_style, tokens: chunk }.apply_style(block_style));
+        }
         output
     }
 }


### PR DESCRIPTION
This applies the same style as code snippet line numbers to non highlighted code lines as they otherwise still stand out quite a bit.

Fixes #285 

![image](https://github.com/user-attachments/assets/86a86ddd-8163-4d2a-9874-e8f1d80fd630)
