### PR TITLE
fix: don't use transparency in kitty modal background

### DIFF
--- a/src/processing/builder.rs
+++ b/src/processing/builder.rs
@@ -206,7 +206,7 @@ impl<'a> PresentationBuilder<'a> {
         // If we don't have an rgb color (or we don't have a color at all), we default to a semi
         // transparent dark background.
         let rgba = match color {
-            Some((r, g, b)) => [r, g, b, 230],
+            Some((r, g, b)) => [r, g, b, 255],
             None => [0, 0, 0, 128],
         };
         let mut image = DynamicImage::new_rgba8(1, 1);


### PR DESCRIPTION
The transparency in the modal background sounds nice but it looks bad depending on whether there's an image behind it and the color it uses. This disables the transparency so it always looks good regardless of what's behind it.