### PR TITLE
feat: add color palette in theme to allow reusing colors

### DIFF
--- a/src/markdown/text_style.rs
+++ b/src/markdown/text_style.rs
@@ -1,9 +1,11 @@
+use crate::theme::ColorPalette;
 use crossterm::style::Stylize;
 use hex::{FromHex, FromHexError};
 use serde::{Deserialize, Serialize};
 use serde_with::{DeserializeFromStr, SerializeDisplay};
 use std::{
     fmt::{self, Display},
+    ops::Deref,
     str::FromStr,
 };
 
@@ -110,7 +112,7 @@ impl TextStyle {
     }
 
     /// Apply this style to a piece of text.
-    pub(crate) fn apply<T: Into<String>>(&self, text: T) -> <String as Stylize>::Styled {
+    pub(crate) fn apply<T: Into<String>>(&self, text: T) -> Result<<String as Stylize>::Styled, PaletteColorError> {
         let text: String = text.into();
         let mut styled = text.stylize();
         if self.is_bold() {
@@ -126,12 +128,12 @@ impl TextStyle {
             styled = styled.underlined();
         }
         if let Some(color) = self.colors.background {
-            styled = styled.on(color.into());
+            styled = styled.on(color.try_into()?);
         }
         if let Some(color) = self.colors.foreground {
-            styled = styled.with(color.into());
+            styled = styled.with(color.try_into()?);
         }
-        styled
+        Ok(styled)
     }
 
     /// Checks whether this style has any modifiers (bold, italics, etc).
@@ -177,11 +179,17 @@ pub(crate) enum Color {
     White,
     Grey,
     Rgb { r: u8, g: u8, b: u8 },
+    Palette(FixedStr),
 }
 
 impl Color {
     pub(crate) fn new(r: u8, g: u8, b: u8) -> Self {
         Self::Rgb { r, g, b }
+    }
+
+    pub(crate) fn new_palette(name: &str) -> Result<Self, ParseColorError> {
+        let color: FixedStr = name.try_into().map_err(|_| ParseColorError::PaletteColorLength(name.to_string()))?;
+        if color.is_empty() { Err(ParseColorError::PaletteColorEmpty) } else { Ok(Self::Palette(color)) }
     }
 
     pub(crate) fn as_rgb(&self) -> Option<(u8, u8, u8)> {
@@ -204,6 +212,13 @@ impl Color {
             _ => return None,
         };
         Some(color)
+    }
+
+    pub(crate) fn resolve(&self, palette: &ColorPalette) -> Result<Color, UndefinedPaletteColorError> {
+        match self {
+            Color::Palette(name) => palette.colors.get(name.deref()).cloned().ok_or(UndefinedPaletteColorError(*name)),
+            _ => Ok(*self),
+        }
     }
 }
 
@@ -228,6 +243,8 @@ impl FromStr for Color {
             "dark_magenta" => Self::DarkMagenta,
             "cyan" => Self::Cyan,
             "dark_cyan" => Self::DarkCyan,
+            other if other.starts_with("palette:") => Self::new_palette(other.trim_start_matches("palette:"))?,
+            other if other.starts_with("p:") => Self::new_palette(other.trim_start_matches("p:"))?,
             // Fallback to hex-encoded rgb
             _ => {
                 let values = <[u8; 3]>::from_hex(input)?;
@@ -258,14 +275,17 @@ impl Display for Color {
             Self::DarkMagenta => write!(f, "dark_magenta"),
             Self::Cyan => write!(f, "cyan"),
             Self::DarkCyan => write!(f, "dark_cyan"),
+            Self::Palette(name) => write!(f, "palette:{name}"),
         }
     }
 }
 
-impl From<Color> for crossterm::style::Color {
-    fn from(value: Color) -> Self {
+impl TryFrom<Color> for crossterm::style::Color {
+    type Error = PaletteColorError;
+
+    fn try_from(value: Color) -> Result<Self, Self::Error> {
         use crossterm::style::Color as C;
-        match value {
+        let output = match value {
             Color::Black => C::Black,
             Color::DarkGrey => C::DarkGrey,
             Color::Red => C::Red,
@@ -283,9 +303,61 @@ impl From<Color> for crossterm::style::Color {
             Color::White => C::White,
             Color::Grey => C::Grey,
             Color::Rgb { r, g, b } => C::Rgb { r, g, b },
+            Color::Palette(color) => return Err(PaletteColorError(color)),
+        };
+        Ok(output)
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct FixedStr<const N: usize = 16> {
+    data: [u8; N],
+    length: u8,
+}
+
+impl<const N: usize> TryFrom<&str> for FixedStr<N> {
+    type Error = ();
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        let data = value.as_bytes();
+        if data.len() <= N {
+            let mut this = Self { data: [0; N], length: data.len() as u8 };
+            this.data[0..data.len()].copy_from_slice(data);
+            Ok(this)
+        } else {
+            Err(())
         }
     }
 }
+
+impl<const N: usize> Deref for FixedStr<N> {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        let data = &self.data[0..self.length as usize];
+        std::str::from_utf8(data).expect("invalid utf8")
+    }
+}
+
+impl<const N: usize> fmt::Debug for FixedStr<N> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.deref())
+    }
+}
+
+impl<const N: usize> fmt::Display for FixedStr<N> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.deref())
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("unresolved palette color: {0}")]
+pub(crate) struct PaletteColorError(FixedStr);
+
+#[derive(Debug, thiserror::Error)]
+#[error("undefined palette color: {0}")]
+pub(crate) struct UndefinedPaletteColorError(FixedStr);
 
 /// Text colors.
 #[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
@@ -303,27 +375,77 @@ impl Colors {
         let foreground = self.foreground.or(other.foreground);
         Self { background, foreground }
     }
+
+    pub(crate) fn resolve(mut self, palette: &ColorPalette) -> Result<Self, UndefinedPaletteColorError> {
+        if let Some(color) = self.foreground.as_mut() {
+            *color = color.resolve(palette)?;
+        }
+        if let Some(color) = self.background.as_mut() {
+            *color = color.resolve(palette)?;
+        }
+        Ok(self)
+    }
 }
 
