### PR TITLE
fix: reset colors properly after async blocks in export mode

### DIFF
--- a/src/third_party.rs
+++ b/src/third_party.rs
@@ -379,7 +379,7 @@ impl AsRenderOperations for RenderThirdParty {
                     z_index: DEFAULT_IMAGE_Z_INDEX,
                     size,
                     restore_cursor: false,
-                    background_color: None,
+                    background_color: self.default_colors.background,
                 };
 
                 vec![


### PR DESCRIPTION
A recent change caused async render blocks (mermaid, typst) to change the following lines' background color.