### PR TITLE
feat!: use "template" footer in built-in themes

### DIFF
--- a/src/theme.rs
+++ b/src/theme.rs
@@ -474,12 +474,7 @@ pub(crate) enum FooterStyle {
 
 impl Default for FooterStyle {
     fn default() -> Self {
-        Self::Template {
-            left: Some("{current_slide} / {total_slides}".to_string()),
-            center: None,
-            right: None,
-            colors: Colors::default(),
-        }
+        Self::Template { left: None, center: None, right: None, colors: Colors::default() }
     }
 }
 

--- a/themes/catppuccin-frappe.yaml
+++ b/themes/catppuccin-frappe.yaml
@@ -68,6 +68,7 @@ intro_slide:
     colors:
       foreground: "b5bfe2"
     positioning: page_bottom
+  footer: false
 
 headings:
   h1:
@@ -108,9 +109,8 @@ typst:
     background: "414559"
 
 footer:
-  style: progress_bar
-  colors:
-    background: "8caaee"
+  style: template
+  right: "{current_slide} / {total_slides}"
 
 modals:
   selection_colors:

--- a/themes/catppuccin-latte.yaml
+++ b/themes/catppuccin-latte.yaml
@@ -68,6 +68,7 @@ intro_slide:
     colors:
       foreground: "5c5f77"
     positioning: page_bottom
+  footer: false
 
 headings:
   h1:
@@ -108,9 +109,8 @@ typst:
     background: "ccd0da"
 
 footer:
-  style: progress_bar
-  colors:
-    background: "1e66f5"
+  style: template
+  right: "{current_slide} / {total_slides}"
 
 modals:
   selection_colors:

--- a/themes/catppuccin-macchiato.yaml
+++ b/themes/catppuccin-macchiato.yaml
@@ -68,6 +68,7 @@ intro_slide:
     colors:
       foreground: "b8c0e0"
     positioning: page_bottom
+  footer: false
 
 headings:
   h1:
@@ -108,9 +109,8 @@ typst:
     background: "363a4f"
 
 footer:
-  style: progress_bar
-  colors:
-    background: "8aadf4"
+  style: template
+  right: "{current_slide} / {total_slides}"
 
 modals:
   selection_colors:

--- a/themes/catppuccin-mocha.yaml
+++ b/themes/catppuccin-mocha.yaml
@@ -68,6 +68,7 @@ intro_slide:
     colors:
       foreground: "bac2de"
     positioning: page_bottom
+  footer: false
 
 headings:
   h1:
@@ -108,9 +109,8 @@ typst:
     background: "313244"
 
 footer:
-  style: progress_bar
-  colors:
-    foreground: "89b4fa"
+  style: template
+  right: "{current_slide} / {total_slides}"
 
 modals:
   selection_colors:

--- a/themes/dark.yaml
+++ b/themes/dark.yaml
@@ -69,6 +69,7 @@ intro_slide:
     colors:
       foreground: "b6eada"
     positioning: page_bottom
+  footer: false
 
 headings:
   h1:
@@ -109,9 +110,8 @@ typst:
     background: "292e42"
 
 footer:
-  style: progress_bar
-  colors:
-    foreground: "7aa2f7"
+  style: template
+  right: "{current_slide} / {total_slides}"
 
 modals:
   selection_colors:

--- a/themes/light.yaml
+++ b/themes/light.yaml
@@ -69,6 +69,7 @@ intro_slide:
     colors:
       foreground: "4a4e69"
     positioning: page_bottom
+  footer: false
 
 headings:
   h1:
@@ -109,9 +110,8 @@ typst:
     background: "e9ecef"
 
 footer:
-  style: progress_bar
-  colors:
-    foreground: "7aa2f7"
+  style: template
+  right: "{current_slide} / {total_slides}"
 
 modals:
   selection_colors:

--- a/themes/terminal-dark.yaml
+++ b/themes/terminal-dark.yaml
@@ -67,6 +67,7 @@ intro_slide:
     colors:
       foreground: white
     positioning: page_bottom
+  footer: false
 
 headings:
   h1:
@@ -107,9 +108,8 @@ typst:
     background: "292e42"
 
 footer:
-  style: progress_bar
-  colors:
-    foreground: blue
+  style: template
+  right: "{current_slide} / {total_slides}"
 
 modals:
   selection_colors:

--- a/themes/terminal-light.yaml
+++ b/themes/terminal-light.yaml
@@ -67,6 +67,7 @@ intro_slide:
     colors:
       foreground: black
     positioning: page_bottom
+  footer: false
 
 headings:
   h1:
@@ -107,9 +108,8 @@ typst:
     background: "e9ecef"
 
 footer:
-  style: progress_bar
-  colors:
-    foreground: dark_blue
+  style: template
+  right: "{current_slide} / {total_slides}"
 
 modals:
   selection_colors:

--- a/themes/tokyonight-storm.yaml
+++ b/themes/tokyonight-storm.yaml
@@ -69,6 +69,7 @@ intro_slide:
     colors:
       foreground: "9ece6a"
     positioning: page_bottom
+  footer: false
 
 headings:
   h1:
@@ -109,9 +110,8 @@ typst:
     background: "545c7e"
 
 footer:
-  style: progress_bar
-  colors:
-    foreground: "7aa2f7"
+  style: template
+  right: "{current_slide} / {total_slides}"
 
 modals:
   selection_colors:


### PR DESCRIPTION
This makes the footer in built in themes be a template with `{current_slide} / {total_slides}` in the right. The progress bar was "cool" but it's not very professional so I don't think it should be the default.

Relates to #339 #357