### PR TITLE
feat: allow capping max columns on presentation

### DIFF
--- a/config-file-schema.json
+++ b/config-file-schema.json
@@ -40,6 +40,13 @@
             }
           ]
         },
+        "max_columns": {
+          "description": "A max width in columns that the presentation must always be capped to.",
+          "default": 65535,
+          "type": "integer",
+          "format": "uint16",
+          "minimum": 0.0
+        },
         "terminal_font_size": {
           "description": "Override the terminal font size when in windows or when using sixel.",
           "default": 16,

--- a/src/config.rs
+++ b/src/config.rs
@@ -77,6 +77,10 @@ pub struct DefaultsConfig {
     /// Validate that the presentation does not overflow the terminal screen.
     #[serde(default)]
     pub validate_overflows: ValidateOverflows,
+
+    /// A max width in columns that the presentation must always be capped to.
+    #[serde(default = "default_max_columns")]
+    pub max_columns: u16,
 }
 
 impl Default for DefaultsConfig {
@@ -86,6 +90,7 @@ impl Default for DefaultsConfig {
             terminal_font_size: default_font_size(),
             image_protocol: Default::default(),
             validate_overflows: Default::default(),
+            max_columns: default_max_columns(),
         }
     }
 }
@@ -213,6 +218,10 @@ impl Default for MermaidConfig {
 
 pub(crate) fn default_mermaid_scale() -> u32 {
     2
+}
+
+pub(crate) fn default_max_columns() -> u16 {
+    u16::MAX
 }
 
 /// The snippet execution configuration for a specific programming language.

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -49,7 +49,7 @@ pub struct ThemesDemo<W: TerminalWrite> {
 impl<W: TerminalWrite> ThemesDemo<W> {
     pub fn new(themes: Themes, bindings: CommandKeyBindings, writer: W) -> io::Result<Self> {
         let input = KeyboardListener::new(bindings);
-        let drawer = TerminalDrawer::new(writer, Default::default(), 1)?;
+        let drawer = TerminalDrawer::new(writer, Default::default(), Default::default())?;
         Ok(Self { themes, input, drawer })
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -395,6 +395,7 @@ fn run(mut cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             font_size_fallback: config.defaults.terminal_font_size,
             bindings: config.bindings,
             validate_overflows,
+            max_columns: config.defaults.max_columns,
         };
         let presenter = Presenter::new(
             &default_theme,

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -19,8 +19,8 @@ use crate::{
         diff::PresentationDiffer,
     },
     render::{
-        ErrorSource, RenderError, RenderResult, TerminalDrawer, operation::RenderAsyncState, properties::WindowSize,
-        validate::OverflowValidator,
+        ErrorSource, RenderError, RenderResult, TerminalDrawer, TerminalDrawerOptions, operation::RenderAsyncState,
+        properties::WindowSize, validate::OverflowValidator,
     },
     resource::Resources,
     terminal::image::printer::{ImagePrinter, ImageRegistry},
@@ -45,6 +45,7 @@ pub struct PresenterOptions {
     pub font_size_fallback: u8,
     pub bindings: KeyBindingsConfig,
     pub validate_overflows: bool,
+    pub max_columns: u16,
 }
 
 /// A slideshow presenter.
@@ -104,8 +105,11 @@ impl<'a> Presenter<'a> {
         self.state = PresenterState::Presenting(Presentation::from(vec![]));
         self.try_reload(path, true);
 
-        let mut drawer =
-            TerminalDrawer::new(io::stdout(), self.image_printer.clone(), self.options.font_size_fallback)?;
+        let drawer_options = TerminalDrawerOptions {
+            font_size_fallback: self.options.font_size_fallback,
+            max_columns: self.options.max_columns,
+        };
+        let mut drawer = TerminalDrawer::new(io::stdout(), self.image_printer.clone(), drawer_options)?;
         loop {
             if matches!(self.options.mode, PresentMode::Export) {
                 if let PresenterState::Failure { error, .. } = &self.state {

--- a/src/render/validate.rs
+++ b/src/render/validate.rs
@@ -18,7 +18,7 @@ impl OverflowValidator {
         for (index, slide) in presentation.iter_slides().enumerate() {
             let index = index + 1;
             let mut terminal = Terminal::new(io::Empty::default(), printer.clone()).map_err(RenderError::from)?;
-            let options = RenderEngineOptions { validate_overflows: true };
+            let options = RenderEngineOptions { validate_overflows: true, ..Default::default() };
             let engine = RenderEngine::new(&mut terminal, dimensions.clone(), options);
             match engine.render(slide.iter_visible_operations()) {
                 Ok(()) => (),


### PR DESCRIPTION
This adds a `defaults.max_columns` property in the config file that allows specifying the maximum number of columns you want the presentation to take up. This means if `columns > max_columns`, the presentation will be capped to `max_columns` and the entire presentation will be centered with the remainder of the size being spread equally on both sides of the presentation.

Fixes #410