### PR TITLE
feat: move hidden line prefix into executors file

### DIFF
--- a/config-file-schema.json
+++ b/config-file-schema.json
@@ -247,6 +247,13 @@
         "filename": {
           "description": "The filename to use for the snippet input file.",
           "type": "string"
+        },
+        "hidden_line_prefix": {
+          "description": "The prefix to use to hide lines visually but still execute them.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       }
     },

--- a/executors.yaml
+++ b/executors.yaml
@@ -3,38 +3,46 @@ bash:
   filename: script.sh
   commands:
     - ["bash", "$pwd/script.sh"]
+  hidden_line_prefix: "/// "
 c++:
   filename: snippet.cpp
   commands:
     - ["g++", "-std=c++20", "$pwd/snippet.cpp", "-o", "$pwd/snippet"]
     - ["$pwd/snippet"]
+  hidden_line_prefix: "/// "
 c:
   filename: snippet.c
   commands:
     - ["gcc", "$pwd/snippet.c", "-o", "$pwd/snippet"]
     - ["$pwd/snippet"]
+  hidden_line_prefix: "/// "
 fish:
   filename: script.fish
   commands:
     - ["fish", "$pwd/script.fish"]
+  hidden_line_prefix: "/// "
 go:
   filename: snippet.go
   environment:
     GO11MODULE: off
   commands:
     - ["go", "run", "$pwd/snippet.go"]
+  hidden_line_prefix: "/// "
 java:
   filename: Snippet.java
   commands:
     - ["java", "$pwd/Snippet.java"]
+  hidden_line_prefix: "/// "
 js:
   filename: snippet.js
   commands:
     - ["node", "$pwd/snippet.js"]
+  hidden_line_prefix: "/// "
 kotlin:
   filename: snippet.kts
   commands:
     - ["kotlinc", "-script", "$pwd/script.kts"]
+  hidden_line_prefix: "/// "
 lua:
   filename: snippet.lua
   commands:
@@ -51,10 +59,12 @@ php:
   filename: snippet.php
   commands:
     - ["php", "-f", "$pwd/snippet.php"]
+  hidden_line_prefix: "/// "
 python:
   filename: snippet.py
   commands:
     - ["python", "-u", "$pwd/snippet.py"]
+  hidden_line_prefix: "/// "
 ruby:
   filename: snippet.rb
   commands:
@@ -63,16 +73,20 @@ rust-script:
   filename: snippet.rs
   commands:
     - ["rust-script", "$pwd/snippet.rs"]
+  hidden_line_prefix: "# "
 rust:
   filename: snippet.rs
   commands:
     - ["rustc", "--crate-name", "presenterm_snippet", "$pwd/snippet.rs", "-o", "$pwd/snippet"]
     - ["$pwd/snippet"]
+  hidden_line_prefix: "# "
 sh:
   filename: script.sh
   commands:
     - ["sh", "$pwd/script.sh"]
+  hidden_line_prefix: "/// "
 zsh:
   filename: script.sh
   commands:
     - ["zsh", "$pwd/script.sh"]
+  hidden_line_prefix: "/// "

--- a/src/custom.rs
+++ b/src/custom.rs
@@ -226,6 +226,9 @@ pub struct LanguageSnippetExecutionConfig {
 
     /// The commands to be run when executing snippets for this programming language.
     pub commands: Vec<Vec<String>>,
+
+    /// The prefix to use to hide lines visually but still execute them.
+    pub hidden_line_prefix: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, ValueEnum, JsonSchema)]

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -62,7 +62,12 @@ impl SnippetExecutor {
         let Some(config) = self.executors.get(&code.language) else {
             return Err(CodeExecuteError::UnsupportedExecution);
         };
-        Self::execute_lang(config, code.executable_contents().as_bytes(), &self.cwd)
+        let hide_prefix = config.hidden_line_prefix.as_deref();
+        Self::execute_lang(config, code.executable_contents(hide_prefix).as_bytes(), &self.cwd)
+    }
+
+    pub(crate) fn hidden_line_prefix(&self, language: &SnippetLanguage) -> Option<&str> {
+        self.executors.get(language).and_then(|lang| lang.hidden_line_prefix.as_deref())
     }
 
     fn execute_lang(

--- a/src/processing/builder.rs
+++ b/src/processing/builder.rs
@@ -731,7 +731,8 @@ impl<'a> PresentationBuilder<'a> {
         } else if snippet.attributes.execute_replace && self.options.enable_snippet_execution_replace {
             return self.push_code_execution(snippet, 0, ExecutionMode::ReplaceSnippet);
         }
-        let lines = CodePreparer::new(&self.theme).prepare(&snippet);
+        let lines =
+            CodePreparer::new(&self.theme, self.code_executor.hidden_line_prefix(&snippet.language)).prepare(&snippet);
         let block_length = lines.iter().map(|line| line.width()).max().unwrap_or(0);
         let (lines, context) = self.highlight_lines(&snippet, lines, block_length);
         for line in lines {


### PR DESCRIPTION
This moves the hidden line prefix into the executors file. This allows making this more explicit and harder to miss, and also allows custom executors in config files to define this without having to touch the code.

Fixes #313