### PR TITLE
feat: allow scaling +render code blocks

### DIFF
--- a/src/markdown/elements.rs
+++ b/src/markdown/elements.rs
@@ -368,6 +368,11 @@ pub(crate) struct SnippetAttributes {
 
     /// The groups of lines to highlight.
     pub(crate) highlight_groups: Vec<HighlightGroup>,
+
+    /// The width of the generated image.
+    ///
+    /// Only valid for +render snippets.
+    pub(crate) width: Option<Percent>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -428,6 +433,29 @@ impl Table {
 /// A table row.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct TableRow(pub(crate) Vec<TextBlock>);
+
+/// A percentage.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct Percent(pub(crate) u8);
+
+impl Percent {
+    pub(crate) fn as_ratio(&self) -> f64 {
+        self.0 as f64 / 100.0
+    }
+}
+
+impl FromStr for Percent {
+    type Err = PercentParseError;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        let value: u8 = input.strip_suffix('%').unwrap_or(input).parse().map_err(|_| PercentParseError)?;
+        if (1..=100).contains(&value) { Ok(Percent(value)) } else { Err(PercentParseError) }
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+#[error("value must be a number between 1-100")]
+pub struct PercentParseError;
 
 #[cfg(test)]
 mod test {

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -598,7 +598,7 @@ pub(crate) struct ImageProperties {
 #[derive(Clone, Debug, Default, PartialEq)]
 pub(crate) enum ImageSize {
     #[default]
-    Scaled,
+    ShrinkIfNeeded,
     Specific(u16, u16),
     WidthScaled {
         ratio: f64,

--- a/src/render/engine.rs
+++ b/src/render/engine.rs
@@ -174,7 +174,7 @@ where
 
         let (width, height) = image.dimensions();
         let (cursor_position, columns, rows) = match properties.size {
-            ImageSize::Scaled => {
+            ImageSize::ShrinkIfNeeded => {
                 let scale = fit_image_to_window(&rect.dimensions, width, height, &starting_position);
                 (CursorPosition { row: starting_position.row, column: scale.start_column }, scale.columns, scale.rows)
             }


### PR DESCRIPTION
This builds on top of the effort in #288 and adds a new `width` attribute to `+render` code blocks that allows specifying the width in % of the generated image, allowing you to scale mermaid/typst/latex images to fit the presentation as you please.