### PR TITLE
feat: add markdown alert support

### DIFF
--- a/src/markdown/elements.rs
+++ b/src/markdown/elements.rs
@@ -1,4 +1,5 @@
 use super::text_style::TextStyle;
+use comrak::nodes::AlertType;
 use std::{fmt, iter, path::PathBuf, str::FromStr};
 use unicode_width::UnicodeWidthStr;
 
@@ -51,6 +52,18 @@ pub(crate) enum MarkdownElement {
 
     /// A block quote containing a list of lines.
     BlockQuote(Vec<Line>),
+
+    /// An alert.
+    Alert {
+        /// The alert's type.
+        alert_type: AlertType,
+
+        /// The optional title.
+        title: Option<String>,
+
+        /// The content lines in this alert.
+        lines: Vec<Line>,
+    },
 }
 
 #[derive(Clone, Copy, Debug, Default)]

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -150,6 +150,10 @@ pub struct PresentationTheme {
     #[serde(default)]
     pub(crate) block_quote: BlockQuoteStyle,
 
+    /// The style for an alert.
+    #[serde(default)]
+    pub(crate) alert: AlertStyle,
+
     /// The default style.
     #[serde(rename = "default", default)]
     pub(crate) default_style: DefaultStyle,
@@ -325,7 +329,62 @@ pub(crate) struct BlockQuoteColors {
     pub(crate) base: Colors,
 
     /// The color of the vertical bar that prefixes each line in the quote.
+    #[serde(default)]
     pub(crate) prefix: Option<Color>,
+}
+
+/// The style of an alert.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub(crate) struct AlertStyle {
+    /// The alignment.
+    #[serde(flatten, default)]
+    pub(crate) alignment: Option<Alignment>,
+
+    /// The prefix to be added to this block quote.
+    ///
+    /// This allows adding something like a vertical bar before the text.
+    #[serde(default)]
+    pub(crate) prefix: Option<String>,
+
+    /// The colors to be used.
+    #[serde(default)]
+    pub(crate) colors: AlertColors,
+}
+
+/// The colors of an alert.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub(crate) struct AlertColors {
+    /// The foreground/background colors.
+    #[serde(flatten)]
+    pub(crate) base: Colors,
+
+    /// The color of the vertical bar that prefixes each line in the quote.
+    #[serde(default)]
+    pub(crate) types: AlertTypeColors,
+}
+
+/// The colors of each alert type.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub(crate) struct AlertTypeColors {
+    /// The color for note type alerts.
+    #[serde(default)]
+    pub(crate) note: Option<Color>,
+
+    /// The color for tip type alerts.
+    #[serde(default)]
+    pub(crate) tip: Option<Color>,
+
+    /// The color for important type alerts.
+    #[serde(default)]
+    pub(crate) important: Option<Color>,
+
+    /// The color for warning type alerts.
+    #[serde(default)]
+    pub(crate) warning: Option<Color>,
+
+    /// The color for caution type alerts.
+    #[serde(default)]
+    pub(crate) caution: Option<Color>,
 }
 
 /// The style for the presentation introduction slide.

