### PR TITLE
feat: add support for kitty's font size protocol

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,8 @@ use crate::{
     code::snippet::SnippetLanguage,
     commands::keyboard::KeyBinding,
     terminal::{
-        GraphicsMode, emulator::TerminalEmulator, image::protocols::kitty::KittyMode, query::TerminalCapabilities,
+        GraphicsMode, capabilities::TerminalCapabilities, emulator::TerminalEmulator,
+        image::protocols::kitty::KittyMode,
     },
 };
 use clap::ValueEnum;

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -11,7 +11,7 @@ use crate::{
         builder::{BuildError, PresentationBuilder},
     },
     render::TerminalDrawer,
-    terminal::TerminalWrite,
+    terminal::{TerminalWrite, emulator::TerminalEmulator},
 };
 use std::{io, rc::Rc};
 
@@ -104,7 +104,10 @@ impl<W: TerminalWrite> ThemesDemo<W> {
         let image_registry = ImageRegistry::default();
         let mut resources = Resources::new("non_existent", image_registry.clone());
         let mut third_party = ThirdPartyRender::default();
-        let options = PresentationBuilderOptions::default();
+        let options = PresentationBuilderOptions {
+            font_size_supported: TerminalEmulator::capabilities().font_size,
+            ..Default::default()
+        };
         let executer = Rc::new(SnippetExecutor::default());
         let bindings_config = Default::default();
         let builder = PresentationBuilder::new(

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ use std::{
     rc::Rc,
     sync::Arc,
 };
+use terminal::emulator::TerminalEmulator;
 
 mod code;
 mod commands;
@@ -258,6 +259,7 @@ impl CoreComponents {
             enable_snippet_execution_replace: config.snippet.exec_replace.enable,
             render_speaker_notes_only,
             auto_render_languages: config.options.auto_render_languages.clone(),
+            font_size_supported: TerminalEmulator::capabilities().font_size,
         }
     }
 
@@ -349,6 +351,8 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         println!("{}", String::from_utf8_lossy(acknowledgements));
         return Ok(());
     } else if cli.list_themes {
+        // Load this ahead of time so we don't do it when we're already in raw mode.
+        TerminalEmulator::capabilities();
         let Customizations { config, themes, .. } =
             Customizations::load(cli.config_file.clone().map(PathBuf::from), &current_dir()?)?;
         let bindings = config.bindings.try_into()?;

--- a/src/render/engine.rs
+++ b/src/render/engine.rs
@@ -188,7 +188,7 @@ where
     }
 
     fn render_line_break(&mut self) -> RenderResult {
-        self.terminal.move_to_next_line(1)?;
+        self.terminal.move_to_next_line()?;
         Ok(())
     }
 

--- a/src/terminal/emulator.rs
+++ b/src/terminal/emulator.rs
@@ -1,6 +1,9 @@
-use super::{GraphicsMode, image::protocols::kitty::KittyMode, query::TerminalCapabilities};
+use super::{GraphicsMode, capabilities::TerminalCapabilities, image::protocols::kitty::KittyMode};
+use once_cell::sync::Lazy;
 use std::env;
 use strum::IntoEnumIterator;
