### PR TITLE
feat: use kitty image protocol in ghostty

### DIFF
--- a/src/media/emulator.rs
+++ b/src/media/emulator.rs
@@ -15,6 +15,7 @@ pub enum TerminalEmulator {
     Mlterm,
     St,
     Xterm,
+    Ghostty,
     Unknown,
 }
 
@@ -60,13 +61,14 @@ impl TerminalEmulator {
             TerminalEmulator::Mlterm => term == "mlterm",
             TerminalEmulator::St => term == "st-256color",
             TerminalEmulator::Xterm => ["xterm", "xterm-256color"].contains(&term),
+            TerminalEmulator::Ghostty => term_program.contains("ghostty"),
             TerminalEmulator::Unknown => true,
         }
     }
 
     fn supports_graphics_mode(&self, mode: &GraphicsMode, capabilities: &TerminalCapabilities) -> bool {
         match (mode, self) {
-            (GraphicsMode::Kitty { mode, .. }, Self::Kitty | Self::WezTerm) => match mode {
+            (GraphicsMode::Kitty { mode, .. }, Self::Kitty | Self::WezTerm | Self::Ghostty) => match mode {
                 KittyMode::Local => capabilities.kitty_local,
                 KittyMode::Remote => true,
             },


### PR DESCRIPTION
This detects ghostty and uses the kitty graphics protocol on it by default. I don't have access to ghostty yet so I can't test this but based on [this article](https://fredrikaverpil.github.io/blog/2024/12/04/ghostty-on-macos/) `TERM_PROGRAM=ghostty` is the way to detect this. If it implements the protocol correctly, this should work out of the box.

@fredrikaverpil could I ask for your help here? :)