### PR TITLE
fix: allow executing compiled snippets in windows

### DIFF
--- a/executors.yaml
+++ b/executors.yaml
@@ -5,13 +5,13 @@ bash:
 c++:
   filename: snippet.cpp
   commands:
-    - ["g++", "-std=c++20", "snippet.cpp", "-o", "snippet"]
-    - ["./snippet"]
+    - ["g++", "-std=c++20", "snippet.cpp", "-o", "$pwd/snippet"]
+    - ["$pwd/snippet"]
 c:
   filename: snippet.c
   commands:
-    - ["gcc", "snippet.c", "-o", "snippet"]
-    - ["./snippet"]
+    - ["gcc", "snippet.c", "-o", "$pwd/snippet"]
+    - ["$pwd/snippet"]
 fish:
   filename: script.fish
   commands:
@@ -61,8 +61,8 @@ rust-script:
 rust:
   filename: snippet.rs
   commands:
-    - ["rustc", "--crate-name", "presenterm_snippet", "snippet.rs", "-o", "snippet"]
-    - ["./snippet"]
+    - ["rustc", "--crate-name", "presenterm_snippet", "snippet.rs", "-o", "$pwd/snippet"]
+    - ["$pwd/snippet"]
 sh:
   filename: script.sh
   commands:

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -169,11 +169,14 @@ impl CommandsRunner {
 
     fn launch_process(
         &self,
-        commands: Vec<String>,
+        mut commands: Vec<String>,
         env: &HashMap<String, String>,
     ) -> Result<(Child, PipeReader), CodeExecuteError> {
         let (reader, writer) = os_pipe::pipe().map_err(CodeExecuteError::Pipe)?;
         let writer_clone = writer.try_clone().map_err(CodeExecuteError::Pipe)?;
+        for command in &mut commands {
+            *command = command.replace("$pwd", &self.script_directory.path().to_string_lossy());
+        }
         let (command, args) = commands.split_first().expect("no commands");
         let child = process::Command::new(command)
             .args(args)


### PR DESCRIPTION
Running compiled language snippets wasn't working on windows because the "current dir" parameter to `Command` behaves differently in each platform.