### PR TITLE
fix: support mmdc on windows

### DIFF
--- a/src/tools.rs
+++ b/src/tools.rs
@@ -18,7 +18,12 @@ impl ThirdPartyTools {
     }
 
     pub(crate) fn mermaid(args: &[&str]) -> Tool {
-        Tool::new("mmdc", args)
+        let mmdc = if cfg!(windows) {
+            "mmdc.cmd"
+        } else {
+            "mmdc"
+        };
+        Tool::new(mmdc, args)
     }
 
     pub(crate) fn presenterm_export(args: &[&str]) -> Tool {

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -18,11 +18,7 @@ impl ThirdPartyTools {
     }
 
     pub(crate) fn mermaid(args: &[&str]) -> Tool {
-        let mmdc = if cfg!(windows) {
-            "mmdc.cmd"
-        } else {
-            "mmdc"
-        };
+        let mmdc = if cfg!(windows) { "mmdc.cmd" } else { "mmdc" };
         Tool::new(mmdc, args)
     }
 


### PR DESCRIPTION
I am not sure if Windows platform support is of any importance but I encountered an issue where `mmdc` cannot be found on Windows. This is due to this [issue](https://doc.rust-lang.org/std/process/struct.Command.html#implementations) where `Command::new()` on Windows works in this way: "if the file has a different extension, a filename including the extension needs to be provided, otherwise the file won’t be found.". 

Since mmdc on Windows is an alias for the `mmdc.cmd` script and not an `exe`, this updates the name used to find the mmdc tool.