### PR TITLE
fix: add padding to right of code block wrapped lines

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -152,6 +152,7 @@ mod test {
     #[case(RenderOperation::RenderBlockLine(
         BlockLine{
             prefix: "".into(),
+            right_padding_length: 0,
             repeat_prefix_on_wrap: false,
             text: WeightedTextBlock::from("".to_string()),
             alignment: Default::default(),

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -555,6 +555,7 @@ pub(crate) struct PresentationThemeMetadata {
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct BlockLine {
     pub(crate) prefix: WeightedText,
+    pub(crate) right_padding_length: u16,
     pub(crate) repeat_prefix_on_wrap: bool,
     pub(crate) text: WeightedTextBlock,
     pub(crate) block_length: u16,

--- a/src/processing/builder.rs
+++ b/src/processing/builder.rs
@@ -679,6 +679,7 @@ impl<'a> PresentationBuilder<'a> {
             }
             self.chunk_operations.push(RenderOperation::RenderBlockLine(BlockLine {
                 prefix: prefix.clone().into(),
+                right_padding_length: 0,
                 repeat_prefix_on_wrap: true,
                 text: line.into(),
                 block_length,
@@ -835,12 +836,13 @@ impl<'a> PresentationBuilder<'a> {
         let block_style = &self.theme.code;
         for line in lines.into_iter() {
             let prefix = line.dim_prefix(&dim_style);
-            let highlighted = line.highlight(&dim_style, &mut code_highlighter, block_style);
+            let highlighted = line.highlight(&mut code_highlighter, block_style);
             let not_highlighted = line.dim(&dim_style);
             let line_number = line.line_number;
             let context = context.clone();
             output.push(HighlightedLine {
                 prefix,
+                right_padding_length: line.right_padding_length,
                 highlighted,
                 not_highlighted,
                 line_number,

--- a/src/processing/execution.rs
+++ b/src/processing/execution.rs
@@ -112,6 +112,7 @@ impl AsRenderOperations for RunSnippetOperation {
         for line in &inner.output_lines {
             operations.push(RenderOperation::RenderBlockLine(BlockLine {
                 prefix: "".into(),
+                right_padding_length: 0,
                 repeat_prefix_on_wrap: false,
                 text: line.clone(),
                 block_length,

--- a/src/processing/separator.rs
+++ b/src/processing/separator.rs
@@ -65,6 +65,7 @@ impl AsRenderOperations for RenderSeparator {
         };
         vec![RenderOperation::RenderBlockLine(BlockLine {
             prefix: "".into(),
+            right_padding_length: 0,
             repeat_prefix_on_wrap: false,
             text: separator.into(),
             block_length: width as u16,

--- a/src/render/engine.rs
+++ b/src/render/engine.rs
@@ -161,7 +161,7 @@ where
         let dimensions = self.current_dimensions();
         let positioning = layout.compute(dimensions, text.width() as u16);
         let prefix = "".into();
-        let text_drawer = TextDrawer::new(&prefix, text, positioning, &self.colors)?;
+        let text_drawer = TextDrawer::new(&prefix, 0, text, positioning, &self.colors)?;
         text_drawer.draw(self.terminal)
     }
 
@@ -208,7 +208,15 @@ where
     }
 
     fn render_block_line(&mut self, operation: &BlockLine) -> RenderResult {
-        let BlockLine { text, block_length, alignment, block_color, prefix, repeat_prefix_on_wrap } = operation;
+        let BlockLine {
+            text,
+            block_length,
+            alignment,
+            block_color,
+            prefix,
+            right_padding_length,
+            repeat_prefix_on_wrap,
+        } = operation;
         let layout = self.build_layout(alignment.clone());
 
         let dimensions = self.current_dimensions();
@@ -220,7 +228,7 @@ where
         self.terminal.move_to_column(start_column)?;
 
         let positioning = Positioning { max_line_length, start_column };
-        let text_drawer = TextDrawer::new(prefix, text, positioning, &self.colors)?
+        let text_drawer = TextDrawer::new(prefix, *right_padding_length, text, positioning, &self.colors)?
             .with_surrounding_block(*block_color)
             .repeat_prefix_on_wrap(*repeat_prefix_on_wrap);
         text_drawer.draw(self.terminal)?;


### PR DESCRIPTION
This fixes a styling issue leftover from #320 where there was no padding being applied to the right of wrapped code block lines.