### PR TITLE
fix: udp socket bind issues in windows/mac

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -479,8 +479,14 @@ fn default_suspend_bindings() -> Vec<KeyBinding> {
     make_keybindings(["<c-z>"])
 }
 
+#[cfg(target_os = "linux")]
 fn default_speaker_notes_address() -> SocketAddr {
     SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 255, 255, 255)), 59418)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn default_speaker_notes_address() -> SocketAddr {
+    SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 59418)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
It looks like mac and windows can't bind to 127.255.255.255, whereas this works in linux. For now those 2 will bind to 127.0.0.1, which means you won't be able to run more than one presentation using speaker notes at the same time, which is anyway something that should never happen in practice.