### PR TITLE
chore: restructure `Terminal` code and add test for margins/layouts

### DIFF
--- a/src/demo.rs
+++ b/src/demo.rs
@@ -11,7 +11,7 @@ use crate::{
         builder::{BuildError, PresentationBuilder},
     },
     render::TerminalDrawer,
-    terminal::{TerminalWrite, emulator::TerminalEmulator},
+    terminal::emulator::TerminalEmulator,
 };
 use std::{io, rc::Rc};
 
@@ -40,16 +40,16 @@ fn greet(name: &str) -> String {
 <!-- end_slide -->
 "#;
 
-pub struct ThemesDemo<W: TerminalWrite> {
+pub struct ThemesDemo {
     themes: Themes,
     input: KeyboardListener,
-    drawer: TerminalDrawer<W>,
+    drawer: TerminalDrawer,
 }
 
-impl<W: TerminalWrite> ThemesDemo<W> {
-    pub fn new(themes: Themes, bindings: CommandKeyBindings, writer: W) -> io::Result<Self> {
+impl ThemesDemo {
+    pub fn new(themes: Themes, bindings: CommandKeyBindings) -> io::Result<Self> {
         let input = KeyboardListener::new(bindings);
-        let drawer = TerminalDrawer::new(writer, Default::default(), Default::default())?;
+        let drawer = TerminalDrawer::new(Default::default(), Default::default())?;
         Ok(Self { themes, input, drawer })
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -356,7 +356,7 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         let Customizations { config, themes, .. } =
             Customizations::load(cli.config_file.clone().map(PathBuf::from), &current_dir()?)?;
         let bindings = config.bindings.try_into()?;
-        let demo = ThemesDemo::new(themes, bindings, io::stdout())?;
+        let demo = ThemesDemo::new(themes, bindings)?;
         demo.run()?;
         return Ok(());
     }

--- a/src/presentation/builder.rs
+++ b/src/presentation/builder.rs
@@ -273,8 +273,9 @@ impl<'a> PresentationBuilder<'a> {
         self.chunk_operations.extend([
             RenderOperation::ClearScreen,
             RenderOperation::ApplyMargin(MarginProperties {
-                horizontal_margin: self.theme.default_style.margin.clone().unwrap_or_default(),
-                bottom_slide_margin: DEFAULT_BOTTOM_SLIDE_MARGIN,
+                horizontal: self.theme.default_style.margin.clone().unwrap_or_default(),
+                top: 0,
+                bottom: DEFAULT_BOTTOM_SLIDE_MARGIN,
             }),
         ]);
         self.push_line_break();

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -17,7 +17,10 @@ use crate::{
         properties::WindowSize, validate::OverflowValidator,
     },
     resource::Resources,
-    terminal::image::printer::{ImagePrinter, ImageRegistry},
+    terminal::{
+        image::printer::{ImagePrinter, ImageRegistry},
+        printer::TerminalIo,
+    },
     theme::PresentationTheme,
     third_party::ThirdPartyRender,
 };
@@ -25,7 +28,7 @@ use std::{
     collections::HashSet,
     fmt::Display,
     fs,
-    io::{self, Stdout},
+    io::{self},
     mem,
     ops::Deref,
     path::Path,
@@ -103,7 +106,7 @@ impl<'a> Presenter<'a> {
             font_size_fallback: self.options.font_size_fallback,
             max_columns: self.options.max_columns,
         };
-        let mut drawer = TerminalDrawer::new(io::stdout(), self.image_printer.clone(), drawer_options)?;
+        let mut drawer = TerminalDrawer::new(self.image_printer.clone(), drawer_options)?;
         loop {
             if matches!(self.options.mode, PresentMode::Export) {
                 if let PresenterState::Failure { error, .. } = &self.state {
@@ -202,7 +205,7 @@ impl<'a> Presenter<'a> {
         Ok(false)
     }
 
-    fn render(&mut self, drawer: &mut TerminalDrawer<Stdout>) -> RenderResult {
+    fn render(&mut self, drawer: &mut TerminalDrawer) -> RenderResult {
         let result = match &self.state {
             PresenterState::Presenting(presentation) => {
                 drawer.render_operations(presentation.current_slide().iter_visible_operations())
@@ -392,7 +395,7 @@ impl<'a> Presenter<'a> {
         }
     }
 
-    fn suspend(&self, drawer: &mut TerminalDrawer<Stdout>) {
+    fn suspend(&self, drawer: &mut TerminalDrawer) {
         #[cfg(unix)]
         unsafe {
             drawer.terminal.suspend();

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -13,13 +13,16 @@ use crate::{
     },
     render::{operation::RenderOperation, properties::WindowSize},
     terminal::{
-        Terminal, TerminalWrite,
+        Terminal,
         image::printer::{ImagePrinter, PrintImageError},
     },
     theme::{Alignment, Margin},
 };
 use engine::{RenderEngine, RenderEngineOptions};
-use std::{io, sync::Arc};
+use std::{
+    io::{self, Stdout},
+    sync::Arc,
+};
 
 /// The result of a render operation.
 pub(crate) type RenderResult = Result<(), RenderError>;
@@ -39,17 +42,14 @@ impl Default for TerminalDrawerOptions {
 }
 
 /// Allows drawing on the terminal.
-pub(crate) struct TerminalDrawer<W: TerminalWrite> {
-    pub(crate) terminal: Terminal<W>,
+pub(crate) struct TerminalDrawer {
+    pub(crate) terminal: Terminal<Stdout>,
     options: TerminalDrawerOptions,
 }
 
-impl<W> TerminalDrawer<W>
-where
-    W: TerminalWrite,
-{
-    pub(crate) fn new(handle: W, image_printer: Arc<ImagePrinter>, options: TerminalDrawerOptions) -> io::Result<Self> {
-        let terminal = Terminal::new(handle, image_printer)?;
+impl TerminalDrawer {
+    pub(crate) fn new(image_printer: Arc<ImagePrinter>, options: TerminalDrawerOptions) -> io::Result<Self> {
+        let terminal = Terminal::new(io::stdout(), image_printer)?;
         Ok(Self { terminal, options })
     }
 
@@ -97,7 +97,7 @@ where
         Ok(())
     }
 
-    fn create_engine(&mut self, dimensions: WindowSize) -> RenderEngine<W> {
+    fn create_engine(&mut self, dimensions: WindowSize) -> RenderEngine<Terminal<Stdout>> {
         let options = RenderEngineOptions { max_columns: self.options.max_columns, ..Default::default() };
         RenderEngine::new(&mut self.terminal, dimensions, options)
     }

--- a/src/render/operation.rs
+++ b/src/render/operation.rs
@@ -113,10 +113,13 @@ pub(crate) enum ImageSize {
 #[derive(Clone, Debug, Default)]
 pub(crate) struct MarginProperties {
     /// The horizontal margin.
-    pub(crate) horizontal_margin: Margin,
+    pub(crate) horizontal: Margin,
 
-    /// The margin at the bottom of the slide.
-    pub(crate) bottom_slide_margin: u16,
+    /// The margin at the top.
+    pub(crate) top: u16,
+
+    /// The margin at the bottom.
+    pub(crate) bottom: u16,
 }
 
 /// A type that can generate render operations.

--- a/src/render/text.rs
+++ b/src/render/text.rs
@@ -87,8 +87,10 @@ impl<'a> TextDrawer<'a> {
             let Text { content, style } = self.prefix.text();
             style.apply(content)?
         };
-        terminal.move_to_column(self.positioning.start_column)?;
-        terminal.print_styled_line(styled_prefix.clone(), &self.properties)?;
+        if self.prefix.width() > 0 {
+            terminal.move_to_column(self.positioning.start_column)?;
+            terminal.print_styled_line(styled_prefix.clone(), &self.properties)?;
+        }
 
         let start_column = self.positioning.start_column + self.prefix_length;
         for (line_index, line) in self.line.split(self.positioning.max_line_length as usize).enumerate() {

--- a/src/render/text.rs
+++ b/src/render/text.rs
@@ -5,7 +5,7 @@ use crate::{
         text_style::{Color, Colors},
     },
     render::{RenderError, RenderResult, layout::Positioning},
-    terminal::{Terminal, TerminalWrite, printer::TextProperties},
+    terminal::printer::{TerminalIo, TextProperties},
 };
 
 const MINIMUM_LINE_LENGTH: u16 = 10;
@@ -76,9 +76,9 @@ impl<'a> TextDrawer<'a> {
     /// Draw text on the given handle.
     ///
     /// This performs word splitting and word wrapping.
-    pub(crate) fn draw<W>(self, terminal: &mut Terminal<W>) -> RenderResult
+    pub(crate) fn draw<T>(self, terminal: &mut T) -> RenderResult
     where
-        W: TerminalWrite,
+        T: TerminalIo,
     {
         let mut line_length: u16 = 0;
 
@@ -127,9 +127,9 @@ impl<'a> TextDrawer<'a> {
         Ok(())
     }
 
-    fn print_block_background<W>(&self, line_length: u16, terminal: &mut Terminal<W>) -> RenderResult
+    fn print_block_background<T>(&self, line_length: u16, terminal: &mut T) -> RenderResult
     where
-        W: TerminalWrite,
+        T: TerminalIo,
     {
         if self.draw_block {
             let remaining =

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -295,7 +295,7 @@ impl CenterModalContent {
 impl AsRenderOperations for CenterModalContent {
     fn as_render_operations(&self, dimensions: &WindowSize) -> Vec<RenderOperation> {
         let margin = dimensions.columns.saturating_sub(self.content_width) / 2;
-        let properties = MarginProperties { horizontal_margin: Margin::Fixed(margin), bottom_slide_margin: 0 };
+        let properties = MarginProperties { horizontal: Margin::Fixed(margin), top: 0, bottom: 0 };
         // However many we see + 3 for the title and 1 at the bottom.
         let content_height = (self.content_height + 4) as u16;
         let target_row = dimensions.rows.saturating_sub(content_height) / 2;


### PR DESCRIPTION
This refactors the `Terminal` code a bit to be able to test it, and add tests to layout handling since the implementation for #437 will require creating new rect to print the images in.