### PR TITLE
feat: add symbols to alerts

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -8,7 +8,7 @@ name: Merge checks
 
 jobs:
   check:
-    name: Check
+    name: Checks
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
@@ -16,40 +16,25 @@ jobs:
 
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@1.78.0
+        with:
+          components: clippy
 
       - name: Run cargo check
         run: cargo check --features sixel
 
-  test:
-    name: Tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-
-      - name: Install rust toolchain
-        uses: dtolnay/rust-toolchain@1.78.0
-
       - name: Run cargo test
         run: cargo test
 
-  lints:
-    name: Lints
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@nightly
-        with:
-          components: rustfmt, clippy
-
-      - name: Run cargo fmt
-        run: cargo fmt --all -- --check
-
       - name: Run cargo clippy
         run: cargo clippy -- -D warnings
+
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
+
+      - name: Run cargo fmt
+        run: cargo +nightly fmt --all -- --check
 
   nix-flake:
     name: Validate nix flake

--- a/src/code/snippet.rs
+++ b/src/code/snippet.rs
@@ -745,13 +745,10 @@ mod test {
     #[test]
     fn highlight_line_range() {
         let attributes = parse_attributes("bash {   1, 2-4,6 ,  all , 10 - 12  }");
-        assert_eq!(attributes.highlight_groups, &[HighlightGroup::new(vec![
-            Single(1),
-            Range(2..5),
-            Single(6),
-            All,
-            Range(10..13)
-        ])]);
+        assert_eq!(
+            attributes.highlight_groups,
+            &[HighlightGroup::new(vec![Single(1), Range(2..5), Single(6), All, Range(10..13)])]
+        );
     }
 
     #[test]

--- a/src/presentation/builder.rs
+++ b/src/presentation/builder.rs
@@ -733,21 +733,25 @@ impl<'a> PresentationBuilder<'a> {
     }
 
     fn push_alert(&mut self, alert_type: AlertType, title: Option<String>, mut lines: Vec<Line>) -> BuildResult {
-        let (default_title, prefix_color) = match alert_type {
-            AlertType::Note => ("Note", self.theme.alert.colors.types.note),
-            AlertType::Tip => ("Tip", self.theme.alert.colors.types.tip),
-            AlertType::Important => ("Important", self.theme.alert.colors.types.important),
-            AlertType::Warning => ("Warning", self.theme.alert.colors.types.warning),
-            AlertType::Caution => ("Caution", self.theme.alert.colors.types.caution),
+        let (prefix_color, default_title, symbol) = match alert_type {
+            AlertType::Note => self.theme.alert.styles.note.as_parts(),
+            AlertType::Tip => self.theme.alert.styles.tip.as_parts(),
+            AlertType::Important => self.theme.alert.styles.important.as_parts(),
+            AlertType::Warning => self.theme.alert.styles.warning.as_parts(),
+            AlertType::Caution => self.theme.alert.styles.caution.as_parts(),
         };
-        let prefix_color = prefix_color.or(self.theme.alert.colors.base.foreground);
+        let prefix_color = prefix_color.or(self.theme.alert.base_colors.foreground);
         let title = title.unwrap_or_else(|| default_title.to_string());
-        let title_colors = Colors { foreground: prefix_color, background: self.theme.alert.colors.base.background };
+        let title = match symbol {
+            Some(symbol) => format!("{symbol} {title}"),
+            None => title,
+        };
+        let title_colors = Colors { foreground: prefix_color, background: self.theme.alert.base_colors.background };
         lines.insert(0, Line::from(Text::from("")));
         lines.insert(0, Line::from(Text::new(title, TextStyle::default().colors(title_colors))));
 
         let prefix = self.theme.block_quote.prefix.clone().unwrap_or_default();
-        self.push_quoted_text(lines, prefix, self.theme.alert.colors.base, prefix_color)
+        self.push_quoted_text(lines, prefix, self.theme.alert.base_colors, prefix_color)
     }
 
     fn push_quoted_text(

--- a/src/presentation/builder.rs
+++ b/src/presentation/builder.rs
@@ -1685,11 +1685,10 @@ mod test {
     #[test]
     fn iterate_list_starting_from_other() {
         let list = ListIterator::new(
-            vec![ListItem { depth: 0, contents: "0".into(), item_type: ListItemType::Unordered }, ListItem {
-                depth: 0,
-                contents: "1".into(),
-                item_type: ListItemType::Unordered,
-            }],
+            vec![
+                ListItem { depth: 0, contents: "0".into(), item_type: ListItemType::Unordered },
+                ListItem { depth: 0, contents: "1".into(), item_type: ListItemType::Unordered },
+            ],
             3,
         );
         let expected_indexes = [3, 4];
@@ -1776,10 +1775,10 @@ mod test {
 
     #[test]
     fn implicit_slide_ends_with_front_matter() {
-        let elements =
-            vec![MarkdownElement::FrontMatter("theme:\n name: light".into()), MarkdownElement::SetexHeading {
-                text: "hi".into(),
-            }];
+        let elements = vec![
+            MarkdownElement::FrontMatter("theme:\n name: light".into()),
+            MarkdownElement::SetexHeading { text: "hi".into() },
+        ];
         let options = PresentationBuilderOptions { implicit_slide_ends: true, ..Default::default() };
         let slides = build_presentation_with_options(elements, options).into_slides();
         assert_eq!(slides.len(), 1);

--- a/src/ui/execution.rs
+++ b/src/ui/execution.rs
@@ -473,12 +473,15 @@ impl AsRenderOperations for RunImageSnippet {
         match state.deref() {
             RunImageSnippetState::NotStarted | RunImageSnippetState::Running(_) => vec![],
             RunImageSnippetState::Success(image) => {
-                vec![RenderOperation::RenderImage(image.clone(), ImageRenderProperties {
-                    z_index: 0,
-                    size: ImageSize::ShrinkIfNeeded,
-                    restore_cursor: false,
-                    background_color: None,
-                })]
+                vec![RenderOperation::RenderImage(
+                    image.clone(),
+                    ImageRenderProperties {
+                        z_index: 0,
+                        size: ImageSize::ShrinkIfNeeded,
+                        restore_cursor: false,
+                        background_color: None,
+                    },
+                )]
             }
             RunImageSnippetState::Failure(lines) => {
                 let mut output = Vec::new();

--- a/src/ui/footer.rs
+++ b/src/ui/footer.rs
@@ -82,10 +82,13 @@ impl AsRenderOperations for FooterGenerator {
                 let columns_ratio = (total_columns as f64 * progress_ratio).ceil();
                 let bar = character.repeat(columns_ratio as usize);
                 let bar = Text::new(bar, TextStyle::default().colors(*colors));
-                vec![RenderOperation::JumpToBottomRow { index: 0 }, RenderOperation::RenderText {
-                    line: vec![bar].into(),
-                    alignment: Alignment::Left { margin: Margin::Fixed(0) },
-                }]
+                vec![
+                    RenderOperation::JumpToBottomRow { index: 0 },
+                    RenderOperation::RenderText {
+                        line: vec![bar].into(),
+                        alignment: Alignment::Left { margin: Margin::Fixed(0) },
+                    },
+                ]
             }
             FooterStyle::Empty => vec![],
         }

--- a/themes/dark.yaml
+++ b/themes/dark.yaml
@@ -106,15 +106,20 @@ block_quote:
 
 alert:
   prefix: "▍ "
-  colors:
+  base_colors:
     foreground: palette:light_gray
     background: palette:blue_gray
-    types:
-      note: palette:blue
-      tip: palette:light_green
-      important: palette:purple
-      warning: palette:orange
-      caution: palette:red
+  styles:
+    note:
+      color: palette:blue
+    tip:
+      color: palette:light_green
+    important:
+      color: palette:purple
+    warning:
+      color: palette:orange
+    caution:
+      color: palette:red
 
 typst:
   colors:


### PR DESCRIPTION
This is a follow up on #423 that adds symbols before the title of alert type elements. The structure of the theme changed a bit to be able to pack the styles for each alert type into a single type.

This causes the following presentation:

```markdown
> [!note]
> this is a note

> [!tip]
> this is a tip

> [!important]
> this is important

> [!warning]
> this is warning!

> [!caution]
> this advises caution!

>>> [!note] other title
ez
multiline
>>>
```

To render like this:

![image](https://github.com/user-attachments/assets/ce90a4e0-7543-4100-83b2-5f8d86f4cbe2)

