### PR TITLE
feat: always show snippet execution bar

### DIFF
--- a/src/theme.rs
+++ b/src/theme.rs
@@ -528,6 +528,10 @@ pub(crate) struct ExecutionStatusBlockStyle {
     /// The colors for the "finished with error" status.
     #[serde(default)]
     pub(crate) failure: Colors,
+
+    /// The colors for the "not started" status.
+    #[serde(default)]
+    pub(crate) not_started: Colors,
 }
 
 /// The style for inline code.

--- a/themes/catppuccin-frappe.yaml
+++ b/themes/catppuccin-frappe.yaml
@@ -35,6 +35,8 @@ execution_output:
       foreground: "a6d189"
     failure:
       foreground: "e78284"
+    not_started:
+      foreground: "e5c890"
 
 inline_code:
   colors:

--- a/themes/catppuccin-latte.yaml
+++ b/themes/catppuccin-latte.yaml
@@ -35,6 +35,8 @@ execution_output:
       foreground: "40a02b"
     failure:
       foreground: "d20f39"
+    not_started:
+      foreground: "df8e1d"
 
 inline_code:
   colors:

--- a/themes/catppuccin-macchiato.yaml
+++ b/themes/catppuccin-macchiato.yaml
@@ -35,6 +35,8 @@ execution_output:
       foreground: "a6da95"
     failure:
       foreground: "ed8796"
+    not_started:
+      foreground: "eed49f"
 
 inline_code:
   colors:

--- a/themes/catppuccin-mocha.yaml
+++ b/themes/catppuccin-mocha.yaml
@@ -35,6 +35,8 @@ execution_output:
       foreground: "a6e3a1"
     failure:
       foreground: "f38ba8"
+    not_started:
+      foreground: "f9e2af"
 
 inline_code:
   colors:

--- a/themes/dark.yaml
+++ b/themes/dark.yaml
@@ -35,6 +35,8 @@ execution_output:
       foreground: "a8df8e"
     failure:
       foreground: "f78ca2"
+    not_started:
+      foreground: "ee9322"
 
 inline_code:
   colors:

--- a/themes/light.yaml
+++ b/themes/light.yaml
@@ -35,6 +35,8 @@ execution_output:
       foreground: "52b788"
     failure:
       foreground: "f07167"
+    not_started:
+      foreground: "f77f00"
 
 inline_code:
   colors:

--- a/themes/terminal-dark.yaml
+++ b/themes/terminal-dark.yaml
@@ -34,6 +34,8 @@ execution_output:
       foreground: "green"
     failure:
       foreground: "red"
+    not_started:
+      foreground: "yellow"
 
 inline_code:
   colors:

--- a/themes/terminal-light.yaml
+++ b/themes/terminal-light.yaml
@@ -29,11 +29,13 @@ execution_output:
     background: grey
   status:
     running:
-      foreground: "dark_blue"
+      foreground: dark_blue
     success:
-      foreground: "dark_green"
+      foreground: dark_green
     failure:
-      foreground: "dark_red"
+      foreground: dark_red
+    not_started:
+      foreground: dark_yellow
 
 inline_code:
   colors:

--- a/themes/tokyonight-storm.yaml
+++ b/themes/tokyonight-storm.yaml
@@ -35,6 +35,8 @@ execution_output:
       foreground: "9ece6a"
     failure:
       foreground: "f7768e"
+    not_started:
+      foreground: "e0af68"
 
 inline_code:
   colors:


### PR DESCRIPTION
This makes it so that executable snippets always have the status bar shown, which serves as an indication that a code snippet is executable.

Fixes #278