### PR TITLE
feat: add `+no_margin` to remove margin in code blocks

### DIFF
--- a/src/processing/code.rs
+++ b/src/processing/code.rs
@@ -232,6 +232,7 @@ impl CodeBlockParser {
                 Attribute::Exec => attributes.execute = true,
                 Attribute::ExecReplace => attributes.execute_replace = true,
                 Attribute::AutoRender => attributes.auto_render = true,
+                Attribute::NoMargin => attributes.no_margin = true,
                 Attribute::HighlightedLines(lines) => attributes.highlight_groups = lines,
                 Attribute::Width(width) => attributes.width = Some(width),
             };
@@ -254,6 +255,7 @@ impl CodeBlockParser {
                     "exec" => Attribute::Exec,
                     "exec_replace" => Attribute::ExecReplace,
                     "render" => Attribute::AutoRender,
+                    "no_margin" => Attribute::NoMargin,
                     token if token.starts_with("width:") => {
                         let value = input.split_once("+width:").unwrap().1;
                         let (width, input) = Self::parse_width(value)?;
@@ -368,6 +370,7 @@ enum Attribute {
     AutoRender,
     HighlightedLines(Vec<HighlightGroup>),
     Width(Percent),
+    NoMargin,
 }
 
 /// A code snippet.
@@ -387,7 +390,7 @@ impl Snippet {
     pub(crate) fn visible_lines<'a, 'b>(
         &'a self,
         hidden_line_prefix: Option<&'b str>,
-    ) -> impl Iterator<Item = &str> + 'b
+    ) -> impl Iterator<Item = &'a str> + 'b
     where
         'a: 'b,
     {
@@ -568,6 +571,9 @@ pub(crate) struct SnippetAttributes {
     ///
     /// Only valid for +render snippets.
     pub(crate) width: Option<Percent>,
+
+    /// Whether to add no margin to a snippet.
+    pub(crate) no_margin: bool,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -570,6 +570,10 @@ impl Margin {
             }
         }
     }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        matches!(self, Self::Fixed(0) | Self::Percent(0))
+    }
 }
 
 impl Default for Margin {


### PR DESCRIPTION
This adds a `+no_margin` attribute to code blocks which removes extra margins. For themes that specify a vertical/horizontal padding (like all built in themes), the padding is still present even when using this. This only removes the margin that typically extends a bit right if your code snippet's max line length is too short.

This is especially useful when using `+exec_replace`  so you don't get any extra margin and instead get the executed program's output as-is. For example, the following now looks like this:

~~~markdown
```bash +exec_replace +no_margin
echo "hello world" | qrencode -t utf8
```
~~~

![image](https://github.com/user-attachments/assets/78478b81-0393-4ad8-afa8-ec3e6a59920f)

Fixes #349
