### PR TITLE
feat: allow auto rendering code snippets

### DIFF
--- a/config-file-schema.json
+++ b/config-file-schema.json
@@ -279,7 +279,17 @@
     },
     "OptionsConfig": {
       "type": "object",
+      "required": [
+        "auto_render_languages"
+      ],
       "properties": {
+        "auto_render_languages": {
+          "description": "Assume snippets for these languages contain `+render` and render them automatically.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SnippetLanguage"
+          }
+        },
         "command_prefix": {
           "description": "The prefix to use for commands.",
           "type": [
@@ -387,6 +397,91 @@
         }
       },
       "additionalProperties": false
+    },
+    "SnippetLanguage": {
+      "description": "The language of a code snippet.",
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "Ada",
+            "Asp",
+            "Awk",
+            "Bash",
+            "BatchFile",
+            "C",
+            "CMake",
+            "Crontab",
+            "CSharp",
+            "Clojure",
+            "Cpp",
+            "Css",
+            "DLang",
+            "Diff",
+            "Docker",
+            "Dotenv",
+            "Elixir",
+            "Elm",
+            "Erlang",
+            "File",
+            "Fish",
+            "Go",
+            "GraphQL",
+            "Haskell",
+            "Html",
+            "Java",
+            "JavaScript",
+            "Json",
+            "Kotlin",
+            "Latex",
+            "Lua",
+            "Makefile",
+            "Mermaid",
+            "Markdown",
+            "Nix",
+            "Nushell",
+            "OCaml",
+            "Perl",
+            "Php",
+            "Protobuf",
+            "Puppet",
+            "Python",
+            "R",
+            "Racket",
+            "Ruby",
+            "Rust",
+            "RustScript",
+            "Scala",
+            "Shell",
+            "Sql",
+            "Swift",
+            "Svelte",
+            "Tcl",
+            "Terraform",
+            "Toml",
+            "TypeScript",
+            "Typst",
+            "Xml",
+            "Yaml",
+            "Verilog",
+            "Vue",
+            "Zig",
+            "Zsh"
+          ]
+        },
+        {
+          "type": "object",
+          "required": [
+            "Unknown"
+          ],
+          "properties": {
+            "Unknown": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
     },
     "SnippetRenderConfig": {
       "type": "object",

--- a/src/config.rs
+++ b/src/config.rs
@@ -129,6 +129,9 @@ pub struct OptionsConfig {
 
     /// Whether to be strict about parsing the presentation's front matter.
     pub strict_front_matter_parsing: Option<bool>,
+
+    /// Assume snippets for these languages contain `+render` and render them automatically.
+    pub auto_render_languages: Vec<SnippetLanguage>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, JsonSchema)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -231,6 +231,7 @@ fn make_builder_options(
         enable_snippet_execution: config.snippet.exec.enable,
         enable_snippet_execution_replace: config.snippet.exec_replace.enable,
         render_speaker_notes_only: speaker_notes_mode.is_some_and(|mode| matches!(mode, SpeakerNotesMode::Receiver)),
+        auto_render_languages: config.options.auto_render_languages.clone(),
     }
 }
 

--- a/src/presentation/builder.rs
+++ b/src/presentation/builder.rs
@@ -72,6 +72,7 @@ pub struct PresentationBuilderOptions {
     pub enable_snippet_execution: bool,
     pub enable_snippet_execution_replace: bool,
     pub render_speaker_notes_only: bool,
+    pub auto_render_languages: Vec<SnippetLanguage>,
 }
 
 impl PresentationBuilderOptions {
@@ -86,6 +87,9 @@ impl PresentationBuilderOptions {
         }
         if let Some(prefix) = options.image_attributes_prefix {
             self.image_attribute_prefix = prefix;
+        }
+        if !options.auto_render_languages.is_empty() {
+            self.auto_render_languages = options.auto_render_languages;
         }
     }
 }
@@ -105,6 +109,7 @@ impl Default for PresentationBuilderOptions {
             enable_snippet_execution: false,
             enable_snippet_execution_replace: false,
             render_speaker_notes_only: false,
+            auto_render_languages: Default::default(),
         }
     }
 }
@@ -784,7 +789,7 @@ impl<'a> PresentationBuilder<'a> {
         }
         self.push_differ(snippet.contents.clone());
 
-        if snippet.attributes.auto_render {
+        if snippet.attributes.render || self.options.auto_render_languages.contains(&snippet.language) {
             return self.push_rendered_code(snippet, source_position);
         } else if snippet.attributes.execute_replace && self.options.enable_snippet_execution_replace {
             return self.push_code_execution(snippet, 0, ExecutionMode::ReplaceSnippet);


### PR DESCRIPTION
This adds a new `auto_render_languages` [option](https://mfontanini.github.io/presenterm/guides/configuration.html#options) (meaning it can be configured in the config file or in the presentation itself) that specifies a list of languages for which the `+render` attribute is implied and are therefore automatically rendered. This means for example this presentation would have its mermaid diagram automatically rendered as an image:

~~~markdown
---
options:
    auto_render_languages:
        - mermaid
---

```mermaid
sequenceDiagram
    bob ->> mike: oh hi
```
~~~

Fixes #416