### PR TITLE
feat: process colored output from execution output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi-parser"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43e7fd8284f025d0bd143c2855618ecdf697db55bde39211e5c9faec7669173"
+dependencies = [
+ "heapless",
+ "nom",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,6 +138,12 @@ name = "bytemuck"
 version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b236fc92302c97ed75b38da1f4917b5cdda4984745740f153a5d3059e48d725e"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "byteorder-lite"
@@ -520,6 +536,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,6 +555,16 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "heck"
@@ -719,6 +754,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,6 +779,16 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -870,6 +921,7 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 name = "presenterm"
 version = "0.8.0"
 dependencies = [
+ "ansi-parser",
  "base64",
  "bincode",
  "clap",
@@ -1299,6 +1351,12 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ version = "0.8.0"
 edition = "2021"
 
 [dependencies]
+ansi-parser = "0.9"
 base64 = "0.22"
 bincode = "1.3"
 clap = { version = "4.4", features = ["derive", "string"] }

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -1,0 +1,99 @@
+use crate::{
+    markdown::{
+        elements::{Text, TextBlock},
+        text::WeightedTextBlock,
+    },
+    style::{Color, TextStyle},
+};
+use ansi_parser::{AnsiParser, AnsiSequence, Output};
+
+pub(crate) struct AnsiSplitter {
+    lines: Vec<WeightedTextBlock>,
+    current_line: TextBlock,
+    current_style: TextStyle,
+}
+
+impl AnsiSplitter {
+    pub(crate) fn new(current_style: TextStyle) -> Self {
+        Self { lines: Default::default(), current_line: Default::default(), current_style }
+    }
+
+    pub(crate) fn split_lines(mut self, lines: &[String]) -> (Vec<WeightedTextBlock>, TextStyle) {
+        for line in lines {
+            for p in line.ansi_parse() {
+                match p {
+                    Output::TextBlock(text) => {
+                        self.current_line.0.push(Text::new(text, self.current_style.clone()));
+                    }
+                    Output::Escape(s) => self.handle_escape(&s),
+                }
+            }
+            let current_line = std::mem::take(&mut self.current_line);
+            self.lines.push(current_line.into());
+        }
+
+        (self.lines, self.current_style)
+    }
+
+    fn handle_escape(&mut self, s: &AnsiSequence) {
+        match s {
+            AnsiSequence::SetGraphicsMode(code) => {
+                let code = GraphicsCode(code);
+                code.update(&mut self.current_style);
+            }
+            AnsiSequence::EraseDisplay => {
+                self.lines.clear();
+                self.current_line.0.clear();
+            }
+            _ => (),
+        }
+    }
+}
+
+struct GraphicsCode<'a>(&'a [u8]);
+
+impl<'a> GraphicsCode<'a> {
+    fn update(&self, style: &mut TextStyle) {
+        // RGB mode
+        let codes = self.0;
+        if codes.starts_with(&[38, 2]) || codes.starts_with(&[48, 2]) {
+            if codes.len() == 5 {
+                let color = Color::new(codes[2], codes[3], codes[4]);
+                if codes[0] == 38 {
+                    style.colors.foreground = Some(color);
+                } else {
+                    style.colors.background = Some(color);
+                }
+            }
+            return;
+        }
+        for value in codes {
+            match value {
+                0 => *style = TextStyle::default(),
+                1 => *style = style.clone().bold(),
+                3 => *style = style.clone().italics(),
+                4 => *style = style.clone().underlined(),
+                9 => *style = style.clone().strikethrough(),
+                30 => style.colors.foreground = Some(Color::Black),
+                40 => style.colors.background = Some(Color::Black),
+                31 => style.colors.foreground = Some(Color::Red),
+                41 => style.colors.background = Some(Color::Red),
+                32 => style.colors.foreground = Some(Color::Green),
+                42 => style.colors.background = Some(Color::Green),
+                33 => style.colors.foreground = Some(Color::Yellow),
+                43 => style.colors.background = Some(Color::Yellow),
+                34 => style.colors.foreground = Some(Color::Blue),
+                44 => style.colors.background = Some(Color::Blue),
+                35 => style.colors.foreground = Some(Color::Magenta),
+                45 => style.colors.background = Some(Color::Magenta),
+                36 => style.colors.foreground = Some(Color::Cyan),
+                46 => style.colors.background = Some(Color::Cyan),
+                37 => style.colors.foreground = Some(Color::White),
+                47 => style.colors.background = Some(Color::White),
+                39 => style.colors.foreground = None,
+                49 => style.colors.background = None,
+                _ => (),
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! This is not meant to be used as a crate!
 
+pub(crate) mod ansi;
 pub(crate) mod custom;
 pub(crate) mod demo;
 pub(crate) mod diff;

--- a/src/markdown/text.rs
+++ b/src/markdown/text.rs
@@ -207,7 +207,7 @@ impl<'a> WeightedTextRef<'a> {
         Self { text, accumulators, style: self.style }
     }
 
-    fn width(&self) -> usize {
+    pub(crate) fn width(&self) -> usize {
         let last_width = self.accumulators.last().map(|a| a.width).unwrap_or(0);
         let first_width = self.accumulators.first().map(|a| a.width).unwrap_or(0);
         last_width - first_width

--- a/src/style.rs
+++ b/src/style.rs
@@ -128,16 +128,34 @@ enum TextFormatFlags {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, SerializeDisplay, DeserializeFromStr)]
-pub(crate) struct Color(crossterm::style::Color);
+pub(crate) enum Color {
+    Black,
+    DarkGrey,
+    Red,
+    DarkRed,
+    Green,
+    DarkGreen,
+    Yellow,
+    DarkYellow,
+    Blue,
+    DarkBlue,
+    Magenta,
+    DarkMagenta,
+    Cyan,
+    DarkCyan,
+    White,
+    Grey,
+    Rgb { r: u8, g: u8, b: u8 },
+}
 
 impl Color {
     pub(crate) fn new(r: u8, g: u8, b: u8) -> Self {
-        Self(crossterm::style::Color::Rgb { r, g, b })
+        Self::Rgb { r, g, b }
     }
 
     pub(crate) fn as_rgb(&self) -> Option<(u8, u8, u8)> {
-        match self.0 {
-            crossterm::style::Color::Rgb { r, g, b } => Some((r, g, b)),
+        match self {
+            Self::Rgb { r, g, b } => Some((*r, *g, *b)),
             _ => None,
         }
     }
@@ -147,27 +165,27 @@ impl FromStr for Color {
     type Err = ParseColorError;
 
     fn from_str(input: &str) -> Result<Self, Self::Err> {
-        use crossterm::style::Color as C;
         let output = match input {
-            "black" => Self(C::Black),
-            "white" => Self(C::White),
-            "grey" => Self(C::Grey),
-            "red" => Self(C::Red),
-            "dark_red" => Self(C::DarkRed),
-            "green" => Self(C::Green),
-            "dark_green" => Self(C::DarkGreen),
-            "blue" => Self(C::Blue),
-            "dark_blue" => Self(C::DarkBlue),
-            "yellow" => Self(C::Yellow),
-            "dark_yellow" => Self(C::DarkYellow),
-            "magenta" => Self(C::Magenta),
-            "dark_magenta" => Self(C::DarkMagenta),
-            "cyan" => Self(C::Cyan),
-            "dark_cyan" => Self(C::DarkCyan),
+            "black" => Self::Black,
+            "white" => Self::White,
+            "grey" => Self::Grey,
+            "dark_grey" => Self::DarkGrey,
+            "red" => Self::Red,
+            "dark_red" => Self::DarkRed,
+            "green" => Self::Green,
+            "dark_green" => Self::DarkGreen,
+            "blue" => Self::Blue,
+            "dark_blue" => Self::DarkBlue,
+            "yellow" => Self::Yellow,
+            "dark_yellow" => Self::DarkYellow,
+            "magenta" => Self::Magenta,
+            "dark_magenta" => Self::DarkMagenta,
+            "cyan" => Self::Cyan,
+            "dark_cyan" => Self::DarkCyan,
             // Fallback to hex-encoded rgb
             _ => {
                 let values = <[u8; 3]>::from_hex(input)?;
-                Self(crossterm::style::Color::Rgb { r: values[0], g: values[1], b: values[2] })
+                Self::Rgb { r: values[0], g: values[1], b: values[2] }
             }
         };
         Ok(output)
@@ -176,32 +194,50 @@ impl FromStr for Color {
 
 impl Display for Color {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use crossterm::style::Color as C;
-        match self.0 {
-            C::Rgb { r, g, b } => write!(f, "{}", hex::encode([r, g, b])),
-            C::Black => write!(f, "black"),
-            C::White => write!(f, "white"),
-            C::Grey => write!(f, "grey"),
-            C::Red => write!(f, "red"),
-            C::DarkRed => write!(f, "dark_red"),
-            C::Green => write!(f, "green"),
-            C::DarkGreen => write!(f, "dark_green"),
-            C::Blue => write!(f, "blue"),
-            C::DarkBlue => write!(f, "dark_blue"),
-            C::Yellow => write!(f, "yellow"),
-            C::DarkYellow => write!(f, "dark_yellow"),
-            C::Magenta => write!(f, "magenta"),
-            C::DarkMagenta => write!(f, "dark_magenta"),
-            C::Cyan => write!(f, "cyan"),
-            C::DarkCyan => write!(f, "dark_cyan"),
-            _ => panic!("unsupported color"),
+        match self {
+            Self::Rgb { r, g, b } => write!(f, "{}", hex::encode([*r, *g, *b])),
+            Self::Black => write!(f, "black"),
+            Self::White => write!(f, "white"),
+            Self::Grey => write!(f, "grey"),
+            Self::DarkGrey => write!(f, "dark_grey"),
+            Self::Red => write!(f, "red"),
+            Self::DarkRed => write!(f, "dark_red"),
+            Self::Green => write!(f, "green"),
+            Self::DarkGreen => write!(f, "dark_green"),
+            Self::Blue => write!(f, "blue"),
+            Self::DarkBlue => write!(f, "dark_blue"),
+            Self::Yellow => write!(f, "yellow"),
+            Self::DarkYellow => write!(f, "dark_yellow"),
+            Self::Magenta => write!(f, "magenta"),
+            Self::DarkMagenta => write!(f, "dark_magenta"),
+            Self::Cyan => write!(f, "cyan"),
+            Self::DarkCyan => write!(f, "dark_cyan"),
         }
     }
 }
 
 impl From<Color> for crossterm::style::Color {
     fn from(value: Color) -> Self {
-        value.0
+        use crossterm::style::Color as C;
+        match value {
+            Color::Black => C::Black,
+            Color::DarkGrey => C::DarkGrey,
+            Color::Red => C::Red,
+            Color::DarkRed => C::DarkRed,
+            Color::Green => C::Green,
+            Color::DarkGreen => C::DarkGreen,
+            Color::Yellow => C::Yellow,
+            Color::DarkYellow => C::DarkYellow,
+            Color::Blue => C::Blue,
+            Color::DarkBlue => C::DarkBlue,
+            Color::Magenta => C::Magenta,
+            Color::DarkMagenta => C::DarkMagenta,
+            Color::Cyan => C::Cyan,
+            Color::DarkCyan => C::DarkCyan,
+            Color::White => C::White,
+            Color::Grey => C::Grey,
+            Color::Rgb { r, g, b } => C::Rgb { r, g, b },
+        }
     }
 }
 


### PR DESCRIPTION
This processes execution output's ansi escape codes and turns them into `WeightedTexBlock`. This can then be rendered so that we:
* Get colored output automatically.
* Handle lines that are too long to fit on the screen automatically.

This needs more testing, I just tested a couple of commands and it works fine but I didn't thoroughly test yet.

This is based on the initial work done on #296.

cc @DrunkenToast @calebdw I would appreciate if you could give this PR a test. It's only handling a very tiny subset of escape codes so I wouldn't be surprised if something failed. At least I tried basic things like `ls --color=always` and piping stuff to `lolcat` and they both seem to work fine to me.