### PR TITLE
feat: add no_background property

### DIFF
--- a/src/processing/builder.rs
+++ b/src/processing/builder.rs
@@ -856,7 +856,7 @@ impl<'a> PresentationBuilder<'a> {
 
     fn code_style(&self, snippet: &Snippet) -> CodeBlockStyle {
         let mut style = self.theme.code.clone();
-        if snippet.attributes.no_margin {
+        if snippet.attributes.no_background {
             style.alignment = match style.alignment {
                 Some(Alignment::Center { .. }) => {
                     Some(Alignment::Center { minimum_size: 0, minimum_margin: Margin::default() })
@@ -865,6 +865,7 @@ impl<'a> PresentationBuilder<'a> {
                 Some(Alignment::Right { .. }) => Some(Alignment::Right { margin: Margin::default() }),
                 None => None,
             };
+            style.background = Some(false);
         }
         style
     }

--- a/src/processing/code.rs
+++ b/src/processing/code.rs
@@ -232,7 +232,7 @@ impl CodeBlockParser {
                 Attribute::Exec => attributes.execute = true,
                 Attribute::ExecReplace => attributes.execute_replace = true,
                 Attribute::AutoRender => attributes.auto_render = true,
-                Attribute::NoMargin => attributes.no_margin = true,
+                Attribute::NoBackground => attributes.no_background = true,
                 Attribute::AcquireTerminal => attributes.acquire_terminal = true,
                 Attribute::HighlightedLines(lines) => attributes.highlight_groups = lines,
                 Attribute::Width(width) => attributes.width = Some(width),
@@ -256,7 +256,7 @@ impl CodeBlockParser {
                     "exec" => Attribute::Exec,
                     "exec_replace" => Attribute::ExecReplace,
                     "render" => Attribute::AutoRender,
-                    "no_margin" => Attribute::NoMargin,
+                    "no_background" => Attribute::NoBackground,
                     "acquire_terminal" => Attribute::AcquireTerminal,
                     token if token.starts_with("width:") => {
                         let value = input.split_once("+width:").unwrap().1;
@@ -372,7 +372,7 @@ enum Attribute {
     AutoRender,
     HighlightedLines(Vec<HighlightGroup>),
     Width(Percent),
-    NoMargin,
+    NoBackground,
     AcquireTerminal,
 }
 
@@ -575,8 +575,8 @@ pub(crate) struct SnippetAttributes {
     /// Only valid for +render snippets.
     pub(crate) width: Option<Percent>,
 
-    /// Whether to add no margin to a snippet.
-    pub(crate) no_margin: bool,
+    /// Whether to add no background to a snippet.
+    pub(crate) no_background: bool,
 
     /// Whether this code snippet acquires the terminal when ran.
     pub(crate) acquire_terminal: bool,

--- a/src/processing/execution.rs
+++ b/src/processing/execution.rs
@@ -27,6 +27,8 @@ use std::{
     rc::Rc,
 };
 
+const MINIMUM_SEPARATOR_WIDTH: u16 = 32;
+
 #[derive(Debug)]
 struct RunSnippetOperationInner {
     handle: Option<ExecutionHandle>,
@@ -104,7 +106,9 @@ impl AsRenderOperations for RunSnippetOperation {
                 let heading = TextBlock(vec![" [".into(), description.clone(), "] ".into()]);
                 let separator_width = match &self.alignment {
                     Alignment::Left { .. } | Alignment::Right { .. } => SeparatorWidth::FitToWindow,
-                    Alignment::Center { .. } => SeparatorWidth::Fixed(self.block_length),
+                    // We need a minimum here otherwise if the code/block length is too narrow, the separator is
+                    // word-wrapped and looks bad.
+                    Alignment::Center { .. } => SeparatorWidth::Fixed(self.block_length.max(MINIMUM_SEPARATOR_WIDTH)),
                 };
                 let separator = RenderSeparator::new(heading, separator_width);
                 vec![

--- a/src/render/highlighting.rs
+++ b/src/render/highlighting.rs
@@ -202,8 +202,8 @@ pub(crate) struct StyledTokens<'a> {
 impl<'a> StyledTokens<'a> {
     pub(crate) fn new(style: Style, tokens: &'a str, block_style: &CodeBlockStyle) -> Self {
         let has_background = block_style.background.unwrap_or(true);
-        let background = parse_color(style.background);
-        let foreground = has_background.then_some(parse_color(style.foreground)).flatten();
+        let background = has_background.then_some(parse_color(style.background)).flatten();
+        let foreground = parse_color(style.foreground);
         let mut style = TextStyle::default();
         style.colors.background = background;
         style.colors.foreground = foreground;


### PR DESCRIPTION
This renames the `no_margin` attribute added in #363 to `no_background` and makes it do everything `no_margin` did but also prevents presenterm from adding a background to the snippet. This currently doesn't play well with `exec_replace` or `exec` meaning the snippet execution output still gets background. I will address this separately as there's other things I want to get to but I want to close this issue.

The following

~~~markdown
```text +no_background
.__    .__
|  |__ |__|   _____   ____   _____
|  |  \|  |  /     \ /  _ \ /     \
|   Y  \  | |  Y Y  (  <_> )  Y Y  \
|___|  /__| |__|_|  /\____/|__|_|  /
     \/           \/             \/
```
~~~

Currently renders like this after this change:

![image](https://github.com/user-attachments/assets/4b883337-f238-4d85-9420-50dc42002cbf)

Fixes #349