### PR TITLE
feat: allow acquiring terminal when running snippets

### DIFF
--- a/src/processing/builder.rs
+++ b/src/processing/builder.rs
@@ -1,6 +1,6 @@
 use super::{
     code::{CodeBlockParser, CodeLine, ExternalFile, Highlight, HighlightGroup, Snippet, SnippetLanguage},
-    execution::{DisplaySeparator, SnippetExecutionDisabledOperation},
+    execution::{DisplaySeparator, RunAcquireTerminalCodeSnippet, SnippetExecutionDisabledOperation},
     modals::KeyBindingsModalBuilder,
 };
 use crate::{
@@ -877,6 +877,16 @@ impl<'a> PresentationBuilder<'a> {
     ) -> Result<(), BuildError> {
         if !self.code_executor.is_execution_supported(&code.language) {
             return Err(BuildError::UnsupportedExecution(code.language));
+        }
+        if code.attributes.acquire_terminal {
+            let operation = RunAcquireTerminalCodeSnippet::new(
+                code,
+                self.code_executor.clone(),
+                self.theme.execution_output.status.failure,
+            );
+            let operation = RenderOperation::RenderAsync(Rc::new(operation));
+            self.chunk_operations.push(operation);
+            return Ok(());
         }
         let separator = match mode {
             ExecutionMode::AlongSnippet => DisplaySeparator::On,

--- a/src/processing/code.rs
+++ b/src/processing/code.rs
@@ -233,6 +233,7 @@ impl CodeBlockParser {
                 Attribute::ExecReplace => attributes.execute_replace = true,
                 Attribute::AutoRender => attributes.auto_render = true,
                 Attribute::NoMargin => attributes.no_margin = true,
+                Attribute::AcquireTerminal => attributes.acquire_terminal = true,
                 Attribute::HighlightedLines(lines) => attributes.highlight_groups = lines,
                 Attribute::Width(width) => attributes.width = Some(width),
             };
@@ -256,6 +257,7 @@ impl CodeBlockParser {
                     "exec_replace" => Attribute::ExecReplace,
                     "render" => Attribute::AutoRender,
                     "no_margin" => Attribute::NoMargin,
+                    "acquire_terminal" => Attribute::AcquireTerminal,
                     token if token.starts_with("width:") => {
                         let value = input.split_once("+width:").unwrap().1;
                         let (width, input) = Self::parse_width(value)?;
@@ -371,6 +373,7 @@ enum Attribute {
     HighlightedLines(Vec<HighlightGroup>),
     Width(Percent),
     NoMargin,
+    AcquireTerminal,
 }
 
 /// A code snippet.
@@ -574,6 +577,9 @@ pub(crate) struct SnippetAttributes {
 
     /// Whether to add no margin to a snippet.
     pub(crate) no_margin: bool,
+
+    /// Whether this code snippet acquires the terminal when ran.
+    pub(crate) acquire_terminal: bool,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]

--- a/src/render/terminal.rs
+++ b/src/render/terminal.rs
@@ -128,7 +128,7 @@ where
     }
 }
 
-fn should_hide_cursor() -> bool {
+pub(crate) fn should_hide_cursor() -> bool {
     // WezTerm on Windows fails to display images if we've hidden the cursor so we **always** hide it
     // unless we're on WezTerm on Windows.
     let term = std::env::var("TERM_PROGRAM");


### PR DESCRIPTION
This introduces a new `+acquire_terminal` snippet attribute which causes the snippet to take ownership of the terminal while the contents of it are being executed. This means the output won't be displayed inside the presentation but instead the presentation will pause, invoke the code snippet, and resume after the snippet is done. This is useful when running TUIs as otherwise those won't run given the terminal is taken by presenterm already.

Fixes #365