### PR TITLE
feat: allow closing with `q`

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -82,4 +82,4 @@ bindings:
   close_modal: ["<esc>"]
 
   # the key binding to close the application.
-  exit: ["<c-c>"]
+  exit: ["<c-c>", "q"]

--- a/docs/src/guides/configuration.md
+++ b/docs/src/guides/configuration.md
@@ -253,7 +253,7 @@ bindings:
   close_modal: ["<esc>"]
 
   # the key binding to close the application.
-  exit: ["<c-c>"]
+  exit: ["<c-c>", "q"]
 ```
 
 You can choose to override any of them. Keep in mind these are overrides so if for example you change `next`, the 

--- a/src/custom.rs
+++ b/src/custom.rs
@@ -409,7 +409,7 @@ fn default_close_modal_bindings() -> Vec<KeyBinding> {
 }
 
 fn default_exit_bindings() -> Vec<KeyBinding> {
-    make_keybindings(["<c-c>"])
+    make_keybindings(["<c-c>", "q"])
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Hello!

This PR adds `q` to the list of exit commands---`q` is a common key used by many programs to exit such as:
- less
- man pages
- vim/neovim
- top/htop/btop
- lookatme
- lazygit
- etc.

This allows both `<c-c>` (the SIGINT signal) and `q` (the common exit key) to exit `presenterm`.

Thanks!