### PR TITLE
feat: add template variables

### DIFF
--- a/src/processing/builder.rs
+++ b/src/processing/builder.rs
@@ -290,7 +290,17 @@ impl<'a> PresentationBuilder<'a> {
         if let Some(options) = metadata.options.take() {
             self.options.merge(options);
         }
-        self.footer_context.borrow_mut().author = metadata.author.clone().unwrap_or_default();
+
+        {
+            let mut footer_context = self.footer_context.borrow_mut();
+            footer_context.title = metadata.title.clone().unwrap_or_default();
+            footer_context.sub_title = metadata.sub_title.clone().unwrap_or_default();
+            footer_context.location = metadata.location.clone().unwrap_or_default();
+            footer_context.event = metadata.event.clone().unwrap_or_default();
+            footer_context.date = metadata.date.clone().unwrap_or_default();
+            footer_context.author = metadata.author.clone().unwrap_or_default();
+        }
+
         self.set_theme(&metadata.theme)?;
         if metadata.has_frontmatter() {
             self.push_slide_prelude();

--- a/src/processing/footer.rs
+++ b/src/processing/footer.rs
@@ -12,6 +12,11 @@ use unicode_width::UnicodeWidthStr;
 pub(crate) struct FooterContext {
     pub(crate) total_slides: usize,
     pub(crate) author: String,
+    pub(crate) title: String,
+    pub(crate) sub_title: String,
+    pub(crate) event: String,
+    pub(crate) location: String,
+    pub(crate) date: String,
 }
 
 #[derive(Debug)]
@@ -32,6 +37,11 @@ impl FooterGenerator {
         let contents = template
             .replace("{current_slide}", current_slide)
             .replace("{total_slides}", &context.total_slides.to_string())
+            .replace("{title}", &context.title)
+            .replace("{sub_title}", &context.sub_title)
+            .replace("{event}", &context.event)
+            .replace("{location}", &context.location)
+            .replace("{date}", &context.date)
             .replace("{author}", &context.author);
         let text = Text::new(contents, TextStyle::default().colors(colors));
         RenderOperation::RenderText { line: vec![text].into(), alignment }


### PR DESCRIPTION
Hello!

This PR adds some more variables that can be used in the footer template (basically everything available in the slide metadata):
- `{title}`
- `{sub_title}`
- `{location}`
- `{event}`
- `{date}`

There may be a better way of including all the metadata in the FooterContext without having to repeat all the definitions?

#### Default Template

I tried to add a default footer template, but I couldn't seem to decouple the footer template itself from the `template` style.

The following template is very common in presentations and I think it would make a great default:

```yaml
left: "{author}"
center: "{title}" # this can also be a short title
right: "{current_slide} / {total_slides}"
```

Ideally, I would like to just be able to set the style to `template` and have the default template used:
```yaml
theme:
  override:
    footer:
      style: template
```

However, it seems I must manually define the template for all of my slides

Thanks!