### PR TITLE
feat: hide footer on intro slide by default

### DIFF
--- a/themes/catppuccin-frappe.yaml
+++ b/themes/catppuccin-frappe.yaml
@@ -68,6 +68,7 @@ intro_slide:
     colors:
       foreground: "b5bfe2"
     positioning: page_bottom
+  footer: false
 
 headings:
   h1:

--- a/themes/catppuccin-latte.yaml
+++ b/themes/catppuccin-latte.yaml
@@ -68,6 +68,7 @@ intro_slide:
     colors:
       foreground: "5c5f77"
     positioning: page_bottom
+  footer: false
 
 headings:
   h1:

--- a/themes/catppuccin-macchiato.yaml
+++ b/themes/catppuccin-macchiato.yaml
@@ -68,6 +68,7 @@ intro_slide:
     colors:
       foreground: "b8c0e0"
     positioning: page_bottom
+  footer: false
 
 headings:
   h1:

--- a/themes/catppuccin-mocha.yaml
+++ b/themes/catppuccin-mocha.yaml
@@ -68,6 +68,7 @@ intro_slide:
     colors:
       foreground: "bac2de"
     positioning: page_bottom
+  footer: false
 
 headings:
   h1:

--- a/themes/dark.yaml
+++ b/themes/dark.yaml
@@ -69,6 +69,7 @@ intro_slide:
     colors:
       foreground: "b6eada"
     positioning: page_bottom
+  footer: false
 
 headings:
   h1:

--- a/themes/light.yaml
+++ b/themes/light.yaml
@@ -69,6 +69,7 @@ intro_slide:
     colors:
       foreground: "4a4e69"
     positioning: page_bottom
+  footer: false
 
 headings:
   h1:

--- a/themes/terminal-dark.yaml
+++ b/themes/terminal-dark.yaml
@@ -67,6 +67,7 @@ intro_slide:
     colors:
       foreground: white
     positioning: page_bottom
+  footer: false
 
 headings:
   h1:

--- a/themes/terminal-light.yaml
+++ b/themes/terminal-light.yaml
@@ -67,6 +67,7 @@ intro_slide:
     colors:
       foreground: black
     positioning: page_bottom
+  footer: false
 
 headings:
   h1:

--- a/themes/tokyonight-storm.yaml
+++ b/themes/tokyonight-storm.yaml
@@ -69,6 +69,7 @@ intro_slide:
     colors:
       foreground: "9ece6a"
     positioning: page_bottom
+  footer: false
 
 headings:
   h1:


### PR DESCRIPTION
Hello!

This PR hides the footer on the intro slide by default which is fairly common in presentations and I think it would make a great default.

If you think differently then feel free to close :).

Note: maybe there's a better way of making this the default in the code without having to add it to all the themes? 

Thanks!