### PR TITLE
feat: prepend and append file content into codeblock

### DIFF
--- a/src/demo.rs
+++ b/src/demo.rs
@@ -53,7 +53,7 @@ impl<W: TerminalWrite> ThemesDemo<W> {
     pub fn run(mut self) -> Result<(), Box<dyn std::error::Error>> {
         let arena = Default::default();
         let parser = MarkdownParser::new(&arena);
-        let elements = parser.parse(PRESENTATION).expect("broken demo presentation");
+        let elements = parser.parse(PRESENTATION, &mut Resources::default()).expect("broken demo presentation");
         let mut presentations = Vec::new();
         for theme_name in self.themes.presentation.theme_names() {
             let theme = self.themes.presentation.load_by_name(&theme_name).expect("theme not found");
@@ -136,6 +136,6 @@ mod test {
     fn demo_presentation() {
         let arena = Default::default();
         let parser = MarkdownParser::new(&arena);
-        parser.parse(PRESENTATION).expect("broken demo presentation");
+        parser.parse(PRESENTATION, &mut Resources::default()).expect("broken demo presentation");
     }
 }

--- a/src/export.rs
+++ b/src/export.rs
@@ -81,12 +81,16 @@ impl<'a> Exporter<'a> {
             Err(e) => return Err(e.into()),
         };
         let version = Version::parse(version.trim()).map_err(|_| ExportError::MinimumVersion)?;
-        if version >= MINIMUM_EXPORTER_VERSION { Ok(()) } else { Err(ExportError::MinimumVersion) }
+        if version >= MINIMUM_EXPORTER_VERSION {
+            Ok(())
+        } else {
+            Err(ExportError::MinimumVersion)
+        }
     }
 
     /// Extract the metadata necessary to make an export.
     fn extract_metadata(&mut self, content: &str, path: &Path) -> Result<ExportMetadata, ExportError> {
-        let elements = self.parser.parse(content)?;
+        let elements = self.parser.parse(content, &mut self.resources)?;
         let path = path.canonicalize().expect("canonicalize");
         let mut presentation = PresentationBuilder::new(
             self.default_theme,

--- a/src/markdown/elements.rs
+++ b/src/markdown/elements.rs
@@ -373,6 +373,20 @@ pub(crate) struct SnippetAttributes {
     ///
     /// Only valid for +render snippets.
     pub(crate) width: Option<Percent>,
+
+    /// File for prepending content
+    pub(crate) prepend_file: Option<FileContentAttributes>,
+
+    /// File for appending content
+    pub(crate) append_file: Option<FileContentAttributes>,
+}
+
+/// Options for adding file contents to code snippets.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FileContentAttributes {
+    pub(crate) path: PathBuf,
+    pub(crate) start_line: Option<usize>,
+    pub(crate) end_line: Option<usize>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -312,7 +312,7 @@ impl<'a> Presenter<'a> {
 
     fn load_presentation(&mut self, path: &Path) -> Result<Presentation, LoadPresentationError> {
         let content = fs::read_to_string(path).map_err(LoadPresentationError::Reading)?;
-        let elements = self.parser.parse(&content)?;
+        let elements = self.parser.parse(&content, &mut self.resources)?;
         let export_mode = matches!(self.options.mode, PresentMode::Export);
         let mut presentation = PresentationBuilder::new(
             self.default_theme,


### PR DESCRIPTION
Fixes ~~#326~~, #307 

This PR adds 2 new codeblock attributes.
- `+prepend_file(file)`
- `+append_file(file)`

Optionally to both you can add a start and/or end line index like so: `+prepend_file(./foo.txt,2,5)` or  `+prepend_file(./foo.txt,,5)`

This is compatible with all other attributes, so you can add `+line_numbers` and `+exec` as you're used to.

This currently uses the resources system, so file changes won't cause the presentation to update, as they are cached.

## TODO/TBD

- [ ] TBD if this format of attributes is ok, maybe something more similar to line_numbers is prefered
- [ ] Parsing might fail if file paths contain ','