### PR TITLE
feat: add mermaid docs and sensible defaults

### DIFF
--- a/docs/src/guides/mermaid.md
+++ b/docs/src/guides/mermaid.md
@@ -35,3 +35,10 @@ sequenceDiagram
 It is recommended to change the `mermaid.scale` parameter until images look big enough and then adjust on an image by 
 image case if necessary using the `+width` attribute. Otherwise, using a small scale and then scaling via `+width` may 
 cause the image to become blurry.
+
+## Theme
+
+The theme of the rendered mermaid diagrams can be changed through the following [theme](themes.html#mermaid) parameters:
+
+* `mermaid.background` the background color passed to the CLI (e.g., `transparent`, `red`, `#F0F0F0`).
+* `mermaid.theme` the [mermaid theme](https://mermaid.js.org/config/theming.html#available-themes) to use.

--- a/docs/src/guides/themes.md
+++ b/docs/src/guides/themes.md
@@ -340,6 +340,19 @@ block_quote:
 [builtin-themes]: https://github.com/mfontanini/presenterm/tree/master/themes
 [build-rs]: https://github.com/mfontanini/presenterm/blob/master/build.rs
 
+### Mermaid
+
+The [mermaid](https://mermaid.js.org/) graphs can be customized using the following parameters:
+
+* `mermaid.background` the background color passed to the CLI (e.g., `transparent`, `red`, `#F0F0F0`).
+* `mermaid.theme` the [mermaid theme](https://mermaid.js.org/config/theming.html#available-themes) to use.
+
+```yaml
+mermaid:
+  background: transparent
+  theme: dark
+```
+
 ### Extending themes
 
 Custom themes can extend other custom or built in themes. This means it will inherit all the properties of the theme 

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -597,7 +597,7 @@ pub(crate) enum AuthorPositioning {
     PageBottom,
 }
 
-/// Where to position the author's name in the intro slide.
+/// Typst styles.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub(crate) struct TypstStyle {
     /// The horizontal margin on the generated images.
@@ -611,7 +611,7 @@ pub(crate) struct TypstStyle {
     pub(crate) colors: Colors,
 }
 
-/// Where to position the author's name in the intro slide.
+/// Mermaid styles.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub(crate) struct MermaidStyle {
     /// The mermaidjs theme to use.

--- a/src/third_party.rs
+++ b/src/third_party.rs
@@ -212,7 +212,7 @@ impl Worker {
             "-t",
             style.theme.as_deref().unwrap_or("default"),
             "-b",
-            style.background.as_deref().unwrap_or("white"),
+            style.background.as_deref().unwrap_or("transparent"),
         ])
         .run()?;
 

--- a/themes/catppuccin-frappe.yaml
+++ b/themes/catppuccin-frappe.yaml
@@ -100,3 +100,7 @@ footer:
 modals:
   selection_colors:
     foreground: "85c1dc"
+
+mermaid:
+  background: transparent
+  theme: dark

--- a/themes/catppuccin-latte.yaml
+++ b/themes/catppuccin-latte.yaml
@@ -100,3 +100,7 @@ footer:
 modals:
   selection_colors:
     foreground: "209fb5"
+
+mermaid:
+  background: transparent
+  theme: default

--- a/themes/catppuccin-macchiato.yaml
+++ b/themes/catppuccin-macchiato.yaml
@@ -100,3 +100,7 @@ footer:
 modals:
   selection_colors:
     foreground: "7dc4e4"
+
+mermaid:
+  background: transparent
+  theme: dark

--- a/themes/catppuccin-mocha.yaml
+++ b/themes/catppuccin-mocha.yaml
@@ -100,3 +100,7 @@ footer:
 modals:
   selection_colors:
     foreground: "74c7ec"
+
+mermaid:
+  background: transparent
+  theme: dark

--- a/themes/dark.yaml
+++ b/themes/dark.yaml
@@ -101,3 +101,7 @@ footer:
 modals:
   selection_colors:
     foreground: "ee9322"
+
+mermaid:
+  background: transparent
+  theme: dark

--- a/themes/light.yaml
+++ b/themes/light.yaml
@@ -101,3 +101,7 @@ footer:
 modals:
   selection_colors:
     foreground: "f77f00"
+
+mermaid:
+  background: transparent
+  theme: default

--- a/themes/terminal-dark.yaml
+++ b/themes/terminal-dark.yaml
@@ -99,3 +99,7 @@ footer:
 modals:
   selection_colors:
     foreground: yellow
+
+mermaid:
+  background: transparent
+  theme: dark

--- a/themes/terminal-light.yaml
+++ b/themes/terminal-light.yaml
@@ -99,3 +99,7 @@ footer:
 modals:
   selection_colors:
     foreground: dark_yellow
+
+mermaid:
+  background: transparent
+  theme: default

--- a/themes/tokyonight-storm.yaml
+++ b/themes/tokyonight-storm.yaml
@@ -101,3 +101,7 @@ footer:
 modals:
   selection_colors:
     foreground: "e0af68"
+
+mermaid:
+  background: transparent
+  theme: dark


### PR DESCRIPTION
Hello!

Changes:
- add mermaid theme docs
- change default mermaid bg to `transparent` (this seems to be how Github renders mermaid charts)
- add sensible mermaid default based on theme

I noticed that the `mermaid` theme parameters didn't make it into the documentation so I decided to add it.

I also tried to add sensible mermaid theme defaults to better match the supported themes instead of always having to override the theme. For instance, on the `dark` theme the original mermaid defaults (bg: white, theme: default) are quite jarring:


![image](https://github.com/user-attachments/assets/044e4996-9163-4b97-bf75-030c2ce33a9e)

But updating to (bg: transparent, theme: dark) looks much nicer:

![image](https://github.com/user-attachments/assets/31a2fca0-e40b-41a9-8125-6e1b12cefd9f)

Thanks!