### PR TITLE
feat: allow snippets to be executed and replaced with output

### DIFF
--- a/config-file-schema.json
+++ b/config-file-schema.json
@@ -322,6 +322,14 @@
             }
           ]
         },
+        "exec_replace": {
+          "description": "The properties for snippet execution.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SnippetExecReplaceConfig"
+            }
+          ]
+        },
         "render": {
           "description": "The properties for snippet auto rendering.",
           "allOf": [
@@ -348,6 +356,19 @@
         },
         "enable": {
           "description": "Whether to enable snippet execution.",
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "SnippetExecReplaceConfig": {
+      "type": "object",
+      "required": [
+        "enable"
+      ],
+      "properties": {
+        "enable": {
+          "description": "Whether to enable snippet replace-executions, which automatically run code snippets without the user's intervention.",
           "type": "boolean"
         }
       },

--- a/src/custom.rs
+++ b/src/custom.rs
@@ -132,6 +132,10 @@ pub struct SnippetConfig {
     #[serde(default)]
     pub exec: SnippetExecConfig,
 
+    /// The properties for snippet execution.
+    #[serde(default)]
+    pub exec_replace: SnippetExecReplaceConfig,
+
     /// The properties for snippet auto rendering.
     #[serde(default)]
     pub render: SnippetRenderConfig,
@@ -146,6 +150,14 @@ pub struct SnippetExecConfig {
     /// Custom snippet executors.
     #[serde(default)]
     pub custom: BTreeMap<SnippetLanguage, LanguageSnippetExecutionConfig>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct SnippetExecReplaceConfig {
+    /// Whether to enable snippet replace-executions, which automatically run code snippets without
+    /// the user's intervention.
+    pub enable: bool,
 }
 
 #[derive(Clone, Debug, Deserialize, JsonSchema)]

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -56,7 +56,7 @@ impl SnippetExecutor {
 
     /// Execute a piece of code.
     pub(crate) fn execute(&self, code: &Snippet) -> Result<ExecutionHandle, CodeExecuteError> {
-        if !code.attributes.execute {
+        if !code.attributes.execute && !code.attributes.execute_replace {
             return Err(CodeExecuteError::NotExecutableCode);
         }
         let Some(config) = self.executors.get(&code.language) else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,6 +69,10 @@ struct Cli {
     #[clap(short = 'x', long)]
     enable_snippet_execution: bool,
 
+    /// Enable code snippet auto execution via `+exec_replace` blocks.
+    #[clap(short = 'X', long)]
+    enable_snippet_execution_replace: bool,
+
     /// The path to the configuration file.
     #[clap(short, long)]
     config_file: Option<String>,
@@ -145,6 +149,7 @@ fn make_builder_options(config: &Config, mode: &PresentMode, force_default_theme
         print_modal_background: false,
         strict_front_matter_parsing: config.options.strict_front_matter_parsing.unwrap_or(true),
         enable_snippet_execution: config.snippet.exec.enable,
+        enable_snippet_execution_replace: config.snippet.exec_replace.enable,
     }
 }
 
@@ -221,6 +226,9 @@ fn run(mut cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
     let mut options = make_builder_options(&config, &mode, force_default_theme);
     if cli.enable_snippet_execution {
         options.enable_snippet_execution = true;
+    }
+    if cli.enable_snippet_execution_replace {
+        options.enable_snippet_execution_replace = true;
     }
     let graphics_mode = select_graphics_mode(&cli, &config);
     let printer = Arc::new(ImagePrinter::new(graphics_mode.clone())?);

--- a/src/processing/code.rs
+++ b/src/processing/code.rs
@@ -232,6 +232,7 @@ impl CodeBlockParser {
             match attribute {
                 Attribute::LineNumbers => attributes.line_numbers = true,
                 Attribute::Exec => attributes.execute = true,
+                Attribute::ExecReplace => attributes.execute_replace = true,
                 Attribute::AutoRender => attributes.auto_render = true,
                 Attribute::HighlightedLines(lines) => attributes.highlight_groups = lines,
                 Attribute::Width(width) => attributes.width = Some(width),
@@ -253,6 +254,7 @@ impl CodeBlockParser {
                 let attribute = match token {
                     "line_numbers" => Attribute::LineNumbers,
                     "exec" => Attribute::Exec,
+                    "exec_replace" => Attribute::ExecReplace,
                     "render" => Attribute::AutoRender,
                     token if token.starts_with("width:") => {
                         let value = input.split_once("+width:").unwrap().1;
@@ -364,6 +366,7 @@ pub enum CodeBlockParseError {
 enum Attribute {
     LineNumbers,
     Exec,
+    ExecReplace,
     AutoRender,
     HighlightedLines(Vec<HighlightGroup>),
     Width(Percent),
@@ -550,6 +553,10 @@ impl FromStr for SnippetLanguage {
 pub(crate) struct SnippetAttributes {
     /// Whether the snippet is marked as executable.
     pub(crate) execute: bool,
+
+    /// Whether the snippet is marked as an executable block that will be replaced with the output
+    /// of its execution.
+    pub(crate) execute_replace: bool,
 
     /// Whether a snippet is marked to be auto rendered.
     ///


### PR DESCRIPTION
This adds the `+exec_replace` attribute that is basically an `+exec` except the output of the snippet's execution replaces the snippet itself. This allows using tools that emit ascii art, colorize outputs, etc.

I added a new set of configs to enable this (`-X` as a cli parameter and `snippet.exec_replace.enable` in the config file) as this adds a whole other level of danger when running someone else's presentation so I don't think the configs for `exec` are enough to protect users.

Fixes #292