### PR TITLE
feat: handle colored output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi-parser"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43e7fd8284f025d0bd143c2855618ecdf697db55bde39211e5c9faec7669173"
+dependencies = [
+ "heapless",
+ "nom",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -521,6 +531,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -531,6 +550,16 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "heck"
@@ -726,6 +755,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -745,6 +780,16 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -878,6 +923,7 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 name = "presenterm"
 version = "0.7.0"
 dependencies = [
+ "ansi-parser",
  "base64 0.22.1",
  "bincode",
  "clap",
@@ -901,7 +947,6 @@ dependencies = [
  "serde_with",
  "serde_yaml",
  "sixel-rs",
- "strip-ansi-escapes",
  "strum",
  "syntect",
  "tempfile",
@@ -1303,13 +1348,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
-name = "strip-ansi-escapes"
-version = "0.2.0"
+name = "stable_deref_trait"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55ff8ef943b384c414f54aefa961dd2bd853add74ec75e7ac74cf91dba62bcfa"
-dependencies = [
- "vte",
-]
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "strsim"
@@ -1475,26 +1517,6 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
-
-[[package]]
-name = "vte"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5022b5fbf9407086c180e9557be968742d839e68346af7792b8592489732197"
-dependencies = [
- "utf8parse",
- "vte_generate_state_changes",
-]
-
-[[package]]
-name = "vte_generate_state_changes"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e"
-dependencies = [
- "proc-macro2",
- "quote",
-]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,6 +901,7 @@ dependencies = [
  "serde_with",
  "serde_yaml",
  "sixel-rs",
+ "strip-ansi-escapes",
  "strum",
  "syntect",
  "tempfile",
@@ -1302,6 +1303,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ff8ef943b384c414f54aefa961dd2bd853add74ec75e7ac74cf91dba62bcfa"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1465,6 +1475,26 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "vte"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5022b5fbf9407086c180e9557be968742d839e68346af7792b8592489732197"
+dependencies = [
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ version = "0.7.0"
 edition = "2021"
 
 [dependencies]
+ansi-parser = "0.9.1"
 base64 = "0.22"
 bincode = "1.3"
 clap = { version = "4.4", features = ["derive", "string"] }
@@ -34,7 +35,6 @@ console = "0.15.8"
 thiserror = "1"
 unicode-width = "0.1"
 os_pipe = "1.1.5"
-strip-ansi-escapes = "0.2.0"
 
 [dependencies.syntect]
 version = "5.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ console = "0.15.8"
 thiserror = "1"
 unicode-width = "0.1"
 os_pipe = "1.1.5"
+strip-ansi-escapes = "0.2.0"
 
 [dependencies.syntect]
 version = "5.2"

--- a/src/processing/execution.rs
+++ b/src/processing/execution.rs
@@ -93,17 +93,15 @@ impl AsRenderOperations for RunSnippetOperation {
             RenderOperation::SetColors(self.block_colors.clone()),
         ];
 
-        let lines = inner
-            .output_lines
-            .iter()
-            .flat_map(|l| AnsiSplitter::split_into_lines(l, &self.block_colors, dimensions.columns))
-            .collect_vec();
+        let lines =
+            AnsiSplitter::new(dimensions.columns.into(), &self.block_colors).split_lines(inner.output_lines.iter());
 
-        let block_length =
-            self.block_length.max(lines.iter().map(|l| l.width).max().unwrap_or(u16::MAX).saturating_add(1));
+        let block_length = self.block_length.max(
+            lines.iter().map(|l| l.width.try_into().unwrap_or(u16::MAX)).max().unwrap_or(u16::MAX).saturating_add(1),
+        );
 
         for line in &lines {
-            operations.push(self.render_line(&line.content, line.width, block_length));
+            operations.push(self.render_line(&line.content, line.width.try_into().unwrap_or(u16::MAX), block_length));
             operations.push(RenderOperation::RenderLineBreak);
         }
 

--- a/src/render/highlighting.rs
+++ b/src/render/highlighting.rs
@@ -234,18 +234,20 @@ impl<'a> StyledTokens<'a> {
 pub(crate) struct AnsiLine {
     /// Full content of line, including ansi codes for styling
     pub(crate) content: String,
-    // TODO: do u16 safely
     /// Represents the visible width of the content, excluding ansi codes
-    pub(crate) width: u16,
+    pub(crate) width: usize,
 }
 
-pub(crate) struct AnsiSplitter;
+pub(crate) struct AnsiSplitter {
+    buffer: String,
+    current_sgr_codes: Vec<String>,
+    reset_str: String,
+    max_width: usize,
+    visible_b_width: usize,
+}
 
 impl AnsiSplitter {
-    // TODO: needs context of all lines to be completely correct
-    pub fn split_into_lines(line: &str, reset_style: &Colors, max_width: u16) -> Vec<AnsiLine> {
-        let parsed = ansi_parser::AnsiParser::ansi_parse(line);
-
+    pub fn new(max_width: usize, reset_style: &Colors) -> Self {
         let mut reset_str = String::new();
 
         if let Some(color) = reset_style.background {
@@ -255,65 +257,85 @@ impl AnsiSplitter {
             reset_str.push_str(&SetForegroundColor(color.into()).to_string())
         }
 
-        let mut current_sgr_codes: Vec<String> = vec![];
+        Self { buffer: String::new(), current_sgr_codes: vec![], reset_str, max_width, visible_b_width: 0 }
+    }
 
+    pub fn split_lines<T>(&mut self, input_lines: T) -> Vec<AnsiLine>
+    where
+        T: std::iter::IntoIterator,
+        T::Item: AsRef<str>,
+    {
         let mut lines: Vec<AnsiLine> = vec![];
-        let mut buffer = String::new();
-        let mut visible_b_width: usize = 0;
 
-        for p in parsed {
-            match p {
-                Output::TextBlock(mut text) => {
-                    while !text.is_empty() {
-                        let mut leftover_char = max_width as usize - visible_b_width;
+        input_lines.into_iter().for_each(|line| {
+            let parsed = ansi_parser::AnsiParser::ansi_parse(line.as_ref());
 
-                        while leftover_char < text.len() && !text.is_char_boundary(leftover_char) {
-                            leftover_char += 1;
-                        }
-
-                        let split_off_index = leftover_char.min(text.len());
-                        let (prev_part, next_part) = text.split_at(split_off_index);
-
-                        // Add to current line
-                        if prev_part.len() > 0 {
-                            buffer.push_str(prev_part);
-                            visible_b_width += prev_part.len();
-                        }
-
-                        // New line
-                        if next_part.len() + visible_b_width > max_width as usize {
-                            lines.push(AnsiLine { content: buffer.clone(), width: visible_b_width as u16 });
-                            buffer.clear();
-                            buffer.push_str(&current_sgr_codes.join(""));
-                            visible_b_width = 0;
-                        }
-
-                        text = next_part;
-                    }
+            for p in parsed {
+                match p {
+                    Output::TextBlock(text) => self.handle_text_block(text, &mut lines),
+                    Output::Escape(s) => self.handle_escape(&s, &mut lines),
                 }
-                Output::Escape(s) => match s {
-                    AnsiSequence::SetGraphicsMode(ref g) => {
-                        let code = match g.first() {
-                            // If it's a reset code, take the reset style
-                            Some(0) => reset_str.to_owned(),
-                            None | Some(_) => s.to_string(),
-                        };
-                        buffer.push_str(&code);
-                        current_sgr_codes.push(code);
-                    }
-                    // TODO: there are interesting render operations that could
-                    // be done here, such as clearing the output block when an erase display occurs
-                    // AS::EraseDisplay => ,
-                    _ => (),
-                },
             }
-        }
 
-        if !buffer.is_empty() {
-            lines.push(AnsiLine { content: buffer, width: visible_b_width as u16 });
-        }
+            if !self.buffer.is_empty() {
+                lines.push(AnsiLine { content: self.buffer.clone(), width: self.visible_b_width });
+                self.buffer.clear();
+            }
+            self.visible_b_width = 0;
+        });
 
         lines
+    }
+
+    fn handle_text_block(&mut self, text: &str, lines: &mut Vec<AnsiLine>) -> () {
+        let mut text = text;
+        while !text.is_empty() {
+            let mut leftover_char = self.max_width - self.visible_b_width;
+
+            while leftover_char < text.len() && !text.is_char_boundary(leftover_char) {
+                leftover_char += 1;
+            }
+
+            let split_off_index = leftover_char.min(text.len());
+            let (prev_part, next_part) = text.split_at(split_off_index);
+
+            // Add to current line
+            if prev_part.len() > 0 {
+                self.buffer.push_str(prev_part);
+                self.visible_b_width += prev_part.len();
+            }
+
+            // New line
+            if next_part.len() + self.visible_b_width > self.max_width {
+                lines.push(AnsiLine { content: self.buffer.clone(), width: self.visible_b_width });
+                self.buffer.clear();
+                self.buffer.push_str(&self.current_sgr_codes.join(""));
+                self.current_sgr_codes.clear();
+                self.visible_b_width = 0;
+            }
+
+            text = next_part;
+        }
+    }
+
+    fn handle_escape(&mut self, s: &AnsiSequence, lines: &mut Vec<AnsiLine>) -> () {
+        match s {
+            AnsiSequence::SetGraphicsMode(ref g) => {
+                let code = match g.first() {
+                    // If it's a reset code, take the reset style
+                    Some(0) => self.reset_str.to_owned(),
+                    None | Some(_) => s.to_string(),
+                };
+                self.buffer.push_str(&code);
+                // TODO: This can done way more clearly.
+                // We only need to keep what changes, not every single state
+                self.current_sgr_codes.push(code);
+            }
+            // TODO: there are interesting render operations that could
+            // be done here, such as clearing the output block when an erase display occurs
+            AnsiSequence::EraseDisplay => lines.clear(),
+            _ => (),
+        }
     }
 }
 


### PR DESCRIPTION
Fix #272

Don't write a lot of Rust, so all feedback obviously welcome!

![image](https://github.com/user-attachments/assets/d72858e4-578b-49a5-b058-c4b4bc3caf74)

Colored output works, **however with the caveat of chunking not working**.
I am not sure how to approach chunking as it would be likely that I cut through ANSI escapes codes.
Keeping track of positions for where to slice seems messy.

Another expected issue is that the reset code clears out the codeblock format colors, not sure if we wanna resolve that too.
I was thinking that the rendering could intercept clear codes and apply the chosen colors but I think that is out of scope for this PR.