-impl From<Colors> for crossterm::style::Colors {
-    fn from(value: Colors) -> Self {
-        let foreground = value.foreground.map(Color::into);
-        let background = value.background.map(Color::into);
-        Self { foreground, background }
+impl TryFrom<Colors> for crossterm::style::Colors {
+    type Error = PaletteColorError;
+
+    fn try_from(value: Colors) -> Result<Self, Self::Error> {
+        let foreground = value.foreground.map(Color::try_into).transpose()?;
+        let background = value.background.map(Color::try_into).transpose()?;
+        Ok(Self { foreground, background })
     }
 }
 
 #[derive(thiserror::Error, Debug)]
-#[error("invalid color: {0}")]
-pub(crate) struct ParseColorError(#[from] FromHexError);
+pub(crate) enum ParseColorError {
+    #[error("invalid hex color: {0}")]
+    Hex(#[from] FromHexError),
+
+    #[error("palette color name is too long: {0}")]
+    PaletteColorLength(String),
+
+    #[error("palette color name is empty")]
+    PaletteColorEmpty,
+}
 
 #[cfg(test)]
 mod test {
     use super::*;
+    use rstest::rstest;
 
     #[test]
     fn color_serde() {
         let color: Color = "beef42".parse().unwrap();
         assert_eq!(color.to_string(), "beef42");
+    }
+
+    #[test]
+    fn invalid_fixed_str() {
+        FixedStr::<1>::try_from("AB").unwrap_err();
+        FixedStr::<1>::try_from("🚀").unwrap_err();
+    }
+
+    #[test]
+    fn valid_fixed_str() {
+        let str = FixedStr::<3>::try_from("ABC").unwrap();
+        assert_eq!(str.to_string(), "ABC");
+    }
+
+    #[rstest]
+    #[case::empty1("p:")]
+    #[case::empty2("palette:")]
+    #[case::too_long("palette:12345678901234567")]
+    fn invalid_palette_color_names(#[case] input: &str) {
+        Color::from_str(input).expect_err("not an error");
+    }
+
+    #[rstest]
+    #[case::short("p:hi", "hi")]
+    #[case::long("palette:bye", "bye")]
+    fn valid_palette_color_names(#[case] input: &str, #[case] expected: &str) {
+        let color = Color::from_str(input).expect("failed to parse");
+        let Color::Palette(name) = color else { panic!("not a palette color") };
+        assert_eq!(name.deref(), expected);
     }
 }

--- a/src/presentation/builder.rs
+++ b/src/presentation/builder.rs
@@ -14,7 +14,7 @@ use crate::{
             Text,
         },
         text::WeightedLine,
-        text_style::{Color, Colors, TextStyle},
+        text_style::{Color, Colors, TextStyle, UndefinedPaletteColorError},
     },
     presentation::{
         ChunkMutator, Modals, Presentation, PresentationMetadata, PresentationState, PresentationThemeMetadata,
@@ -188,7 +188,7 @@ impl<'a> PresentationBuilder<'a> {
         self.set_code_theme()?;
 
         if self.chunk_operations.is_empty() {
-            self.push_slide_prelude();
+            self.push_slide_prelude()?;
         }
         for element in elements {
             self.slide_state.ignore_element_line_break = false;
@@ -203,7 +203,7 @@ impl<'a> PresentationBuilder<'a> {
             }
         }
         if !self.chunk_operations.is_empty() || !self.slide_chunks.is_empty() {
-            self.terminate_slide();
+            self.terminate_slide()?;
         }
         self.footer_context.borrow_mut().total_slides = self.slides.len();
 
@@ -257,10 +257,15 @@ impl<'a> PresentationBuilder<'a> {
         if last_valid { Ok(()) } else { Err(BuildError::NotInsideColumn) }
     }
 
-    fn push_slide_prelude(&mut self) {
+    fn set_colors(&mut self, colors: Colors) -> Result<(), UndefinedPaletteColorError> {
+        self.chunk_operations.push(RenderOperation::SetColors(colors.resolve(&self.theme.palette)?));
+        Ok(())
+    }
+
+    fn push_slide_prelude(&mut self) -> Result<(), BuildError> {
         let colors = self.theme.default_style.colors;
+        self.set_colors(colors)?;
         self.chunk_operations.extend([
-            RenderOperation::SetColors(colors),
             RenderOperation::ClearScreen,
             RenderOperation::ApplyMargin(MarginProperties {
                 horizontal_margin: self.theme.default_style.margin.clone().unwrap_or_default(),
@@ -268,6 +273,7 @@ impl<'a> PresentationBuilder<'a> {
             }),
         ]);
         self.push_line_break();
+        Ok(())
     }
 
     fn process_element_for_presentation_mode(&mut self, element: MarkdownElement) -> Result<(), BuildError> {
@@ -276,19 +282,19 @@ impl<'a> PresentationBuilder<'a> {
             // This one is processed before everything else as it affects how the rest of the
             // elements is rendered.
             MarkdownElement::FrontMatter(_) => self.slide_state.ignore_element_line_break = true,
-            MarkdownElement::SetexHeading { text } => self.push_slide_title(text),
-            MarkdownElement::Heading { level, text } => self.push_heading(level, text),
+            MarkdownElement::SetexHeading { text } => self.push_slide_title(text)?,
+            MarkdownElement::Heading { level, text } => self.push_heading(level, text)?,
             MarkdownElement::Paragraph(elements) => self.push_paragraph(elements)?,
-            MarkdownElement::List(elements) => self.push_list(elements),
+            MarkdownElement::List(elements) => self.push_list(elements)?,
             MarkdownElement::Snippet { info, code, source_position } => self.push_code(info, code, source_position)?,
-            MarkdownElement::Table(table) => self.push_table(table),
-            MarkdownElement::ThematicBreak => self.process_thematic_break(),
+            MarkdownElement::Table(table) => self.push_table(table)?,
+            MarkdownElement::ThematicBreak => self.process_thematic_break()?,
             MarkdownElement::Comment { comment, source_position } => self.process_comment(comment, source_position)?,
-            MarkdownElement::BlockQuote(lines) => self.push_block_quote(lines),
+            MarkdownElement::BlockQuote(lines) => self.push_block_quote(lines)?,
             MarkdownElement::Image { path, title, source_position } => {
                 self.push_image_from_path(path, title, source_position)?
             }
-            MarkdownElement::Alert { alert_type, title, lines } => self.push_alert(alert_type, title, lines),
+            MarkdownElement::Alert { alert_type, title, lines } => self.push_alert(alert_type, title, lines)?,
         };
         if should_clear_last {
             self.slide_state.last_element = LastElement::Other;
@@ -299,7 +305,7 @@ impl<'a> PresentationBuilder<'a> {
     fn process_element_for_speaker_notes_mode(&mut self, element: MarkdownElement) -> Result<(), BuildError> {
         match element {
             MarkdownElement::Comment { comment, source_position } => self.process_comment(comment, source_position)?,
-            MarkdownElement::SetexHeading { text } => self.push_slide_title(text),
+            MarkdownElement::SetexHeading { text } => self.push_slide_title(text)?,
             _ => {}
         }
         // Allows us to start the next speaker slide when a title is pushed and implicit_slide_ends is enabled.
@@ -334,8 +340,8 @@ impl<'a> PresentationBuilder<'a> {
 
         self.set_theme(&metadata.theme)?;
         if metadata.has_frontmatter() {
-            self.push_slide_prelude();
-            self.push_intro_slide(metadata);
+            self.push_slide_prelude()?;
+            self.push_intro_slide(metadata)?;
         }
         Ok(())
     }
@@ -365,8 +371,9 @@ impl<'a> PresentationBuilder<'a> {
                 return Err(BuildError::InvalidMetadata("theme overrides can't use 'extends'".into()));
             }
             // This shouldn't fail as the models are already correct.
-            let theme = merge_struct::merge(self.theme.as_ref(), overrides)
+            let mut theme = merge_struct::merge(self.theme.as_ref(), overrides)
                 .map_err(|e| BuildError::InvalidMetadata(format!("invalid theme: {e}")))?;
+            theme.resolve_palette_colors()?;
             self.theme = Cow::Owned(theme);
         }
         Ok(())
@@ -381,7 +388,7 @@ impl<'a> PresentationBuilder<'a> {
         Ok(())
     }
 
-    fn push_intro_slide(&mut self, metadata: PresentationMetadata) {
+    fn push_intro_slide(&mut self, metadata: PresentationMetadata) -> Result<(), BuildError> {
         let styles = self.theme.intro_slide.clone();
         let create_text =
             |text: Option<String>, style: TextStyle| -> Option<Text> { text.map(|text| Text::new(text, style)) };
@@ -401,21 +408,21 @@ impl<'a> PresentationBuilder<'a> {
         }
         self.chunk_operations.push(RenderOperation::JumpToVerticalCenter);
         if let Some(title) = title {
-            self.push_line(title, ElementType::PresentationTitle);
+            self.push_line(title, ElementType::PresentationTitle)?;
         }
         if let Some(sub_title) = sub_title {
-            self.push_line(sub_title, ElementType::PresentationSubTitle);
+            self.push_line(sub_title, ElementType::PresentationSubTitle)?;
         }
         if event.is_some() || location.is_some() || date.is_some() {
             self.push_line_breaks(2);
             if let Some(event) = event {
-                self.push_line(event, ElementType::PresentationEvent);
+                self.push_line(event, ElementType::PresentationEvent)?;
             }
             if let Some(location) = location {
-                self.push_line(location, ElementType::PresentationLocation);
+                self.push_line(location, ElementType::PresentationLocation)?;
             }
             if let Some(date) = date {
-                self.push_line(date, ElementType::PresentationDate);
+                self.push_line(date, ElementType::PresentationDate)?;
             }
         }
         if !authors.is_empty() {
@@ -428,11 +435,11 @@ impl<'a> PresentationBuilder<'a> {
                 }
             };
             for author in authors {
-                self.push_line(author, ElementType::PresentationAuthor);
+                self.push_line(author, ElementType::PresentationAuthor)?;
             }
         }
         self.slide_state.title = Some(Line::from("[Introduction]"));
-        self.terminate_slide();
+        self.terminate_slide()
     }
 
     fn process_comment(&mut self, comment: String, source_position: SourcePosition) -> Result<(), BuildError> {
@@ -459,7 +466,7 @@ impl<'a> PresentationBuilder<'a> {
     fn process_comment_command_presentation_mode(&mut self, comment_command: CommentCommand) -> Result<(), BuildError> {
         match comment_command {
             CommentCommand::Pause => self.process_pause(),
-            CommentCommand::EndSlide => self.terminate_slide(),
+            CommentCommand::EndSlide => self.terminate_slide()?,
             CommentCommand::NewLine => self.push_line_break(),
             CommentCommand::NewLines(count) => {
                 for _ in 0..count {
@@ -511,11 +518,11 @@ impl<'a> PresentationBuilder<'a> {
         match comment_command {
             CommentCommand::SpeakerNote(note) => {
                 for line in note.lines() {
-                    self.push_text(line.into(), ElementType::Paragraph);
+                    self.push_text(line.into(), ElementType::Paragraph)?;
                     self.push_line_break();
                 }
             }
-            CommentCommand::EndSlide => self.terminate_slide(),
+            CommentCommand::EndSlide => self.terminate_slide()?,
             _ => {}
         }
         Ok(())
@@ -554,9 +561,9 @@ impl<'a> PresentationBuilder<'a> {
         self.slide_chunks.push(SlideChunk::new(chunk_operations, mutators));
     }
 
-    fn push_slide_title(&mut self, mut text: Line) {
+    fn push_slide_title(&mut self, mut text: Line) -> Result<(), BuildError> {
         if self.options.implicit_slide_ends && !matches!(self.slide_state.last_element, LastElement::None) {
-            self.terminate_slide();
+            self.terminate_slide()?;
         }
 
         if self.slide_state.title.is_none() {
@@ -577,7 +584,7 @@ impl<'a> PresentationBuilder<'a> {
         text.apply_style(&text_style);
 
         self.push_line_breaks(style.padding_top.unwrap_or(0) as usize);
-        self.push_text(text, ElementType::SlideTitle);
+        self.push_text(text, ElementType::SlideTitle)?;
         self.push_line_break();
 
         for _ in 0..style.padding_bottom.unwrap_or(0) {
@@ -588,9 +595,10 @@ impl<'a> PresentationBuilder<'a> {
         }
         self.push_line_break();
         self.slide_state.ignore_element_line_break = true;
+        Ok(())
     }
 
-    fn push_heading(&mut self, level: u8, mut text: Line) {
+    fn push_heading(&mut self, level: u8, mut text: Line) -> Result<(), BuildError> {
         let (element_type, style) = match level {
             1 => (ElementType::Heading1, &self.theme.headings.h1),
             2 => (ElementType::Heading2, &self.theme.headings.h2),
@@ -608,25 +616,27 @@ impl<'a> PresentationBuilder<'a> {
         let text_style = TextStyle::default().bold().colors(style.colors);
         text.apply_style(&text_style);
 
-        self.push_text(text, element_type);
+        self.push_text(text, element_type)?;
         self.push_line_break();
+        Ok(())
     }
 
     fn push_paragraph(&mut self, lines: Vec<Line>) -> Result<(), BuildError> {
         for text in lines {
-            self.push_text(text, ElementType::Paragraph);
+            self.push_text(text, ElementType::Paragraph)?;
             self.push_line_break();
         }
         Ok(())
     }
 
-    fn process_thematic_break(&mut self) {
+    fn process_thematic_break(&mut self) -> Result<(), BuildError> {
         if self.options.end_slide_shorthand {
-            self.terminate_slide();
+            self.terminate_slide()?;
             self.slide_state.ignore_element_line_break = true;
         } else {
             self.chunk_operations.extend([RenderSeparator::default().into(), RenderOperation::RenderLineBreak]);
         }
+        Ok(())
     }
 
     fn push_image_from_path(
@@ -655,14 +665,12 @@ impl<'a> PresentationBuilder<'a> {
             restore_cursor: false,
             background_color: self.theme.default_style.colors.background,
         };
-        self.chunk_operations.extend([
-            RenderOperation::RenderImage(image, properties),
-            RenderOperation::SetColors(self.theme.default_style.colors),
-        ]);
+        self.chunk_operations.push(RenderOperation::RenderImage(image, properties));
+        self.set_colors(self.theme.default_style.colors)?;
         Ok(())
     }
 
-    fn push_list(&mut self, list: Vec<ListItem>) {
+    fn push_list(&mut self, list: Vec<ListItem>) -> Result<(), BuildError> {
         let last_chunk_operation = self.slide_chunks.last().and_then(|chunk| chunk.iter_operations().last());
         // If the last chunk ended in a list, pop the newline so we get them all next to each
         // other.
@@ -684,11 +692,12 @@ impl<'a> PresentationBuilder<'a> {
             if index > 0 && incremental_lists {
                 self.process_pause();
             }
-            self.push_list_item(item.index, item.item);
+            self.push_list_item(item.index, item.item)?;
         }
+        Ok(())
     }
 
-    fn push_list_item(&mut self, index: usize, item: ListItem) {
+    fn push_list_item(&mut self, index: usize, item: ListItem) -> Result<(), BuildError> {
         let padding_length = (item.depth as usize + 1) * 3;
         let mut prefix: String = " ".repeat(padding_length);
         match item.item_type {
@@ -711,23 +720,29 @@ impl<'a> PresentationBuilder<'a> {
         };
 
         let prefix_length = prefix.len() as u16;
-        self.push_text(prefix.into(), ElementType::List);
+        self.push_text(prefix.into(), ElementType::List)?;
 
         let text = item.contents;
-        self.push_aligned_text(text, Alignment::Left { margin: Margin::Fixed(prefix_length) });
+        self.push_aligned_text(text, Alignment::Left { margin: Margin::Fixed(prefix_length) })?;
         self.push_line_break();
         if item.depth == 0 {
             self.slide_state.last_element = LastElement::List { last_index: index };
         }
+        Ok(())
     }
 
-    fn push_block_quote(&mut self, lines: Vec<Line>) {
+    fn push_block_quote(&mut self, lines: Vec<Line>) -> Result<(), BuildError> {
         let prefix = self.theme.block_quote.prefix.clone().unwrap_or_default();
         let prefix_color = self.theme.block_quote.colors.prefix.or(self.theme.block_quote.colors.base.foreground);
-        self.push_quoted_text(lines, prefix, self.theme.block_quote.colors.base, prefix_color);
+        self.push_quoted_text(lines, prefix, self.theme.block_quote.colors.base, prefix_color)
     }
 
-    fn push_alert(&mut self, alert_type: AlertType, title: Option<String>, mut lines: Vec<Line>) {
+    fn push_alert(
+        &mut self,
+        alert_type: AlertType,
+        title: Option<String>,
+        mut lines: Vec<Line>,
+    ) -> Result<(), BuildError> {
         let (default_title, prefix_color) = match alert_type {
             AlertType::Note => ("Note", self.theme.alert.colors.types.note),
             AlertType::Tip => ("Tip", self.theme.alert.colors.types.tip),
@@ -742,10 +757,16 @@ impl<'a> PresentationBuilder<'a> {
         lines.insert(0, Line::from(Text::new(title, TextStyle::default().colors(title_colors))));
 
         let prefix = self.theme.block_quote.prefix.clone().unwrap_or_default();
-        self.push_quoted_text(lines, prefix, self.theme.alert.colors.base, prefix_color);
+        self.push_quoted_text(lines, prefix, self.theme.alert.colors.base, prefix_color)
     }
 
-    fn push_quoted_text(&mut self, lines: Vec<Line>, prefix: String, base_colors: Colors, prefix_color: Option<Color>) {
+    fn push_quoted_text(
+        &mut self,
+        lines: Vec<Line>,
+        prefix: String,
+        base_colors: Colors,
+        prefix_color: Option<Color>,
+    ) -> Result<(), BuildError> {
         let block_length = lines.iter().map(|line| line.width() + prefix.width()).max().unwrap_or(0) as u16;
         let prefix = Text::new(
             prefix,
@@ -775,29 +796,36 @@ impl<'a> PresentationBuilder<'a> {
             }));
             self.push_line_break();
         }
-        self.chunk_operations.push(RenderOperation::SetColors(self.theme.default_style.colors));
+        self.set_colors(self.theme.default_style.colors)?;
+        Ok(())
     }
 
-    fn push_line(&mut self, text: Text, element_type: ElementType) {
-        self.push_text(Line::from(text), element_type);
+    fn push_line(&mut self, text: Text, element_type: ElementType) -> Result<(), BuildError> {
+        self.push_text(Line::from(text), element_type)?;
         self.push_line_break();
+        Ok(())
     }
 
-    fn push_text(&mut self, text: Line, element_type: ElementType) {
+    fn push_text(&mut self, line: Line, element_type: ElementType) -> Result<(), BuildError> {
         let alignment = self.theme.alignment(&element_type);
-        self.push_aligned_text(text, alignment);
+        self.push_aligned_text(line, alignment)?;
+        Ok(())
     }
 
-    fn push_aligned_text(&mut self, mut block: Line, alignment: Alignment) {
+    fn push_aligned_text(&mut self, mut block: Line, alignment: Alignment) -> Result<(), BuildError> {
         for chunk in &mut block.0 {
             if chunk.style.is_code() {
                 chunk.style.colors = self.theme.inline_code.colors;
+            } else {
+                let style = &mut chunk.style;
+                style.colors = style.colors.resolve(&self.theme.palette)?;
             }
         }
         if !block.0.is_empty() {
             self.chunk_operations
                 .push(RenderOperation::RenderText { line: WeightedLine::from(block), alignment: alignment.clone() });
         }
+        Ok(())
     }
 
     fn push_line_break(&mut self) {
@@ -832,7 +860,7 @@ impl<'a> PresentationBuilder<'a> {
         for line in lines {
             self.chunk_operations.push(RenderOperation::RenderDynamic(Rc::new(line)));
         }
-        self.chunk_operations.push(RenderOperation::SetColors(self.theme.default_style.colors));
+        self.set_colors(self.theme.default_style.colors)?;
         if self.options.allow_mutations && context.borrow().groups.len() > 1 {
             self.chunk_mutators.push(Box::new(HighlightMutator::new(context)));
         }
@@ -1008,7 +1036,7 @@ impl<'a> PresentationBuilder<'a> {
         Ok(())
     }
 
-    fn terminate_slide(&mut self) {
+    fn terminate_slide(&mut self) -> Result<(), BuildError> {
         let footer = self.generate_footer();
 
         let operations = mem::take(&mut self.chunk_operations);
@@ -1020,9 +1048,10 @@ impl<'a> PresentationBuilder<'a> {
         self.index_builder.add_title(self.slide_state.title.take().unwrap_or_else(|| Text::from("<no title>").into()));
         self.slides.push(slide);
 
-        self.push_slide_prelude();
+        self.push_slide_prelude()?;
         self.slide_state = Default::default();
         self.slide_state.last_element = LastElement::None;
+        Ok(())
     }
 
     fn generate_footer(&mut self) -> Vec<RenderOperation> {
@@ -1043,12 +1072,12 @@ impl<'a> PresentationBuilder<'a> {
         ]
     }
 
-    fn push_table(&mut self, table: Table) {
+    fn push_table(&mut self, table: Table) -> Result<(), BuildError> {
         let widths: Vec<_> = (0..table.columns())
             .map(|column| table.iter_column(column).map(|text| text.width()).max().unwrap_or(0))
             .collect();
         let flattened_header = Self::prepare_table_row(table.header, &widths);
-        self.push_text(flattened_header, ElementType::Table);
+        self.push_text(flattened_header, ElementType::Table)?;
         self.push_line_break();
 
         let mut separator = Line(Vec::new());
@@ -1066,14 +1095,15 @@ impl<'a> PresentationBuilder<'a> {
             separator.0.push(Text::from(contents));
         }
 
-        self.push_text(separator, ElementType::Table);
+        self.push_text(separator, ElementType::Table)?;
         self.push_line_break();
 
         for row in table.rows {
             let flattened_row = Self::prepare_table_row(row, &widths);
-            self.push_text(flattened_row, ElementType::Table);
+            self.push_text(flattened_row, ElementType::Table)?;
             self.push_line_break();
         }
+        Ok(())
     }
 
     fn prepare_table_row(row: TableRow, widths: &[usize]) -> Line {
@@ -1208,6 +1238,9 @@ pub enum BuildError {
 
     #[error("language {0:?} does not support execution")]
     UnsupportedExecution(SnippetLanguage),
+
+    #[error(transparent)]
+    UndefinedPaletteColor(#[from] UndefinedPaletteColorError),
 }
 
 enum ExecutionMode {

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     markdown::{
         elements::Text,
         text::WeightedLine,
-        text_style::{Color, Colors, TextStyle},
+        text_style::{Color, Colors, PaletteColorError, TextStyle},
     },
     render::{operation::RenderOperation, properties::WindowSize},
     terminal::{
@@ -126,6 +126,9 @@ pub(crate) enum RenderError {
 
     #[error("vertical overflow")]
     VerticalOverflow,
+
+    #[error(transparent)]
+    PaletteColor(#[from] PaletteColorError),
 }
 
 pub(crate) enum ErrorSource {

--- a/src/render/text.rs
+++ b/src/render/text.rs
@@ -83,7 +83,7 @@ impl<'a> TextDrawer<'a> {
         // Print the prefix at the beginning of the line.
         let styled_prefix = {
             let Text { content, style } = self.prefix.text();
-            style.apply(content)
+            style.apply(content)?
         };
         terminal.move_to_column(self.positioning.start_column)?;
         terminal.print_styled_line(styled_prefix.clone())?;
@@ -111,7 +111,7 @@ impl<'a> TextDrawer<'a> {
                 line_length = line_length.saturating_add(chunk.width() as u16);
 
                 let (text, style) = chunk.into_parts();
-                let text = style.apply(text);
+                let text = style.apply(text)?;
                 terminal.print_styled_line(text)?;
 
                 // Crossterm resets colors if any attributes are set so let's just re-apply colors

--- a/src/terminal/image/printer.rs
+++ b/src/terminal/image/printer.rs
@@ -6,7 +6,11 @@ use super::{
         kitty::{KittyImage, KittyMode, KittyPrinter},
     },
 };
-use crate::{markdown::text_style::Color, render::properties::CursorPosition, terminal::GraphicsMode};
+use crate::{
+    markdown::text_style::{Color, PaletteColorError},
+    render::properties::CursorPosition,
+    terminal::GraphicsMode,
+};
 use image::{DynamicImage, ImageError};
 use std::{
     borrow::Cow,
@@ -189,8 +193,14 @@ pub(crate) enum PrintImageError {
     #[error("image decoding: {0}")]
     Image(#[from] ImageError),
 
-    #[error("other: {0}")]
+    #[error("{0}")]
     Other(Cow<'static, str>),
+}
+
+impl From<PaletteColorError> for PrintImageError {
+    fn from(e: PaletteColorError) -> Self {
+        Self::Other(e.to_string().into())
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/terminal/image/protocols/ascii.rs
+++ b/src/terminal/image/protocols/ascii.rs
@@ -83,7 +83,7 @@ impl PrintImage for AsciiPrinter {
         // will contain the pixels at (x, y) and (x, y + 1) combined.
         let image = image.0.resize_exact(options.columns as u32, 2 * options.rows as u32, FilterType::Triangle);
         let image = image.into_rgba8();
-        let default_background = options.background_color.map(Color::from);
+        let default_background = options.background_color.map(Color::try_from).transpose()?;
 
         // Iterate pixel rows in pairs to be able to merge both pixels in a single iteration.
         // Note that may not have a second row if there's an odd number of them.
@@ -98,7 +98,7 @@ impl PrintImage for AsciiPrinter {
                 // Get pixel colors for both of these. At this point the special case for the odd
                 // number of rows disappears as we treat a transparent pixel and a non-existent
                 // one the same: they're simply transparent.
-                let background = options.background_color.map(Color::from);
+                let background = default_background;
                 let top = Self::pixel_color(top_pixel, background);
                 let bottom = bottom_pixel.and_then(|c| Self::pixel_color(c, background));
                 match (top, bottom) {

--- a/src/terminal/image/protocols/kitty.rs
+++ b/src/terminal/image/protocols/kitty.rs
@@ -329,7 +329,7 @@ impl KittyPrinter {
         image_id: u32,
     ) -> Result<(), PrintImageError> {
         let color = Color::new((image_id >> 16) as u8, (image_id >> 8) as u8, image_id as u8);
-        writer.queue(SetForegroundColor(color.into()))?;
+        writer.queue(SetForegroundColor(color.try_into()?))?;
         if options.rows.max(options.columns) >= DIACRITICS.len() as u16 {
             return Err(PrintImageError::other("image is too large to fit in tmux"));
         }

--- a/src/terminal/printer.rs
+++ b/src/terminal/printer.rs
@@ -87,13 +87,15 @@ impl<W: TerminalWrite> Terminal<W> {
     }
 
     pub(crate) fn set_colors(&mut self, colors: Colors) -> io::Result<()> {
+        let colors = colors.try_into().map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
         self.writer.queue(style::ResetColor)?;
-        self.writer.queue(style::SetColors(colors.into()))?;
+        self.writer.queue(style::SetColors(colors))?;
         Ok(())
     }
 
     pub(crate) fn set_background_color(&mut self, color: Color) -> io::Result<()> {
-        self.writer.queue(style::SetBackgroundColor(color.into()))?;
+        let color = color.try_into().map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+        self.writer.queue(style::SetBackgroundColor(color))?;
         Ok(())
     }
 

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,4 +1,4 @@
-use crate::markdown::text_style::{Color, Colors, UndefinedPaletteColorError};
+use crate::markdown::text_style::{Color, Colors, FixedStr, UndefinedPaletteColorError};
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, fs, io, path::Path};
 
@@ -943,7 +943,7 @@ impl ModalStyle {
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub(crate) struct ColorPalette {
     #[serde(default)]
-    pub(crate) colors: BTreeMap<String, Color>,
+    pub(crate) colors: BTreeMap<FixedStr, Color>,
 }
 
 /// An error loading a presentation theme.

--- a/themes/dark.yaml
+++ b/themes/dark.yaml
@@ -3,7 +3,7 @@ default:
   margin:
     percent: 8
   colors:
-    foreground: "e6e6e6"
+    foreground: palette:white
     background: "040312"
 
 slide_title:
@@ -11,7 +11,7 @@ slide_title:
   padding_bottom: 1
   padding_top: 1
   colors:
-    foreground: "ee9322"
+    foreground: palette:orange
   bold: true
 
 code:
@@ -26,17 +26,17 @@ code:
 
 execution_output:
   colors:
-    foreground: "e6e6e6"
-    background: "2d2d2d"
+    foreground: palette:white
+    background: palette:black
   status:
     running:
-      foreground: "b4ccff"
+      foreground: palette:light_blue
     success:
-      foreground: "a8df8e"
+      foreground: palette:light_green
     failure:
-      foreground: "f78ca2"
+      foreground: palette:red
     not_started:
-      foreground: "ee9322"
+      foreground: palette:orange
 
 inline_code:
   colors:
@@ -47,23 +47,23 @@ intro_slide:
   title:
     alignment: center
     colors:
-      foreground: "b4ccff"
+      foreground: palette:light_blue
   subtitle:
     alignment: center
     colors:
-      foreground: "a5d7e8"
+      foreground: palette:aqua
   event:
     alignment: center
     colors:
-      foreground: "b4ccff"
+      foreground: palette:light_blue
   location:
     alignment: center
     colors:
-      foreground: "a5d7e8"
+      foreground: palette:aqua
   date:
     alignment: center
     colors:
-      foreground: "ee9322"
+      foreground: palette:orange
   author:
     alignment: center
     colors:
@@ -75,51 +75,51 @@ headings:
   h1:
     prefix: "██"
     colors:
-      foreground: "3085c3"
+      foreground: palette:blue 
   h2:
     prefix: "▓▓▓"
     colors:
-      foreground: "a8df8e"
+      foreground: palette:light_green
   h3:
     prefix: "▒▒▒▒"
     colors:
-      foreground: "f78ca2"
+      foreground: palette:red
   h4:
     prefix: "░░░░░"
     colors:
-      foreground: "d2d2d2"
+      foreground: palette:gray
   h5:
     prefix: "░░░░░░"
     colors:
-      foreground: "d2d2d2"
+      foreground: palette:gray
   h6:
     prefix: "░░░░░░░"
     colors:
-      foreground: "d2d2d2"
+      foreground: palette:gray
 
 block_quote:
   prefix: "▍ "
   colors:
-    foreground: "f0f0f0"
-    background: "292e42"
-    prefix: "ee9322"
+    foreground: palette:light_gray
+    background: palette:blue_gray
+    prefix: palette:orange
 
 alert:
   prefix: "▍ "
   colors:
-    foreground: "f0f0f0"
-    background: "292e42"
+    foreground: palette:light_gray
+    background: palette:blue_gray
     types:
-      note: "3085c3"
-      tip: "a8df8e"
-      important: "986ee2"
-      warning: "ee9322"
-      caution: "f78ca2"
+      note: palette:blue
+      tip: palette:light_green
+      important: palette:purple
+      warning: palette:orange
+      caution: palette:red
 
 typst:
   colors:
-    foreground: "f0f0f0"
-    background: "292e42"
+    foreground: palette:light_gray
+    background: palette:blue_gray
 
 footer:
   style: template
@@ -127,8 +127,23 @@ footer:
 
 modals:
   selection_colors:
-    foreground: "ee9322"
+    foreground: palette:orange
 
 mermaid:
   background: transparent
   theme: dark
+
+palette:
+  colors:
+    blue: "3085c3"
+    light_blue: "b4ccff"
+    blue_gray: "292e42"
+    aqua: "a5d7e8"
+    light_green: "a8df8e"
+    red: "f78ca2"
+    orange: "ee9322"
+    purple: "986ee2"
+    white: "e6e6e6"
+    black: "2d2d2d"
+    gray: "d2d2d2"
+    light_gray: "f0f0f0"


### PR DESCRIPTION
This allows defining a color palette in themes, which allows reusing colors across the theme and in html span tags. In particular in theme files there's always the same set of colors used all over the place, and it's annoying to have to always address them using a RGB hex spec. This instead allows defining a set of named colors and then those colors can be referenced where a color would be used (e.g. in a theme or in a span tag) by using the `palette:<name>` or `p:<name>` syntax.

For the color name this uses a stack allocated string of at most 16 characters. This is not an optimization but a workaround since `Color`, `Colors` and `TextStyle` are currently `Copy` and using a `String` would make them non copy which would involve changing lots of code. This constraints the length of the palette colors but I don't feel like changing this all over the codebase, plus "16 characters ought to be enough for everybody".