### PR TITLE
feat: add event, location, and date frontmatter

### DIFF
--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -493,6 +493,18 @@ pub(crate) struct PresentationMetadata {
     #[serde(default)]
     pub(crate) sub_title: Option<String>,
 
+    /// The presentation event.
+    #[serde(default)]
+    pub(crate) event: Option<String>,
+
+    /// The presentation location.
+    #[serde(default)]
+    pub(crate) location: Option<String>,
+
+    /// The presentation date.
+    #[serde(default)]
+    pub(crate) date: Option<String>,
+
     /// The presentation author.
     #[serde(default)]
     pub(crate) author: Option<String>,
@@ -508,6 +520,19 @@ pub(crate) struct PresentationMetadata {
     /// The presentation's options.
     #[serde(default)]
     pub(crate) options: Option<OptionsConfig>,
+}
+
+impl PresentationMetadata {
+    /// Check if this presentation has frontmatter.
+    pub(crate) fn has_frontmatter(&self) -> bool {
+        self.title.is_some()
+            || self.sub_title.is_some()
+            || self.event.is_some()
+            || self.location.is_some()
+            || self.date.is_some()
+            || self.author.is_some()
+            || !self.authors.is_empty()
+    }
 }
 
 /// A presentation's theme metadata.

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -206,6 +206,9 @@ impl PresentationTheme {
             Code => &self.code.alignment,
             PresentationTitle => &self.intro_slide.title.alignment,
             PresentationSubTitle => &self.intro_slide.subtitle.alignment,
+            PresentationEvent => &self.intro_slide.event.alignment,
+            PresentationLocation => &self.intro_slide.location.alignment,
+            PresentationDate => &self.intro_slide.date.alignment,
             PresentationAuthor => &self.intro_slide.author.alignment,
             Table => &self.table,
             BlockQuote => &self.block_quote.alignment,
@@ -335,6 +338,18 @@ pub(crate) struct IntroSlideStyle {
     /// The style of the subtitle line.
     #[serde(default)]
     pub(crate) subtitle: BasicStyle,
+
+    /// The style of the event line.
+    #[serde(default)]
+    pub(crate) event: BasicStyle,
+
+    /// The style of the location line.
+    #[serde(default)]
+    pub(crate) location: BasicStyle,
+
+    /// The style of the date line.
+    #[serde(default)]
+    pub(crate) date: BasicStyle,
 
     /// The style of the author line.
     #[serde(default)]
@@ -580,6 +595,9 @@ pub(crate) enum ElementType {
     Code,
     PresentationTitle,
     PresentationSubTitle,
+    PresentationEvent,
+    PresentationLocation,
+    PresentationDate,
     PresentationAuthor,
     Table,
     BlockQuote,

--- a/themes/catppuccin-frappe.yaml
+++ b/themes/catppuccin-frappe.yaml
@@ -1,3 +1,4 @@
+---
 default:
   margin:
     percent: 8
@@ -48,6 +49,18 @@ intro_slide:
     alignment: center
     colors:
       foreground: "85c1dc"
+  event:
+    alignment: center
+    colors:
+      foreground: "a6d189"
+  location:
+    alignment: center
+    colors:
+      foreground: "85c1dc"
+  date:
+    alignment: center
+    colors:
+      foreground: "e5c890"
   author:
     alignment: center
     colors:

--- a/themes/catppuccin-latte.yaml
+++ b/themes/catppuccin-latte.yaml
@@ -1,3 +1,4 @@
+---
 default:
   margin:
     percent: 8
@@ -48,6 +49,18 @@ intro_slide:
     alignment: center
     colors:
       foreground: "209fb5"
+  event:
+    alignment: center
+    colors:
+      foreground: "40a02b"
+  location:
+    alignment: center
+    colors:
+      foreground: "209fb5"
+  date:
+    alignment: center
+    colors:
+      foreground: "df8e1d"
   author:
     alignment: center
     colors:

--- a/themes/catppuccin-macchiato.yaml
+++ b/themes/catppuccin-macchiato.yaml
@@ -1,3 +1,4 @@
+---
 default:
   margin:
     percent: 8
@@ -48,6 +49,18 @@ intro_slide:
     alignment: center
     colors:
       foreground: "7dc4e4"
+  event:
+    alignment: center
+    colors:
+      foreground: "a6da95"
+  location:
+    alignment: center
+    colors:
+      foreground: "7dc4e4"
+  date:
+    alignment: center
+    colors:
+      foreground: "eed49f"
   author:
     alignment: center
     colors:

--- a/themes/catppuccin-mocha.yaml
+++ b/themes/catppuccin-mocha.yaml
@@ -1,3 +1,4 @@
+---
 default:
   margin:
     percent: 8
@@ -48,6 +49,18 @@ intro_slide:
     alignment: center
     colors:
       foreground: "74c7ec"
+  event:
+    alignment: center
+    colors:
+      foreground: "a6e3a1"
+  location:
+    alignment: center
+    colors:
+      foreground: "74c7ec"
+  date:
+    alignment: center
+    colors:
+      foreground: "f9e2af"
   author:
     alignment: center
     colors:

--- a/themes/dark.yaml
+++ b/themes/dark.yaml
@@ -1,3 +1,4 @@
+---
 default:
   margin:
     percent: 8
@@ -49,6 +50,18 @@ intro_slide:
     alignment: center
     colors:
       foreground: "a5d7e8"
+  event:
+    alignment: center
+    colors:
+      foreground: "b4ccff"
+  location:
+    alignment: center
+    colors:
+      foreground: "a5d7e8"
+  date:
+    alignment: center
+    colors:
+      foreground: "ee9322"
   author:
     alignment: center
     colors:
@@ -93,7 +106,7 @@ typst:
     foreground: "f0f0f0"
     background: "292e42"
 
-footer: 
+footer:
   style: progress_bar
   colors:
     foreground: "7aa2f7"

--- a/themes/light.yaml
+++ b/themes/light.yaml
@@ -1,3 +1,4 @@
+---
 default:
   margin:
     percent: 8
@@ -49,6 +50,18 @@ intro_slide:
     alignment: center
     colors:
       foreground: "8e9aaf"
+  event:
+    alignment: center
+    colors:
+      foreground: "52b788"
+  location:
+    alignment: center
+    colors:
+      foreground: "f77f00"
+  date:
+    alignment: center
+    colors:
+      foreground: "f77f00"
   author:
     alignment: center
     colors:
@@ -93,7 +106,7 @@ typst:
     foreground: "212529"
     background: "e9ecef"
 
-footer: 
+footer:
   style: progress_bar
   colors:
     foreground: "7aa2f7"

--- a/themes/terminal-dark.yaml
+++ b/themes/terminal-dark.yaml
@@ -1,9 +1,10 @@
+---
 default:
   margin:
     percent: 8
   colors:
     foreground: null
-    background: null 
+    background: null
 
 slide_title:
   alignment: center
@@ -47,6 +48,18 @@ intro_slide:
     alignment: center
     colors:
       foreground: blue
+  event:
+    alignment: center
+    colors:
+      foreground: green
+  location:
+    alignment: center
+    colors:
+      foreground: blue
+  date:
+    alignment: center
+    colors:
+      foreground: yellow
   author:
     alignment: center
     colors:
@@ -91,7 +104,7 @@ typst:
     foreground: "f0f0f0"
     background: "292e42"
 
-footer: 
+footer:
   style: progress_bar
   colors:
     foreground: blue

--- a/themes/terminal-light.yaml
+++ b/themes/terminal-light.yaml
@@ -1,3 +1,4 @@
+---
 default:
   margin:
     percent: 8
@@ -47,6 +48,18 @@ intro_slide:
     alignment: center
     colors:
       foreground: dark_blue
+  event:
+    alignment: center
+    colors:
+      foreground: dark_green
+  location:
+    alignment: center
+    colors:
+      foreground: dark_blue
+  date:
+    alignment: center
+    colors:
+      foreground: dark_yellow
   author:
     alignment: center
     colors:
@@ -91,7 +104,7 @@ typst:
     foreground: "212529"
     background: "e9ecef"
 
-footer: 
+footer:
   style: progress_bar
   colors:
     foreground: dark_blue

--- a/themes/tokyonight-storm.yaml
+++ b/themes/tokyonight-storm.yaml
@@ -1,3 +1,4 @@
+---
 default:
   margin:
     percent: 8
@@ -49,6 +50,18 @@ intro_slide:
     alignment: center
     colors:
       foreground: "a9b1d6"
+  event:
+    alignment: center
+    colors:
+      foreground: "7aa2f7"
+  location:
+    alignment: center
+    colors:
+      foreground: "a9b1d6"
+  date:
+    alignment: center
+    colors:
+      foreground: "e0af68"
   author:
     alignment: center
     colors:
@@ -93,7 +106,7 @@ typst:
     foreground: "f0f0f0"
     background: "545c7e"
 
-footer: 
+footer:
   style: progress_bar
   colors:
     foreground: "7aa2f7"


### PR DESCRIPTION
Hello!

Closes #312 


This PR adds fields for the presentation `event`, `location`, and `date`---these are optional fields but are common frontmatter elements, particularly if the presentation is for a larger conference / event.

Example:
~~~markdown
---
title: How to Think Like a Designer
sub_title: It's easier than you think
event: Laracon US 2024
location: Dallas, TX
date: 2024-08-28
author: Jack McDade
---
~~~

![image](https://github.com/user-attachments/assets/613e6f50-efec-451b-8275-0d040ff9238f)


Thanks!

P.S., I'm really new to Rust so sorry if I didn't do thing in the idiomatic Rust way!