### PR TITLE
feat: style markdown inside block quotes properly

### DIFF
--- a/src/markdown/elements.rs
+++ b/src/markdown/elements.rs
@@ -49,8 +49,8 @@ pub(crate) enum MarkdownElement {
     /// An HTML comment.
     Comment { comment: String, source_position: SourcePosition },
 
-    /// A quote.
-    BlockQuote(Vec<String>),
+    /// A block quote containing a list of lines.
+    BlockQuote(Vec<TextBlock>),
 }
 
 #[derive(Clone, Debug, Default)]

--- a/src/markdown/elements.rs
+++ b/src/markdown/elements.rs
@@ -17,8 +17,8 @@ pub(crate) enum MarkdownElement {
     /// A normal heading.
     Heading { level: u8, text: TextBlock },
 
-    /// A paragraph, composed of text and line breaks.
-    Paragraph(Vec<ParagraphElement>),
+    /// A paragraph composed by a list of lines.
+    Paragraph(Vec<TextBlock>),
 
     /// An image.
     Image { path: PathBuf, title: String, source_position: SourcePosition },
@@ -82,20 +82,6 @@ impl From<comrak::nodes::LineColumn> for LineColumn {
     fn from(position: comrak::nodes::LineColumn) -> Self {
         Self { line: position.line, column: position.column }
     }
-}
-
-/// The components that make up a paragraph.
-///
-/// This does not map one-to-one with the commonmark spec and only handles text (including its
-/// style) and line breaks. Any other inlines that could show up on a paragraph, such as images,
-/// are a [MarkdownElement] on their own.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) enum ParagraphElement {
-    /// A block of text.
-    Text(TextBlock),
-
-    /// A line break.
-    LineBreak,
 }
 
 /// A block of text.

--- a/src/markdown/parse.rs
+++ b/src/markdown/parse.rs
@@ -1,6 +1,6 @@
 use super::elements::SourcePosition;
 use crate::{
-    markdown::elements::{ListItem, ListItemType, MarkdownElement, ParagraphElement, Table, TableRow, Text, TextBlock},
+    markdown::elements::{ListItem, ListItemType, MarkdownElement, Table, TableRow, Text, TextBlock},
     style::TextStyle,
 };
 use comrak::{
@@ -186,8 +186,8 @@ impl<'a> MarkdownParser<'a> {
         let mut paragraph_elements = Vec::new();
         for inline in inlines {
             match inline {
-                Inline::Text(text) => paragraph_elements.push(ParagraphElement::Text(text)),
-                Inline::LineBreak => paragraph_elements.push(ParagraphElement::LineBreak),
+                Inline::Text(text) => paragraph_elements.push(text),
+                Inline::LineBreak => (),
                 Inline::Image { path, title } => {
                     if !paragraph_elements.is_empty() {
                         elements.push(MarkdownElement::Paragraph(mem::take(&mut paragraph_elements)));
@@ -575,7 +575,7 @@ boop
             Text::new("strikethrough", TextStyle::default().strikethrough()),
         ];
 
-        let expected_elements = &[ParagraphElement::Text(TextBlock(expected_chunks))];
+        let expected_elements = &[TextBlock(expected_chunks)];
         assert_eq!(elements, expected_elements);
     }
 
@@ -586,7 +586,7 @@ boop
         let expected_chunks =
             vec![Text::from("my "), Text::new("https://example.com", TextStyle::default().link_url())];
 
-        let expected_elements = &[ParagraphElement::Text(TextBlock(expected_chunks))];
+        let expected_elements = &[TextBlock(expected_chunks)];
         assert_eq!(elements, expected_elements);
     }
 
@@ -602,7 +602,7 @@ boop
             Text::from(")"),
         ];
 
-        let expected_elements = &[ParagraphElement::Text(TextBlock(expected_chunks))];
+        let expected_elements = &[TextBlock(expected_chunks)];
         assert_eq!(elements, expected_elements);
     }
 
@@ -618,7 +618,7 @@ boop
             Text::from("\""),
         ];
 
-        let expected_elements = &[ParagraphElement::Text(TextBlock(expected_chunks))];
+        let expected_elements = &[TextBlock(expected_chunks)];
         assert_eq!(elements, expected_elements);
     }
 
@@ -637,7 +637,7 @@ boop
             Text::from(")"),
         ];
 
-        let expected_elements = &[ParagraphElement::Text(TextBlock(expected_chunks))];
+        let expected_elements = &[TextBlock(expected_chunks)];
         assert_eq!(elements, expected_elements);
     }
 
@@ -715,13 +715,11 @@ another",
         assert_eq!(parsed.len(), 2);
 
         let MarkdownElement::Paragraph(elements) = &parsed[0] else { panic!("not a line break: {parsed:?}") };
-        assert_eq!(elements.len(), 3);
+        assert_eq!(elements.len(), 2);
 
         let expected_chunks = &[Text::from("some text"), Text::from(" "), Text::from("with line breaks")];
-        let ParagraphElement::Text(text) = &elements[0] else { panic!("non-text in paragraph") };
+        let text = &elements[0];
         assert_eq!(text.0, expected_chunks);
-        assert!(matches!(&elements[1], ParagraphElement::LineBreak));
-        assert!(matches!(&elements[2], ParagraphElement::Text(_)));
     }
 
     #[test]
@@ -745,7 +743,7 @@ let q = 42;
         let expected_chunks = &[Text::from("some "), Text::new("inline code", TextStyle::default().code())];
         assert_eq!(elements.len(), 1);
 
-        let ParagraphElement::Text(text) = &elements[0] else { panic!("non-text in paragraph") };
+        let text = &elements[0];
         assert_eq!(text.0, expected_chunks);
     }
 

--- a/src/processing/builder.rs
+++ b/src/processing/builder.rs
@@ -8,8 +8,8 @@ use crate::{
     execute::SnippetExecutor,
     markdown::{
         elements::{
-            ListItem, ListItemType, MarkdownElement, ParagraphElement, Percent, PercentParseError, SourcePosition,
-            Table, TableRow, Text, TextBlock,
+            ListItem, ListItemType, MarkdownElement, Percent, PercentParseError, SourcePosition, Table, TableRow, Text,
+            TextBlock,
         },
         text::WeightedTextBlock,
     },
@@ -553,17 +553,10 @@ impl<'a> PresentationBuilder<'a> {
         self.push_line_break();
     }
 
-    fn push_paragraph(&mut self, elements: Vec<ParagraphElement>) -> Result<(), BuildError> {
-        for element in elements {
-            match element {
-                ParagraphElement::Text(text) => {
-                    self.push_text(text, ElementType::Paragraph);
-                    self.push_line_break();
-                }
-                ParagraphElement::LineBreak => {
-                    // Line breaks are already pushed after every text chunk.
-                }
-            };
+    fn push_paragraph(&mut self, lines: Vec<TextBlock>) -> Result<(), BuildError> {
+        for text in lines {
+            self.push_text(text, ElementType::Paragraph);
+            self.push_line_break();
         }
         Ok(())
     }
@@ -1652,7 +1645,7 @@ mod test {
         let elements = vec![
             MarkdownElement::Paragraph(vec![]),
             MarkdownElement::ThematicBreak,
-            MarkdownElement::Paragraph(vec![ParagraphElement::Text("hi".into())]),
+            MarkdownElement::Paragraph(vec!["hi".into()]),
         ];
         let presentation = build_presentation_with_options(elements, options);
         assert_eq!(presentation.iter_slides().count(), 2);


### PR DESCRIPTION
This adds proper styling (bold, italics, etc) to block quotes.

Fixes #341