### PR TITLE
feat: detect kitty through tmux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,19 +366,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "console"
-version = "0.15.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
-dependencies = [
- "encode_unicode",
- "lazy_static",
- "libc",
- "unicode-width 0.1.14",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -527,12 +514,6 @@ name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
-
-[[package]]
-name = "encode_unicode"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "entities"
@@ -802,12 +783,6 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -1133,7 +1108,6 @@ dependencies = [
  "bincode",
  "clap",
  "comrak",
- "console",
  "crossterm",
  "directories",
  "flate2",
@@ -1158,7 +1132,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.5",
  "tl",
- "unicode-width 0.2.0",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1914,12 +1888,6 @@ checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ serde_with = "3.6"
 strum = { version = "0.26", features = ["derive"] }
 tempfile = "3.10"
 tl = "0.7"
-console = "0.15.8"
 thiserror = "2"
 unicode-width = "0.2"
 os_pipe = "1.1.5"

--- a/src/custom.rs
+++ b/src/custom.rs
@@ -1,7 +1,7 @@
 use crate::{
     GraphicsMode,
     input::user::KeyBinding,
-    media::{emulator::TerminalEmulator, kitty::KittyMode},
+    media::{emulator::TerminalEmulator, kitty::KittyMode, query::TerminalCapabilities},
     processing::code::SnippetLanguage,
 };
 use clap::ValueEnum;
@@ -270,10 +270,10 @@ impl TryFrom<&ImageProtocol> for GraphicsMode {
             }
             ImageProtocol::Iterm2 => GraphicsMode::Iterm2,
             ImageProtocol::KittyLocal => {
-                GraphicsMode::Kitty { mode: KittyMode::Local, inside_tmux: TerminalEmulator::is_inside_tmux() }
+                GraphicsMode::Kitty { mode: KittyMode::Local, inside_tmux: TerminalCapabilities::is_inside_tmux() }
             }
             ImageProtocol::KittyRemote => {
-                GraphicsMode::Kitty { mode: KittyMode::Remote, inside_tmux: TerminalEmulator::is_inside_tmux() }
+                GraphicsMode::Kitty { mode: KittyMode::Remote, inside_tmux: TerminalCapabilities::is_inside_tmux() }
             }
             ImageProtocol::AsciiBlocks => GraphicsMode::AsciiBlocks,
             #[cfg(feature = "sixel")]

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod image;
 mod iterm;
 pub(crate) mod kitty;
 pub(crate) mod printer;
+pub(crate) mod query;
 pub(crate) mod register;
 pub(crate) mod scale;
 #[cfg(feature = "sixel")]

--- a/src/media/query.rs
+++ b/src/media/query.rs
@@ -1,0 +1,228 @@
+use super::kitty::{Action, ControlCommand, ControlOption, ImageFormat, TransmissionMedium};
+use base64::{Engine, engine::general_purpose::STANDARD};
+use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
+use image::{DynamicImage, EncodableLayout};
+use std::{
+    env,
+    io::{self, Write},
+};
+use tempfile::NamedTempFile;
+
+#[derive(Default, Debug)]
+pub(crate) struct TerminalCapabilities {
+    pub(crate) kitty_local: bool,
+    pub(crate) kitty_remote: bool,
+    pub(crate) sixel: bool,
+    pub(crate) tmux: bool,
+}
+
+impl TerminalCapabilities {
+    pub(crate) fn is_inside_tmux() -> bool {
+        env::var("TERM_PROGRAM").ok().as_deref() == Some("tmux")
+    }
+
+    pub(crate) fn query() -> io::Result<Self> {
+        let tmux = Self::is_inside_tmux();
+        let mut file = NamedTempFile::new()?;
+        let image = DynamicImage::new_rgba8(1, 1).into_rgba8();
+        let image_bytes = image.as_raw().as_bytes();
+        file.write_all(image_bytes)?;
+        file.flush()?;
+        let Some(path) = file.path().as_os_str().to_str() else {
+            return Ok(Default::default());
+        };
+        let encoded_path = STANDARD.encode(path);
+
+        let base_image_id = rand::random();
+        let ids = KittyImageIds { local: base_image_id, remote: base_image_id.wrapping_add(1) };
+        Self::write_kitty_local_query(ids.local, encoded_path, tmux)?;
+        Self::write_kitty_remote_query(ids.remote, image_bytes, tmux)?;
+        let (start, sequence, end) = match tmux {
+            true => ("\x1bPtmux;", "\x1b\x1b", "\x1b\\"),
+            false => ("", "\x1b", ""),
+        };
+        let _guard = RawModeGuard::new()?;
+        let mut stdout = io::stdout();
+        write!(stdout, "{start}{sequence}[c{end}")?;
+        stdout.flush()?;
+
+        let mut response = Self::parse_response(io::stdin(), ids)?;
+        response.tmux = tmux;
+        Ok(response)
+    }
+
+    fn write_kitty_local_query(image_id: u32, path: String, tmux: bool) -> io::Result<()> {
+        let options = &[
+            ControlOption::Format(ImageFormat::Rgba),
+            ControlOption::Action(Action::Query),
+            ControlOption::Medium(TransmissionMedium::LocalFile),
+            ControlOption::ImageId(image_id),
+            ControlOption::Width(1),
+            ControlOption::Height(1),
+        ];
+        let command = ControlCommand { options, payload: path, tmux };
+        write!(io::stdout(), "{command}")
+    }
+
+    fn write_kitty_remote_query(image_id: u32, image: &[u8], tmux: bool) -> io::Result<()> {
+        let payload = STANDARD.encode(image);
+        let options = &[
+            ControlOption::Format(ImageFormat::Rgba),
+            ControlOption::Action(Action::Query),
+            ControlOption::Medium(TransmissionMedium::Direct),
+            ControlOption::ImageId(image_id),
+            ControlOption::Width(1),
+            ControlOption::Height(1),
+        ];
+        // The image is small enough to fit in a single request so we don't need to bother with
+        // chunks here.
+        let command = ControlCommand { options, payload, tmux };
+        write!(io::stdout(), "{command}")
+    }
+
+    fn parse_response<T: io::Read>(mut term: T, ids: KittyImageIds) -> io::Result<Self> {
+        let mut buffer = [0_u8; 128];
+        let mut state = QueryParseState::default();
+        let mut capabilities = TerminalCapabilities::default();
+        loop {
+            let bytes_read = term.read(&mut buffer)?;
+            for next in &buffer[0..bytes_read] {
+                let next = char::from(*next);
+                let Some(output) = state.update(next) else {
+                    continue;
+                };
+                match output {
+                    Response::KittySupported { image_id } => {
+                        if image_id == ids.local {
+                            capabilities.kitty_local = true;
+                        } else if image_id == ids.remote {
+                            capabilities.kitty_remote = true;
+                        }
+                    }
+                    Response::Capabilities { sixel } => {
+                        capabilities.sixel = sixel;
+                        return Ok(capabilities);
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct RawModeGuard;
+
+impl RawModeGuard {
+    fn new() -> io::Result<Self> {
+        enable_raw_mode()?;
+        Ok(Self)
+    }
+}
+
+impl Drop for RawModeGuard {
+    fn drop(&mut self) {
+        let _ = disable_raw_mode();
+    }
+}
+
+#[derive(Default)]
+struct QueryParseState {
+    data: String,
+    current: ResponseType,
+}
+
+impl QueryParseState {
+    fn update(&mut self, next: char) -> Option<Response> {
+        match &self.current {
+            ResponseType::Unknown => {
+                match (self.data.as_str(), next) {
+                    (_, '\x1b') => {
+                        *self = Default::default();
+                        return None;
+                    }
+                    ("[", '?') => {
+                        self.current = ResponseType::Capabilities;
+                    }
+                    ("_Gi", '=') => {
+                        self.current = ResponseType::Kitty;
+                    }
+                    _ => (),
+                };
+                self.data.push(next);
+            }
+            ResponseType::Kitty => match next {
+                '\\' => {
+                    let response = self.build_kitty_response();
+                    *self = Default::default();
+                    return response;
+                }
+                _ => {
+                    self.data.push(next);
+                }
+            },
+            ResponseType::Capabilities => match next {
+                'c' => {
+                    let mut caps = self.data[2..].split(';');
+                    let sixel = caps.any(|cap| cap == "4");
+
+                    return Some(Response::Capabilities { sixel });
+                }
+                _ => self.data.push(next),
+            },
+        };
+        None
+    }
+
+    fn build_kitty_response(&self) -> Option<Response> {
+        if !self.data.ends_with(";OK\x1b") {
+            return None;
+        }
+        let (_, rest) = self.data.split_once("_Gi=").expect("no kitty prefix");
+        let (image_id, _) = rest.split_once(';')?;
+        let image_id = image_id.parse::<u32>().ok()?;
+        Some(Response::KittySupported { image_id })
+    }
+}
+
+#[derive(Default)]
+enum ResponseType {
+    #[default]
+    Unknown,
+    Kitty,
+    Capabilities,
+}
+
+enum Response {
+    KittySupported { image_id: u32 },
+    Capabilities { sixel: bool },
+}
+
+struct KittyImageIds {
+    local: u32,
+    remote: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use io::Cursor;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::kitty_local("\x1b_Gi=42;OK\x1b\\\x1b[?c", true, false, false)]
+    #[case::kitty_remote("\x1b_Gi=43;OK\x1b\\\x1b[?c", false, true, false)]
+    #[case::kitty_both("\x1b_Gi=42;OK\x1b\\\x1b_Gi=43;OK\x1b\\\x1b[?c", true, true, false)]
+    #[case::kitty_flipped("\x1b_Gi=43;OK\x1b\\\x1b_Gi=42;OK\x1b\\\x1b[?c", true, true, false)]
+    #[case::all("\x1b_Gi=42;OK\x1b\\\x1b_Gi=43;OK\x1b\\\x1b[?4c", true, true, true)]
+    #[case::none("\x1b[?c", false, false, false)]
+    #[case::sixel_single("\x1b[?4c", false, false, true)]
+    #[case::sixel_first("\x1b[?4;42c", false, false, true)]
+    #[case::sixel_middle("\x1b[?1337;4;42c", false, false, true)]
+    fn detection(#[case] input: &str, #[case] kitty_local: bool, #[case] kitty_remote: bool, #[case] sixel: bool) {
+        let input = Cursor::new(input);
+        let ids = KittyImageIds { local: 42, remote: 43 };
+        let capabilities = TerminalCapabilities::parse_response(input, ids).expect("reading failed");
+        assert_eq!(capabilities.kitty_local, kitty_local);
+        assert_eq!(capabilities.kitty_remote, kitty_remote);
+        assert_eq!(capabilities.sixel, sixel);
+    }
+}


### PR DESCRIPTION
This PR adds support for kitty protocol detection when you're using tmux. This means now when you're running tmux inside kitty you no longer need to explicitly configure the image protocol to be kitty-local/remote and it will be instead figured out automatically.

This is done by making two kitty graphics protocol queries (and for local and one for remote support) and another widely supported query just in case the emulator doesn't support the kitty protocol and ignores our queries (this is what's suggested [here](https://sw.kovidgoyal.net/kitty/graphics-protocol/#querying-support-and-available-transmission-mediums)). The [third query](https://vt100.net/docs/vt510-rm/DA1.html) being done gets us the terminal capabilities; we figure out whether we support sixel by parsing its output. This means now we always make these queries once regardless of the protocol being used unless you explicitly configure a protocol other than `auto` (the default).

The caveat here is that terminal emulators may not support [unicode placeholders](https://sw.kovidgoyal.net/kitty/graphics-protocol/#unicode-placeholders) which is a requirement for the kitty protocol to work while inside tmux. At least wezterm [does not currently support them](https://github.com/wez/wezterm/issues/986) so images printed while inside tmux in it look like crap. The workaround for now is to guess that we're inside wezterm + tmux by checking an env var that wezterm sets. This won't work if you start tmux in another terminal (since it inherits _those_ env vars) but it's the best we can do. The outcome of this is if there's another terminal that does support the kitty protocol but does not have unicode placeholders implemented, images will look bad and users will be forced to [specify the image protocol](https://mfontanini.github.io/presenterm/guides/configuration.html#preferred-image-protocol) to be used by hand. 