### PR TITLE
chore: use debug mode in rust-script snippets

### DIFF
--- a/executors.yaml
+++ b/executors.yaml
@@ -72,7 +72,7 @@ ruby:
 rust-script:
   filename: snippet.rs
   commands:
-    - ["rust-script", "$pwd/snippet.rs"]
+    - ["rust-script", "--debug", "$pwd/snippet.rs"]
   hidden_line_prefix: "# "
 rust:
   filename: snippet.rs


### PR DESCRIPTION
The default seems to be release mode which will slow down compilation unnecessarily and is inconsistent with `rust` which uses `cargo run` which uses debug mode by default.