+
+static CAPABILITIES: Lazy<TerminalCapabilities> = Lazy::new(|| TerminalCapabilities::query().unwrap_or_default());
 
 #[derive(Debug, strum::EnumIter)]
 pub enum TerminalEmulator {
@@ -30,8 +33,12 @@ impl TerminalEmulator {
         TerminalEmulator::Unknown
     }
 
+    pub(crate) fn capabilities() -> TerminalCapabilities {
+        CAPABILITIES.clone()
+    }
+
     pub fn preferred_protocol(&self) -> GraphicsMode {
-        let capabilities = TerminalCapabilities::query().unwrap_or_default();
+        let capabilities = Self::capabilities();
         let modes = [
             GraphicsMode::Iterm2,
             GraphicsMode::Kitty { mode: KittyMode::Local, inside_tmux: capabilities.tmux },

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -1,8 +1,8 @@
 pub(crate) mod ansi;
+pub(crate) mod capabilities;
 pub(crate) mod emulator;
 pub(crate) mod image;
 pub(crate) mod printer;
-pub(crate) mod query;
 
 pub(crate) use printer::{Terminal, TerminalWrite, should_hide_cursor};
 

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -303,6 +303,10 @@ pub(crate) struct SlideTitleStyle {
     /// Whether to use underlined font for slide titles.
     #[serde(default)]
     pub(crate) underlined: Option<bool>,
+
+    /// The font size to be used if the terminal supports it.
+    #[serde(default)]
+    pub(crate) font_size: Option<u8>,
 }
 
 impl SlideTitleStyle {
@@ -366,11 +370,16 @@ pub(crate) struct HeadingStyle {
     /// The colors to be used.
     #[serde(default)]
     pub(crate) colors: Colors,
+
+    /// The font size to be used if the terminal supports it.
+    #[serde(default)]
+    pub(crate) font_size: Option<u8>,
 }
 
 impl HeadingStyle {
     fn resolve_palette_colors(&mut self, palette: &ColorPalette) -> Result<(), UndefinedPaletteColorError> {
-        self.colors = self.colors.resolve(palette)?;
+        let Self { colors, alignment: _, prefix: _, font_size: _ } = self;
+        *colors = colors.resolve(palette)?;
         Ok(())
     }
 }
@@ -643,7 +652,7 @@ impl AlertTypeProperties for CautionAlertType {
 pub(crate) struct IntroSlideStyle {
     /// The style of the title line.
     #[serde(default)]
-    pub(crate) title: BasicStyle,
+    pub(crate) title: IntroSlideTitleStyle,
 
     /// The style of the subtitle line.
     #[serde(default)]
@@ -673,9 +682,10 @@ pub(crate) struct IntroSlideStyle {
 impl IntroSlideStyle {
     fn resolve_palette_colors(&mut self, palette: &ColorPalette) -> Result<(), UndefinedPaletteColorError> {
         let Self { title, subtitle, event, location, date, author, footer: _footer } = self;
-        for s in [title, subtitle, event, location, date] {
+        for s in [subtitle, event, location, date] {
             s.resolve_palette_colors(palette)?;
         }
+        title.resolve_palette_colors(palette)?;
         author.resolve_palette_colors(palette)?;
         Ok(())
     }
@@ -716,6 +726,30 @@ pub(crate) struct BasicStyle {
 impl BasicStyle {
     fn resolve_palette_colors(&mut self, palette: &ColorPalette) -> Result<(), UndefinedPaletteColorError> {
         let Self { colors, alignment: _ } = self;
+        *colors = colors.resolve(palette)?;
+        Ok(())
+    }
+}
+
+/// The intro slide title's style.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub(crate) struct IntroSlideTitleStyle {
+    /// The alignment.
+    #[serde(flatten, default)]
+    pub(crate) alignment: Option<Alignment>,
+
+    /// The colors to be used.
+    #[serde(default)]
+    pub(crate) colors: Colors,
+
+    /// The font size to be used if the terminal supports it.
+    #[serde(default)]
+    pub(crate) font_size: Option<u8>,
+}
+
+impl IntroSlideTitleStyle {
+    fn resolve_palette_colors(&mut self, palette: &ColorPalette) -> Result<(), UndefinedPaletteColorError> {
+        let Self { colors, alignment: _, font_size: _ } = self;
         *colors = colors.resolve(palette)?;
         Ok(())
     }

--- a/themes/catppuccin-frappe.yaml
+++ b/themes/catppuccin-frappe.yaml
@@ -13,6 +13,7 @@ slide_title:
   colors:
     foreground: "e5c890"
   bold: true
+  font_size: 2
 
 code:
   alignment: center
@@ -47,6 +48,7 @@ intro_slide:
     alignment: center
     colors:
       foreground: "a6d189"
+    font_size: 2
   subtitle:
     alignment: center
     colors:

--- a/themes/catppuccin-latte.yaml
+++ b/themes/catppuccin-latte.yaml
@@ -13,6 +13,7 @@ slide_title:
   colors:
     foreground: "df8e1d"
   bold: true
+  font_size: 2
 
 code:
   alignment: center
@@ -47,6 +48,7 @@ intro_slide:
     alignment: center
     colors:
       foreground: "40a02b"
+    font_size: 2
   subtitle:
     alignment: center
     colors:

--- a/themes/catppuccin-macchiato.yaml
+++ b/themes/catppuccin-macchiato.yaml
@@ -13,6 +13,7 @@ slide_title:
   colors:
     foreground: "eed49f"
   bold: true
+  font_size: 2
 
 code:
   alignment: center
@@ -47,6 +48,7 @@ intro_slide:
     alignment: center
     colors:
       foreground: "a6da95"
+    font_size: 2
   subtitle:
     alignment: center
     colors:

--- a/themes/catppuccin-mocha.yaml
+++ b/themes/catppuccin-mocha.yaml
@@ -13,6 +13,7 @@ slide_title:
   colors:
     foreground: "f9e2af"
   bold: true
+  font_size: 2
 
 code:
   alignment: center
@@ -47,6 +48,7 @@ intro_slide:
     alignment: center
     colors:
       foreground: "a6e3a1"
+    font_size: 2
   subtitle:
     alignment: center
     colors:

--- a/themes/dark.yaml
+++ b/themes/dark.yaml
@@ -13,6 +13,7 @@ slide_title:
   colors:
     foreground: palette:orange
   bold: true
+  font_size: 2
 
 code:
   alignment: center
@@ -48,6 +49,7 @@ intro_slide:
     alignment: center
     colors:
       foreground: palette:light_blue
+    font_size: 2
   subtitle:
     alignment: center
     colors:

--- a/themes/light.yaml
+++ b/themes/light.yaml
@@ -13,6 +13,7 @@ slide_title:
   colors:
     foreground: "f77f00"
   bold: true
+  font_size: 2
 
 code:
   alignment: center
@@ -48,6 +49,7 @@ intro_slide:
     alignment: center
     colors:
       foreground: "52b788"
+    font_size: 2
   subtitle:
     alignment: center
     colors:

--- a/themes/terminal-dark.yaml
+++ b/themes/terminal-dark.yaml
@@ -13,6 +13,7 @@ slide_title:
   colors:
     foreground: yellow
   bold: true
+  font_size: 2
 
 code:
   alignment: center
@@ -46,6 +47,7 @@ intro_slide:
     alignment: center
     colors:
       foreground: green
+    font_size: 2
   subtitle:
     alignment: center
     colors:

--- a/themes/terminal-light.yaml
+++ b/themes/terminal-light.yaml
@@ -13,6 +13,7 @@ slide_title:
   colors:
     foreground: dark_yellow
   bold: true
+  font_size: 2
 
 code:
   alignment: center
@@ -46,6 +47,7 @@ intro_slide:
     alignment: center
     colors:
       foreground: dark_green
+    font_size: 2
   subtitle:
     alignment: center
     colors:

--- a/themes/tokyonight-storm.yaml
+++ b/themes/tokyonight-storm.yaml
@@ -13,6 +13,7 @@ slide_title:
   colors:
     foreground: "e0af68"
   bold: true
+  font_size: 2
 
 code:
   alignment: center
@@ -48,6 +49,7 @@ intro_slide:
     alignment: center
     colors:
       foreground: "7aa2f7"
+    font_size: 2
   subtitle:
     alignment: center
     colors:


### PR DESCRIPTION
This adds support for kitty's font size protocol (https://github.com/kovidgoyal/kitty/issues/8226) which allows printing characters that take up more than one cell. This feature will be available in kitty >= 0.40.0 and is currently only available in nightly builds.

This for now is only supported in a subset of the theme components, namely:

* The introduction slide's presentation title (`intro_slide.title.font_size`).
* The slide titles (`slide_title.font_size`).
* The headings (`headings.h*.font_size`).

Font sizes are only used if the terminal emulator supports it so this doesn't change anything for emulators other than kitty (or other implementors of the protocol). If you find this somehow breaks something, please create an issue.

For now all built in themes set `intro_slide.title.font_size=2` and `slide_title.font_size=2`. I think this looks a lot better this way but please do comment here if you don't think built in themes should come with these values set.

These are now the first 2 slides in the `demo.md` example:

https://github.com/user-attachments/assets/8d761d86-8855-498a-9766-5294cdae3b57