--- a/src/ui/footer.rs
+++ b/src/ui/footer.rs
@@ -38,6 +38,7 @@ impl FooterGenerator {
         colors: Colors,
         alignment: Alignment,
     ) -> RenderOperation {
+        #[allow(unknown_lints)]
         #[allow(clippy::literal_string_with_formatting_args)]
         let contents = template
             .replace("{current_slide}", current_slide)

--- a/themes/catppuccin-frappe.yaml
+++ b/themes/catppuccin-frappe.yaml
@@ -103,6 +103,18 @@ block_quote:
     background: "414559"
     prefix: "e5c890"
 
+alert:
+  prefix: "▍ "
+  colors:
+    foreground: "c6d0f5"
+    background: "414559"
+    types:
+      note: "8caaee"
+      tip: "a6d189"
+      important: "ca9ee6"
+      warning: "e5c890"
+      caution: "e78284"
+
 typst:
   colors:
     foreground: "c6d0f5"

--- a/themes/catppuccin-latte.yaml
+++ b/themes/catppuccin-latte.yaml
@@ -103,6 +103,18 @@ block_quote:
     background: "ccd0da"
     prefix: "df8e1d"
 
+alert:
+  prefix: "▍ "
+  colors:
+    foreground: "4c4f69"
+    background: "ccd0da"
+    types:
+      note: "1e66f5"
+      tip: "40a02b"
+      important: "8839ef"
+      warning: "df8e1d"
+      caution: "d20f39"
+
 typst:
   colors:
     foreground: "4c4f69"

--- a/themes/catppuccin-macchiato.yaml
+++ b/themes/catppuccin-macchiato.yaml
@@ -103,6 +103,18 @@ block_quote:
     background: "363a4f"
     prefix: "eed49f"
 
+alert:
+  prefix: "▍ "
+  colors:
+    foreground: "cad3f5"
+    background: "363a4f"
+    types:
+      note: "8aadf4"
+      tip: "a6da95"
+      important: "c6a0f6"
+      warning: "f5a97f"
+      caution: "ed8796"
+
 typst:
   colors:
     foreground: "cad3f5"

--- a/themes/catppuccin-mocha.yaml
+++ b/themes/catppuccin-mocha.yaml
@@ -103,6 +103,18 @@ block_quote:
     background: "313244"
     prefix: "f9e2af"
 
+alert:
+  prefix: "▍ "
+  colors:
+    foreground: "cdd6f4"
+    background: "313244"
+    types:
+      note: "89b4fa"
+      tip: "a6e3a1"
+      important: "cba6f7"
+      warning: "fab387"
+      caution: "f38ba8"
+
 typst:
   colors:
     foreground: "cdd6f4"

--- a/themes/dark.yaml
+++ b/themes/dark.yaml
@@ -104,6 +104,18 @@ block_quote:
     background: "292e42"
     prefix: "ee9322"
 
+alert:
+  prefix: "▍ "
+  colors:
+    foreground: "f0f0f0"
+    background: "292e42"
+    types:
+      note: "3085c3"
+      tip: "a8df8e"
+      important: "986ee2"
+      warning: "ee9322"
+      caution: "f78ca2"
+
 typst:
   colors:
     foreground: "f0f0f0"

--- a/themes/light.yaml
+++ b/themes/light.yaml
@@ -104,6 +104,18 @@ block_quote:
     background: "e9ecef"
     prefix: "f77f00"
 
+alert:
+  prefix: "▍ "
+  colors:
+    foreground: "212529"
+    background: "e9ecef"
+    types:
+      note: "1e66f5"
+      tip: "40a02b"
+      important: "8839ef"
+      warning: "df8e1d"
+      caution: "d20f39"
+
 typst:
   colors:
     foreground: "212529"

--- a/themes/terminal-dark.yaml
+++ b/themes/terminal-dark.yaml
@@ -102,6 +102,18 @@ block_quote:
     background: black
     prefix: yellow
 
+alert:
+  prefix: "▍ "
+  colors:
+    foreground: white
+    background: black
+    types:
+      note: blue
+      tip: green
+      important: magenta
+      warning: yellow
+      caution: red
+
 typst:
   colors:
     foreground: "f0f0f0"

--- a/themes/terminal-light.yaml
+++ b/themes/terminal-light.yaml
@@ -102,6 +102,18 @@ block_quote:
     background: grey
     prefix: dark_red
 
+alert:
+  prefix: "▍ "
+  colors:
+    foreground: black
+    background: grey
+    types:
+      note: dark_blue
+      tip: dark_green
+      important: dark_magenta
+      warning: dark_yellow
+      caution: dark_red
+
 typst:
   colors:
     foreground: "212529"

--- a/themes/tokyonight-storm.yaml
+++ b/themes/tokyonight-storm.yaml
@@ -104,6 +104,18 @@ block_quote:
     background: "545c7e"
     prefix: "e0af68"
 
+alert:
+  prefix: "▍ "
+  colors:
+    foreground: "f0f0f0"
+    background: "545c7e"
+    types:
+      note: "7aa2f7"
+      tip: "9ece6a"
+      important: "bb9af7"
+      warning: "e0af68"
+      caution: "f7768e"
+
 typst:
   colors:
     foreground: "f0f0f0"


### PR DESCRIPTION
This adds supports for markdown alerts (github/gitlab style) as support for these was recently added to comrak. This for now looks close a block quote except it also contains a title colored the same color as the vertical bar prefix that shows up on the left of the block quote.

See https://github.com/kivikakk/comrak/pull/519 and https://github.com/kivikakk/comrak/pull/521 for syntax but basically this:

```markdown
> [!note]
> this is a note

> [!tip]
> this is a tip

> [!important]
> this is important

> [!warning]
> this is warning!

> [!caution]
> this advises caution!

>>> [!note] other title
ez
multiline
>>>
```

Renders like this:

![image](https://github.com/user-attachments/assets/219024ae-b635-4bf2-87ba-e252b64ebd67)
