### PR TITLE
Add R to executors

### DIFF
--- a/executors.yaml
+++ b/executors.yaml
@@ -65,6 +65,10 @@ python:
   commands:
     - ["python", "-u", "$pwd/snippet.py"]
   hidden_line_prefix: "/// "
+r:
+  filename: snippet.R
+  commands:
+    - ["Rscript", "$pwd/snippet.R"]
 ruby:
   filename: snippet.rb
   commands:


### PR DESCRIPTION
Thanks for this awesome project! If it's welcome, I added [R](https://www.r-project.org/) support to the executors. I've only tested this locally but it seems to work nicely.

![Screen Recording 2024-11-13 at 1 17 32 PM (1)](https://github.com/user-attachments/assets/f82b7860-3988-4973-8265-d5fe7adb5c16)

[Rscript](https://search.r-project.org/R/refmans/utils/html/Rscript.html) is a command-line tool that's installed along with R, and should behave in a way that's compatible with your approach.