### PR TITLE
feat: handle code overflow

### DIFF
--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -23,7 +23,7 @@ impl AnsiSplitter {
             for p in line.ansi_parse() {
                 match p {
                     Output::TextBlock(text) => {
-                        self.current_line.0.push(Text::new(text, self.current_style.clone()));
+                        self.current_line.0.push(Text::new(text, self.current_style));
                     }
                     Output::Escape(s) => self.handle_escape(&s),
                 }
@@ -70,10 +70,10 @@ impl<'a> GraphicsCode<'a> {
         for value in codes {
             match value {
                 0 => *style = TextStyle::default(),
-                1 => *style = style.clone().bold(),
-                3 => *style = style.clone().italics(),
-                4 => *style = style.clone().underlined(),
-                9 => *style = style.clone().strikethrough(),
+                1 => *style = (*style).bold(),
+                3 => *style = (*style).italics(),
+                4 => *style = (*style).underlined(),
+                9 => *style = (*style).strikethrough(),
                 30 => style.colors.foreground = Some(Color::Black),
                 40 => style.colors.background = Some(Color::Black),
                 31 => style.colors.foreground = Some(Color::Red),

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -114,9 +114,8 @@ where
 mod test {
     use super::*;
     use crate::{
-        presentation::{
-            AsRenderOperations, BlockLine, BlockLineText, RenderAsync, RenderAsyncState, Slide, SlideBuilder,
-        },
+        markdown::text::WeightedTextBlock,
+        presentation::{AsRenderOperations, BlockLine, RenderAsync, RenderAsyncState, Slide, SlideBuilder},
         render::properties::WindowSize,
         style::{Color, Colors},
         theme::{Alignment, Margin},
@@ -156,10 +155,11 @@ mod test {
     #[case(RenderOperation::RenderText{line: String::from("asd").into(), alignment: Default::default()})]
     #[case(RenderOperation::RenderBlockLine(
         BlockLine{
-            text: BlockLineText::Preformatted("".into()),
+            prefix: "".into(),
+            text: WeightedTextBlock::from("".to_string()),
             alignment: Default::default(),
             block_length: 42,
-            unformatted_length: 1337
+            block_color: None,
         }
     ))]
     #[case(RenderOperation::RenderDynamic(Rc::new(Dynamic)))]

--- a/src/markdown/parse.rs
+++ b/src/markdown/parse.rs
@@ -339,14 +339,14 @@ impl<'a> InlinesParser<'a> {
         let data = node.data.borrow();
         match &data.value {
             NodeValue::Text(text) => {
-                self.pending_text.push(Text::new(text.clone(), style.clone()));
+                self.pending_text.push(Text::new(text.clone(), style));
             }
             NodeValue::Code(code) => {
                 self.pending_text.push(Text::new(code.literal.clone(), TextStyle::default().code()));
             }
-            NodeValue::Strong => self.process_children(node, style.clone().bold())?,
-            NodeValue::Emph => self.process_children(node, style.clone().italics())?,
-            NodeValue::Strikethrough => self.process_children(node, style.clone().strikethrough())?,
+            NodeValue::Strong => self.process_children(node, style.bold())?,
+            NodeValue::Emph => self.process_children(node, style.italics())?,
+            NodeValue::Strikethrough => self.process_children(node, style.strikethrough())?,
             NodeValue::SoftBreak => self.pending_text.push(Text::from(" ")),
             NodeValue::Link(link) => self.pending_text.push(Text::new(link.url.clone(), TextStyle::default().link())),
             NodeValue::LineBreak => {
@@ -381,7 +381,7 @@ impl<'a> InlinesParser<'a> {
 
     fn process_children(&mut self, node: &'a AstNode<'a>, style: TextStyle) -> ParseResult<()> {
         for node in node.children() {
-            self.process_node(node, style.clone())?;
+            self.process_node(node, style)?;
         }
         Ok(())
     }

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -1,6 +1,6 @@
 use crate::{
     custom::OptionsConfig,
-    markdown::text::WeightedTextBlock,
+    markdown::text::{WeightedText, WeightedTextBlock},
     media::image::Image,
     render::properties::WindowSize,
     style::{Color, Colors},
@@ -554,16 +554,11 @@ pub(crate) struct PresentationThemeMetadata {
 /// A line of preformatted text to be rendered.
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct BlockLine {
-    pub(crate) text: BlockLineText,
-    pub(crate) unformatted_length: u16,
+    pub(crate) prefix: WeightedText,
+    pub(crate) text: WeightedTextBlock,
     pub(crate) block_length: u16,
+    pub(crate) block_color: Option<Color>,
     pub(crate) alignment: Alignment,
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub(crate) enum BlockLineText {
-    Preformatted(String),
-    Weighted(WeightedTextBlock),
 }
 
 /// A render operation.

--- a/src/processing/footer.rs
+++ b/src/processing/footer.rs
@@ -54,13 +54,7 @@ impl AsRenderOperations for FooterGenerator {
                 ];
                 for (text, alignment) in [left, center, right].iter().zip(alignments) {
                     if let Some(text) = text {
-                        operations.push(Self::render_template(
-                            text,
-                            &current_slide,
-                            &context,
-                            colors.clone(),
-                            alignment,
-                        ));
+                        operations.push(Self::render_template(text, &current_slide, &context, *colors, alignment));
                     }
                 }
                 operations
@@ -71,7 +65,7 @@ impl AsRenderOperations for FooterGenerator {
                 let progress_ratio = (self.current_slide + 1) as f64 / context.total_slides as f64;
                 let columns_ratio = (total_columns as f64 * progress_ratio).ceil();
                 let bar = character.repeat(columns_ratio as usize);
-                let bar = Text::new(bar, TextStyle::default().colors(colors.clone()));
+                let bar = Text::new(bar, TextStyle::default().colors(*colors));
                 vec![
                     RenderOperation::JumpToBottomRow { index: 0 },
                     RenderOperation::RenderText {

--- a/src/processing/modals.rs
+++ b/src/processing/modals.rs
@@ -44,7 +44,7 @@ impl IndexBuilder {
             builder.content.push(title);
         }
         let base_color = theme.modals.colors.merge(&theme.default_style.colors);
-        let selection_style = TextStyle::default().colors(theme.modals.selection_colors.clone()).bold();
+        let selection_style = TextStyle::default().colors(theme.modals.selection_colors).bold();
         let ModalContent { prefix, content, suffix, content_width } = builder.build(base_color);
         let drawer = IndexDrawer {
             prefix,
@@ -88,7 +88,7 @@ impl AsRenderOperations for IndexDrawer {
         for (index, row) in visible_rows {
             let mut row = row.clone();
             if index == current_slide_index {
-                row = row.with_style(self.selection_style.clone());
+                row = row.with_style(self.selection_style);
             }
             let operation = RenderOperation::RenderText { line: row.build(), alignment: Default::default() };
             operations.extend([operation, RenderOperation::RenderLineBreak]);

--- a/src/processing/separator.rs
+++ b/src/processing/separator.rs
@@ -1,6 +1,6 @@
 use crate::{
     markdown::elements::TextBlock,
-    presentation::{AsRenderOperations, BlockLine, BlockLineText, RenderOperation},
+    presentation::{AsRenderOperations, BlockLine, RenderOperation},
     render::properties::WindowSize,
     theme::{Alignment, Margin},
 };
@@ -55,9 +55,10 @@ impl AsRenderOperations for RenderSeparator {
             }
         };
         vec![RenderOperation::RenderBlockLine(BlockLine {
-            text: BlockLineText::Weighted(separator.into()),
-            unformatted_length: width as u16,
+            prefix: "".into(),
+            text: separator.into(),
             block_length: width as u16,
+            block_color: None,
             alignment: Alignment::Center { minimum_size: 1, minimum_margin: Margin::Fixed(0) },
         })]
     }

--- a/src/render/terminal.rs
+++ b/src/render/terminal.rs
@@ -3,7 +3,7 @@ use crate::{
         image::Image,
         printer::{ImagePrinter, PrintImage, PrintImageError, PrintOptions},
     },
-    style::Colors,
+    style::{Color, Colors},
 };
 use crossterm::{
     cursor,
@@ -93,14 +93,13 @@ impl<W: TerminalWrite> Terminal<W> {
         Ok(())
     }
 
-    pub(crate) fn flush(&mut self) -> io::Result<()> {
-        self.writer.flush()?;
+    pub(crate) fn set_background_color(&mut self, color: Color) -> io::Result<()> {
+        self.writer.queue(style::SetBackgroundColor(color.into()))?;
         Ok(())
     }
 
-    pub(crate) fn sync_cursor_row(&mut self, position: u16) -> io::Result<()> {
-        self.cursor_row = position;
-        self.writer.queue(cursor::MoveToRow(position))?;
+    pub(crate) fn flush(&mut self) -> io::Result<()> {
+        self.writer.flush()?;
         Ok(())
     }
 

--- a/src/style.rs
+++ b/src/style.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 /// The style of a piece of text.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub(crate) struct TextStyle {
     flags: u8,
     pub(crate) colors: Colors,
@@ -108,6 +108,11 @@ impl TextStyle {
         styled
     }
 
+    /// Checks whether this style has any modifiers (bold, italics, etc).
+    pub(crate) fn has_modifiers(&self) -> bool {
+        self.flags != 0
+    }
+
     fn add_flag(mut self, flag: TextFormatFlags) -> Self {
         self.flags |= flag as u8;
         self
@@ -158,6 +163,21 @@ impl Color {
             Self::Rgb { r, g, b } => Some((*r, *g, *b)),
             _ => None,
         }
+    }
+
+    pub(crate) fn from_ansi(color: u8) -> Option<Self> {
+        let color = match color {
+            30 | 40 => Color::Black,
+            31 | 41 => Color::Red,
+            32 | 42 => Color::Green,
+            33 | 43 => Color::Yellow,
+            34 | 44 => Color::Blue,
+            35 | 45 => Color::Magenta,
+            36 | 46 => Color::Cyan,
+            37 | 47 => Color::White,
+            _ => return None,
+        };
+        Some(color)
     }
 }
 
@@ -242,7 +262,7 @@ impl From<Color> for crossterm::style::Color {
 }
 
 /// Text colors.
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
 pub(crate) struct Colors {
     /// The background color.
     pub(crate) background: Option<Color>,

--- a/src/third_party.rs
+++ b/src/third_party.rs
@@ -54,18 +54,8 @@ impl ThirdPartyRender {
         slide: usize,
         width: Option<Percent>,
     ) -> Result<RenderOperation, ThirdPartyRenderError> {
-        // Note: this is a bit gore; the diffable content interface needs to be improved as it's
-        // too restrictive.
-        let diffable_content = format!("{request:?}");
         let result = self.render_pool.render(request);
-        let operation = Rc::new(RenderThirdParty::new(
-            result,
-            theme.default_style.colors.clone(),
-            error_holder,
-            slide,
-            diffable_content,
-            width,
-        ));
+        let operation = Rc::new(RenderThirdParty::new(result, theme.default_style.colors, error_holder, slide, width));
         Ok(RenderOperation::RenderAsync(operation))
     }
 }
@@ -318,7 +308,6 @@ pub(crate) struct RenderThirdParty {
     default_colors: Colors,
     error_holder: AsyncPresentationErrorHolder,
     slide: usize,
-    diffable_content: String,
     width: Option<Percent>,
 }
 
@@ -328,18 +317,9 @@ impl RenderThirdParty {
         default_colors: Colors,
         error_holder: AsyncPresentationErrorHolder,
         slide: usize,
-        diffable_content: String,
         width: Option<Percent>,
     ) -> Self {
-        Self {
-            contents: Default::default(),
-            pending_result,
-            default_colors,
-            error_holder,
-            slide,
-            diffable_content,
-            width,
-        }
+        Self { contents: Default::default(), pending_result, default_colors, error_holder, slide, width }
     }
 }
 
@@ -384,7 +364,7 @@ impl AsRenderOperations for RenderThirdParty {
 
                 vec![
                     RenderOperation::RenderImage(image.clone(), properties),
-                    RenderOperation::SetColors(self.default_colors.clone()),
+                    RenderOperation::SetColors(self.default_colors),
                 ]
             }
             None => {
@@ -398,6 +378,6 @@ impl AsRenderOperations for RenderThirdParty {
     }
 
     fn diffable_content(&self) -> Option<&str> {
-        Some(&self.diffable_content)
+        None
     }
 }


### PR DESCRIPTION
This makes it so that code blocks don't overflow to the right of the code block but instead how you'd expect them to: by creating a new line within the code block rect, properly colored and stuff.

![image](https://github.com/user-attachments/assets/529b71e0-a267-4b20-b745-cbb190f310cb)

Fixes #289

cc @DrunkenToast can you give this a shot? It seems to work well including line counts and all.