### PR TITLE
feat: parse inline span tags and css color attributes in them

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -963,6 +963,7 @@ dependencies = [
  "syntect",
  "tempfile",
  "thiserror",
+ "tl",
  "unicode-width 0.2.0",
 ]
 
@@ -1516,6 +1517,12 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tl"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b130bd8a58c163224b44e217b4239ca7b927d82bf6cc2fea1fc561d15056e3f7"
 
 [[package]]
 name = "typed-arena"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ serde_json = "1.0"
 serde_with = "3.6"
 strum = { version = "0.26", features = ["derive"] }
 tempfile = "3.10"
+tl = "0.7"
 console = "0.15.8"
 thiserror = "1"
 unicode-width = "0.2"

--- a/src/markdown/html.rs
+++ b/src/markdown/html.rs
@@ -1,0 +1,179 @@
+use crate::style::{Color, ParseColorError, TextStyle};
+use std::{borrow::Cow, str, str::Utf8Error};
+use tl::Attributes;
+
+pub(crate) struct HtmlParseOptions {
+    pub(crate) strict: bool,
+}
+
+impl Default for HtmlParseOptions {
+    fn default() -> Self {
+        Self { strict: true }
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct HtmlParser {
+    options: HtmlParseOptions,
+}
+
+impl HtmlParser {
+    pub(crate) fn parse(self, input: &str) -> Result<HtmlInline, ParseHtmlError> {
+        if input.starts_with("</") {
+            if input.starts_with("</span") {
+                return Ok(HtmlInline::CloseSpan);
+            } else {
+                return Err(ParseHtmlError::UnsupportedClosingTag(input.to_string()));
+            }
+        }
+        let dom = tl::parse(input, Default::default())?;
+        let top = dom.children().iter().next().ok_or(ParseHtmlError::NoTags)?;
+        let node = top.get(dom.parser()).expect("failed to get");
+        let tag = node.as_tag().ok_or(ParseHtmlError::NoTags)?;
+        if tag.name().as_bytes() != b"span" {
+            return Err(ParseHtmlError::UnsupportedHtml);
+        }
+        let style = self.parse_attributes(tag.attributes())?;
+        Ok(HtmlInline::OpenSpan { style })
+    }
+
+    fn parse_attributes(&self, attributes: &Attributes) -> Result<TextStyle, ParseHtmlError> {
+        let mut style = TextStyle::default();
+        for (name, value) in attributes.iter() {
+            let value = value.unwrap_or(Cow::Borrowed(""));
+            match name.as_ref() {
+                "style" => self.parse_css_attribute(&value, &mut style)?,
+                _ => {
+                    if self.options.strict {
+                        return Err(ParseHtmlError::UnsupportedTagAttribute(name.to_string()));
+                    }
+                }
+            }
+        }
+        Ok(style)
+    }
+
+    fn parse_css_attribute(&self, attribute: &str, style: &mut TextStyle) -> Result<(), ParseHtmlError> {
+        for attribute in attribute.split(';') {
+            let attribute = attribute.trim();
+            if attribute.is_empty() {
+                continue;
+            }
+            let (key, value) = attribute.split_once(':').ok_or(ParseHtmlError::NoColonInAttribute)?;
+            let key = key.trim();
+            let value = value.trim();
+            match key {
+                "color" => *style = style.fg_color(Self::parse_color(value)?),
+                "background-color" => *style = style.bg_color(Self::parse_color(value)?),
+                _ => {
+                    if self.options.strict {
+                        return Err(ParseHtmlError::UnsupportedCssAttribute(key.into()));
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn parse_color(input: &str) -> Result<Color, ParseHtmlError> {
+        if input.starts_with('#') {
+            let color = input.strip_prefix('#').unwrap().parse()?;
+            if matches!(color, Color::Rgb { .. }) { Ok(color) } else { Ok(input.parse()?) }
+        } else {
+            let color = input.parse::<Color>()?;
+            if matches!(color, Color::Rgb { .. }) {
+                Err(ParseHtmlError::InvalidColor("missing '#' in rgb color".into()))
+            } else {
+                Ok(color)
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum HtmlInline {
+    OpenSpan { style: TextStyle },
+    CloseSpan,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum ParseHtmlError {
+    #[error("parsing html failed: {0}")]
+    ParsingHtml(#[from] tl::ParseError),
+
+    #[error("no html tags found")]
+    NoTags,
+
+    #[error("non utf8 content: {0}")]
+    NotUtf8(#[from] Utf8Error),
+
+    #[error("attribute has no ':'")]
+    NoColonInAttribute,
+
+    #[error("invalid color: {0}")]
+    InvalidColor(String),
+
+    #[error("invalid css attribute: {0}")]
+    UnsupportedCssAttribute(String),
+
+    #[error("HTML can only contain span tags")]
+    UnsupportedHtml,
+
+    #[error("unsupported tag attribute: {0}")]
+    UnsupportedTagAttribute(String),
+
+    #[error("unsupported closing tag: {0}")]
+    UnsupportedClosingTag(String),
+}
+
+impl From<ParseColorError> for ParseHtmlError {
+    fn from(e: ParseColorError) -> Self {
+        Self::InvalidColor(e.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::style::Color;
+    use rstest::rstest;
+
+    #[test]
+    fn parse() {
+        let tag =
+            HtmlParser::default().parse(r#"<span style="color: red; background-color: black">"#).expect("parse failed");
+        let HtmlInline::OpenSpan { style } = tag else { panic!("not an open tag") };
+        assert_eq!(style, TextStyle::default().bg_color(Color::Black).fg_color(Color::Red));
+    }
+
+    #[test]
+    fn parse_end_tag() {
+        let tag = HtmlParser::default().parse("</span>").expect("parse failed");
+        assert!(matches!(tag, HtmlInline::CloseSpan));
+    }
+
+    #[rstest]
+    #[case::invalid_start_tag("<div>")]
+    #[case::invalid_end_tag("</div>")]
+    #[case::invalid_attribute("<span foo=\"bar\">")]
+    #[case::invalid_attribute("<span style=\"bleh: 42\"")]
+    #[case::invalid_color("<span style=\"color: 42\"")]
+    fn parse_invalid_html(#[case] input: &str) {
+        HtmlParser::default().parse(input).expect_err("parse succeeded");
+    }
+
+    #[rstest]
+    #[case::rgb("#ff0000", Color::Rgb{r: 255, g: 0, b: 0})]
+    #[case::red("red", Color::Red)]
+    fn parse_color(#[case] input: &str, #[case] expected: Color) {
+        let color: Color = HtmlParser::parse_color(input).expect("parse failed");
+        assert_eq!(color, expected);
+    }
+
+    #[rstest]
+    #[case::rgb("ff0000")]
+    #[case::red("#red")]
+    fn parse_invalid_color(#[case] input: &str) {
+        HtmlParser::parse_color(input).expect_err("parse succeeded");
+    }
+}

--- a/src/markdown/mod.rs
+++ b/src/markdown/mod.rs
@@ -1,3 +1,4 @@
 pub(crate) mod elements;
+pub(crate) mod html;
 pub(crate) mod parse;
 pub(crate) mod text;

--- a/src/render/engine.rs
+++ b/src/render/engine.rs
@@ -162,7 +162,9 @@ where
         let positioning = layout.compute(dimensions, text.width() as u16);
         let prefix = "".into();
         let text_drawer = TextDrawer::new(&prefix, 0, text, positioning, &self.colors)?;
-        text_drawer.draw(self.terminal)
+        text_drawer.draw(self.terminal)?;
+        // Restore colors
+        self.apply_colors()
     }
 
     fn render_line_break(&mut self) -> RenderResult {

--- a/src/style.rs
+++ b/src/style.rs
@@ -65,6 +65,18 @@ impl TextStyle {
         self
     }
 
+    /// Set the background color for this text style.
+    pub(crate) fn bg_color(mut self, color: Color) -> Self {
+        self.colors.background = Some(color);
+        self
+    }
+
+    /// Set the foreground color for this text style.
+    pub(crate) fn fg_color(mut self, color: Color) -> Self {
+        self.colors.foreground = Some(color);
+        self
+    }
+
     /// Check whether this text style is bold.
     pub(crate) fn is_bold(&self) -> bool {
         self.has_flag(TextFormatFlags::Bold)


### PR DESCRIPTION
This PR adds support to parse inline span html tags and the `color` and `background-color` CSS attributes in the `style` span tag attribute. 

The `color` and `background-color` can have any `#RRGGBB` formatted color + any color like `red`, `dark_red`, etc, as used in themes.

For now this only supports "strict" mode in which any deviation from what's supported will raise an error. In another PR I will add a way to configure this flag so if you don't feel like erroring, you can disable it.

After this change, the following:

~~~markdown
# <span style="color: black; background-color: yellow"> _hi_ </span> mom

Paragraphs can <span style="color: #ffff00">**mix** colors <span style="background-color: white">in any way</span>


* <span style="color: red">this is red</span>
* this has <span style="background-color: blue">blue background</span>
~~~

Renders as:

![image](https://github.com/user-attachments/assets/fbd938da-4b78-46a0-ae90-cd8926cf4041)

Fixes #88