### PR TITLE
fix: exit with error on async render error in export mode

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -111,7 +111,7 @@ impl<'a> Exporter<'a> {
         let presenterm_path = presenterm_path.display().to_string();
         let presentation_path = metadata.presentation_path.display().to_string();
         let metadata = serde_json::to_vec(&metadata).expect("serialization failed");
-        let mut args = vec![&presenterm_path, "--export"];
+        let mut args = vec![&presenterm_path, "--enable-export-mode"];
         args.extend(extra_args);
         args.push(&presentation_path);
         ThirdPartyTools::presenterm_export(&args).stdin(metadata).run()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ struct Cli {
 
     /// Run in export mode.
     #[clap(long, hide = true)]
-    export: bool,
+    enable_export_mode: bool,
 
     /// Use presentation mode.
     #[clap(short, long, default_value_t = false)]
@@ -157,7 +157,7 @@ fn load_default_theme(config: &Config, themes: &Themes, cli: &Cli) -> Presentati
 }
 
 fn select_graphics_mode(cli: &Cli, config: &Config) -> GraphicsMode {
-    if cli.export || cli.export_pdf || cli.generate_pdf_metadata {
+    if cli.enable_export_mode || cli.export_pdf || cli.generate_pdf_metadata {
         GraphicsMode::AsciiBlocks
     } else {
         let protocol = cli.image_protocol.as_ref().unwrap_or(&config.defaults.image_protocol);
@@ -192,7 +192,7 @@ fn run(mut cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
 
     let default_theme = load_default_theme(&config, &themes, &cli);
     let force_default_theme = cli.theme.is_some();
-    let mode = match (cli.present, cli.export) {
+    let mode = match (cli.present, cli.enable_export_mode) {
         (true, _) => PresentMode::Presentation,
         (false, true) => PresentMode::Export,
         (false, false) => PresentMode::Development,

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -91,6 +91,11 @@ impl<'a> Presenter<'a> {
         let mut drawer =
             TerminalDrawer::new(io::stdout(), self.image_printer.clone(), self.options.font_size_fallback)?;
         loop {
+            if matches!(self.options.mode, PresentMode::Export) {
+                if let PresenterState::Failure { error, .. } = &self.state {
+                    return Err(PresentationError::Fatal(format!("failed to run presentation: {error}")));
+                }
+            }
             // Poll async renders once before we draw just in case.
             self.poll_async_renders()?;
             self.render(&mut drawer)?;
@@ -425,9 +430,6 @@ pub enum LoadPresentationError {
 pub enum PresentationError {
     #[error(transparent)]
     Render(#[from] RenderError),
-
-    #[error(transparent)]
-    LoadPresentation(#[from] LoadPresentationError),
 
     #[error("io: {0}")]
     Io(#[from] io::Error),


### PR DESCRIPTION
If mermaid wasn't installed and you ran a pdf export, it would generate a pdf with just the failure error over and over again. This PR causes presenterm to fail instead.