### PR TITLE
feat: allow scaling images

### DIFF
--- a/config-file-schema.json
+++ b/config-file-schema.json
@@ -273,6 +273,13 @@
             "null"
           ]
         },
+        "image_attributes_prefix": {
+          "description": "The prefix to use for image attributes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "implicit_slide_ends": {
           "description": "Whether slides are automatically terminated when a slide title is found.",
           "type": [

--- a/src/custom.rs
+++ b/src/custom.rs
@@ -112,6 +112,9 @@ pub struct OptionsConfig {
     /// The prefix to use for commands.
     pub command_prefix: Option<String>,
 
+    /// The prefix to use for image attributes.
+    pub image_attributes_prefix: Option<String>,
+
     /// Show all lists incrementally, by implicitly adding pauses in between elements.
     pub incremental_lists: Option<bool>,
 

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -71,7 +71,11 @@ impl ContentDiff for RenderOperation {
             (RenderText { alignment: original, .. }, RenderText { alignment: updated, .. }) if original != updated => {
                 false
             }
-            (RenderImage(original, _), RenderImage(updated, _)) if original != updated => true,
+            (RenderImage(original, original_properties), RenderImage(updated, updated_properties))
+                if original != updated || original_properties != updated_properties =>
+            {
+                true
+            }
             (RenderBlockLine(original), RenderBlockLine(updated)) if original != updated => true,
             (InitColumnLayout { columns: original }, InitColumnLayout { columns: updated }) if original != updated => {
                 true

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,6 +135,7 @@ fn make_builder_options(config: &Config, mode: &PresentMode, force_default_theme
         allow_mutations: !matches!(mode, PresentMode::Export),
         implicit_slide_ends: config.options.implicit_slide_ends.unwrap_or_default(),
         command_prefix: config.options.command_prefix.clone().unwrap_or_default(),
+        image_attribute_prefix: config.options.image_attributes_prefix.clone().unwrap_or_else(|| "image:".to_string()),
         incremental_lists: config.options.incremental_lists.unwrap_or_default(),
         force_default_theme,
         end_slide_shorthand: config.options.end_slide_shorthand.unwrap_or_default(),

--- a/src/markdown/elements.rs
+++ b/src/markdown/elements.rs
@@ -23,7 +23,7 @@ pub(crate) enum MarkdownElement {
     Paragraph(Vec<ParagraphElement>),
 
     /// An image.
-    Image { path: PathBuf },
+    Image { path: PathBuf, title: String, source_position: SourcePosition },
 
     /// A list.
     ///

--- a/src/media/scale.rs
+++ b/src/media/scale.rs
@@ -1,6 +1,24 @@
 use crate::render::properties::{CursorPosition, WindowSize};
 
+/// Scale an image to a specific size.
 pub(crate) fn scale_image(
+    scale_size: &WindowSize,
+    window_dimensions: &WindowSize,
+    image_width: u32,
+    image_height: u32,
+    position: &CursorPosition,
+) -> TerminalRect {
+    let aspect_ratio = image_height as f64 / image_width as f64;
+    let column_in_pixels = scale_size.pixels_per_column();
+    let width_in_columns = scale_size.columns;
+    let image_width = width_in_columns as f64 * column_in_pixels;
+    let image_height = image_width * aspect_ratio;
+
+    fit_image_to_window(window_dimensions, image_width as u32, image_height as u32, position)
+}
+
+/// Shrink an image so it fits the dimensions of the layout it's being displayed in.
+pub(crate) fn fit_image_to_window(
     dimensions: &WindowSize,
     image_width: u32,
     image_height: u32,
@@ -38,6 +56,7 @@ pub(crate) fn scale_image(
     TerminalRect { start_column, columns: width_in_columns as u16, rows: height_in_rows }
 }
 
+#[derive(Debug)]
 pub(crate) struct TerminalRect {
     pub(crate) start_column: u16,
     pub(crate) columns: u16,

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -586,7 +586,7 @@ pub(crate) enum RenderOperation {
 }
 
 /// The properties of an image being rendered.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub(crate) struct ImageProperties {
     pub(crate) z_index: i32,
     pub(crate) size: ImageSize,
@@ -595,11 +595,14 @@ pub(crate) struct ImageProperties {
 }
 
 /// The size used when printing an image.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub(crate) enum ImageSize {
     #[default]
     Scaled,
     Specific(u16, u16),
+    WidthScaled {
+        ratio: f64,
+    },
 }
 
 /// Slide properties, set on initialization.


### PR DESCRIPTION
This adds support for scaling images. Images can, for now, only be scaled to a percentage of the screen width wise. To do this, use the notation `![image:width:50%](image-path)` (shorthands are also `image:width:50` or `image:w:50`). The reason for having a prefix is I've seen some people wanting to be able to pull presentations made with other tools so I don't want to make any assumptions about what those presentations have inside image tags.

@mikavilpas could you give this a shot and lmk your thoughts? I still need to add some stuff and polish this but it's functional already.

Fixes #260