### PR TITLE
fix: close child process stdin by default

### DIFF
--- a/src/tools.rs
+++ b/src/tools.rs
@@ -35,7 +35,7 @@ pub(crate) struct Tool {
 impl Tool {
     fn new(command_name: &'static str, args: &[&str]) -> Self {
         let mut command = Command::new(command_name);
-        command.args(args).stdout(Stdio::null()).stderr(Stdio::piped());
+        command.args(args).stdin(Stdio::null()).stdout(Stdio::null()).stderr(Stdio::piped());
         Self { command_name, command, stdin: None }
     }
 


### PR DESCRIPTION
The mermaid CLI seems to somehow sometimes consume something from (the inherited) stdin which causes raw mode to break in presenterm. This closes stdin by default, which fixes this issue and also seems like a sane default.