### PR TITLE
Add C# to code executors

### DIFF
--- a/executors.yaml
+++ b/executors.yaml
@@ -94,3 +94,8 @@ zsh:
   commands:
     - ["zsh", "$pwd/script.sh"]
   hidden_line_prefix: "/// "
+csharp:
+  filename: snippet.cs
+  commands:
+    - ["dotnet-script", "$pwd/snippet.cs"]
+  hidden_line_prefix: "/// "


### PR DESCRIPTION
Closes #398.

To test:

```csharp +exec
// ignore
System.Console.WriteLine("Hello from C#");
```