### PR TITLE
fix: don't squash image if font is not 2:1

### DIFF
--- a/src/demo.rs
+++ b/src/demo.rs
@@ -102,7 +102,7 @@ impl ThemesDemo {
         theme: &PresentationTheme,
     ) -> Result<Presentation, BuildError> {
         let image_registry = ImageRegistry::default();
-        let mut resources = Resources::new("non_existent", image_registry.clone());
+        let resources = Resources::new("non_existent", image_registry.clone());
         let mut third_party = ThirdPartyRender::default();
         let options = PresentationBuilderOptions {
             font_size_supported: TerminalEmulator::capabilities().font_size,
@@ -112,7 +112,7 @@ impl ThemesDemo {
         let bindings_config = Default::default();
         let builder = PresentationBuilder::new(
             theme,
-            &mut resources,
+            resources,
             &mut third_party,
             executer,
             &self.themes,

--- a/src/export.rs
+++ b/src/export.rs
@@ -95,7 +95,7 @@ impl<'a> Exporter<'a> {
         let path = path.canonicalize().expect("canonicalize");
         let mut presentation = PresentationBuilder::new(
             self.default_theme,
-            &mut self.resources,
+            self.resources.clone(),
             &mut self.third_party,
             self.code_executor.clone(),
             &self.themes,

--- a/src/presentation/builder.rs
+++ b/src/presentation/builder.rs
@@ -132,7 +132,7 @@ pub(crate) struct PresentationBuilder<'a> {
     highlighter: SnippetHighlighter,
     code_executor: Rc<SnippetExecutor>,
     theme: Cow<'a, PresentationTheme>,
-    resources: &'a mut Resources,
+    resources: Resources,
     third_party: &'a mut ThirdPartyRender,
     slide_state: SlideState,
     presentation_state: PresentationState,
@@ -149,7 +149,7 @@ impl<'a> PresentationBuilder<'a> {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         default_theme: &'a PresentationTheme,
-        resources: &'a mut Resources,
+        resources: Resources,
         third_party: &'a mut ThirdPartyRender,
         code_executor: Rc<SnippetExecutor>,
         themes: &'a Themes,
@@ -662,10 +662,9 @@ impl<'a> PresentationBuilder<'a> {
             None => ImageSize::ShrinkIfNeeded,
         };
         let properties = ImageRenderProperties {
-            z_index: DEFAULT_IMAGE_Z_INDEX,
             size,
-            restore_cursor: false,
             background_color: self.theme.default_style.colors.background,
+            ..Default::default()
         };
         self.chunk_operations.push(RenderOperation::RenderImage(image, properties));
         self.set_colors(self.theme.default_style.colors)?;
@@ -1450,14 +1449,14 @@ mod test {
         options: PresentationBuilderOptions,
     ) -> Result<Presentation, BuildError> {
         let theme = PresentationTheme::default();
-        let mut resources = Resources::new("/tmp", Default::default());
+        let resources = Resources::new("/tmp", Default::default());
         let mut third_party = ThirdPartyRender::default();
         let code_executor = Rc::new(SnippetExecutor::default());
         let themes = Themes::default();
         let bindings = KeyBindingsConfig::default();
         let builder = PresentationBuilder::new(
             &theme,
-            &mut resources,
+            resources,
             &mut third_party,
             code_executor,
             &themes,

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -357,7 +357,7 @@ impl<'a> Presenter<'a> {
         let export_mode = matches!(self.options.mode, PresentMode::Export);
         let mut presentation = PresentationBuilder::new(
             self.default_theme,
-            &mut self.resources,
+            self.resources.clone(),
             &mut self.third_party,
             self.code_executor.clone(),
             &self.themes,

--- a/src/render/operation.rs
+++ b/src/render/operation.rs
@@ -4,6 +4,7 @@ use crate::{
         text::{WeightedLine, WeightedText},
         text_style::{Color, Colors},
     },
+    presentation::builder::DEFAULT_IMAGE_Z_INDEX,
     terminal::image::Image,
     theme::{Alignment, Margin},
 };
@@ -96,6 +97,19 @@ pub(crate) struct ImageRenderProperties {
     pub(crate) size: ImageSize,
     pub(crate) restore_cursor: bool,
     pub(crate) background_color: Option<Color>,
+    pub(crate) center: bool,
+}
+
+impl Default for ImageRenderProperties {
+    fn default() -> Self {
+        Self {
+            z_index: DEFAULT_IMAGE_Z_INDEX,
+            size: Default::default(),
+            restore_cursor: false,
+            background_color: None,
+            center: true,
+        }
+    }
 }
 
 /// The size used when printing an image.

--- a/src/render/properties.rs
+++ b/src/render/properties.rs
@@ -27,10 +27,10 @@ impl WindowSize {
         };
         let font_size_fallback = font_size_fallback as u16;
         if size.width == 0 {
-            size.width = size.columns * font_size_fallback;
+            size.width = size.columns * font_size_fallback.max(1);
         }
         if size.height == 0 {
-            size.height = size.rows * font_size_fallback * 2;
+            size.height = size.rows * font_size_fallback.max(1) * 2;
         }
         Ok(size)
     }
@@ -71,6 +71,11 @@ impl WindowSize {
     /// The number of pixels per row.
     pub(crate) fn pixels_per_row(&self) -> f64 {
         self.height as f64 / self.rows as f64
+    }
+
+    /// The aspect ratio for this size.
+    pub(crate) fn aspect_ratio(&self) -> f64 {
+        (self.rows as f64 / self.height as f64) / (self.columns as f64 / self.width as f64)
     }
 }
 

--- a/src/terminal/image/scale.rs
+++ b/src/terminal/image/scale.rs
@@ -1,64 +1,106 @@
 use crate::render::properties::{CursorPosition, WindowSize};
 
-/// Scale an image to a specific size.
-pub(crate) fn scale_image(
-    scale_size: &WindowSize,
-    window_dimensions: &WindowSize,
-    image_width: u32,
-    image_height: u32,
-    position: &CursorPosition,
-) -> TerminalRect {
-    let aspect_ratio = image_height as f64 / image_width as f64;
-    let column_in_pixels = scale_size.pixels_per_column();
-    let width_in_columns = scale_size.columns;
-    let image_width = width_in_columns as f64 * column_in_pixels;
-    let image_height = image_width * aspect_ratio;
-
-    fit_image_to_window(window_dimensions, image_width as u32, image_height as u32, position)
+pub(crate) struct ImageScaler {
+    horizontal_margin: f64,
 }
 
-/// Shrink an image so it fits the dimensions of the layout it's being displayed in.
-pub(crate) fn fit_image_to_window(
-    dimensions: &WindowSize,
-    image_width: u32,
-    image_height: u32,
-    position: &CursorPosition,
-) -> TerminalRect {
-    let aspect_ratio = image_height as f64 / image_width as f64;
+impl ImageScaler {
+    /// Scale an image to a specific size.
+    pub(crate) fn scale_image(
+        &self,
+        scale_size: &WindowSize,
+        window_dimensions: &WindowSize,
+        image_width: u32,
+        image_height: u32,
+        position: &CursorPosition,
+    ) -> TerminalRect {
+        let aspect_ratio = image_height as f64 / image_width as f64;
+        let column_in_pixels = scale_size.pixels_per_column();
+        let width_in_columns = scale_size.columns;
+        let image_width = width_in_columns as f64 * column_in_pixels;
+        let image_height = image_width * aspect_ratio;
 
-    // Compute the image's width in columns by translating pixels -> columns.
-    let column_in_pixels = dimensions.pixels_per_column();
-    let column_margin = (dimensions.columns as f64 * 0.95) as u32;
-    let mut width_in_columns = (image_width as f64 / column_in_pixels) as u32;
-
-    // Do the same for its height.
-    let row_in_pixels = dimensions.pixels_per_row();
-    let height_in_rows = (image_height as f64 / row_in_pixels) as u32;
-
-    // If the image doesn't fit vertically, shrink it.
-    let available_height = dimensions.rows.saturating_sub(position.row) as u32;
-    if height_in_rows > available_height {
-        // Because we only use the width to draw, here we scale the width based on how much we
-        // need to shrink the height.
-        let shrink_ratio = available_height as f64 / height_in_rows as f64;
-        width_in_columns = (width_in_columns as f64 * shrink_ratio).ceil() as u32;
+        self.fit_image_to_rect(window_dimensions, image_width as u32, image_height as u32, position)
     }
-    // Don't go too far wide.
-    let width_in_columns = width_in_columns.min(column_margin);
-    let height_in_rows = (width_in_columns as f64 * aspect_ratio / 2.0) as u16;
 
-    let width_in_columns = width_in_columns.max(1);
-    let height_in_rows = height_in_rows.max(1);
+    /// Shrink an image so it fits the dimensions of the layout it's being displayed in.
+    pub(crate) fn fit_image_to_rect(
+        &self,
+        dimensions: &WindowSize,
+        image_width: u32,
+        image_height: u32,
+        position: &CursorPosition,
+    ) -> TerminalRect {
+        let aspect_ratio = image_height as f64 / image_width as f64;
 
-    // Draw it in the middle
-    let start_column = dimensions.columns / 2 - (width_in_columns / 2) as u16;
-    let start_column = start_column + position.column;
-    TerminalRect { start_column, columns: width_in_columns as u16, rows: height_in_rows }
+        // Compute the image's width in columns by translating pixels -> columns.
+        let column_in_pixels = dimensions.pixels_per_column();
+        let column_margin = (dimensions.columns as f64 * (1.0 - self.horizontal_margin)) as u32;
+        let mut width_in_columns = (image_width as f64 / column_in_pixels) as u32;
+
+        // Do the same for its height.
+        let row_in_pixels = dimensions.pixels_per_row();
+        let height_in_rows = (image_height as f64 / row_in_pixels) as u32;
+
+        // If the image doesn't fit vertically, shrink it.
+        let available_height = dimensions.rows.saturating_sub(position.row) as u32;
+        if height_in_rows > available_height {
+            // Because we only use the width to draw, here we scale the width based on how much we
+            // need to shrink the height.
+            let shrink_ratio = available_height as f64 / height_in_rows as f64;
+            width_in_columns = (width_in_columns as f64 * shrink_ratio).round() as u32;
+        }
+        // Don't go too far wide.
+        let width_in_columns = width_in_columns.min(column_margin);
+
+        // Now translate width -> height by using the original aspect ratio + translate based on
+        // the window size's aspect ratio.
+        let height_in_rows = (width_in_columns as f64 * aspect_ratio * dimensions.aspect_ratio()).round() as u16;
+
+        let width_in_columns = width_in_columns.max(1);
+        let height_in_rows = height_in_rows.max(1);
+
+        TerminalRect { columns: width_in_columns as u16, rows: height_in_rows }
+    }
 }
 
-#[derive(Debug)]
+impl Default for ImageScaler {
+    fn default() -> Self {
+        Self { horizontal_margin: 0.05 }
+    }
+}
+
+#[derive(Debug, PartialEq)]
 pub(crate) struct TerminalRect {
-    pub(crate) start_column: u16,
     pub(crate) columns: u16,
     pub(crate) rows: u16,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    const WINDOW: WindowSize = WindowSize { rows: 50, columns: 100, height: 200, width: 200 };
+    const SMALL_WINDOW: WindowSize = WindowSize { rows: 3, columns: 6, height: 10, width: 10 };
+    const OTHER_RATIO: WindowSize = WindowSize { rows: 10, columns: 10, height: 10, width: 10 };
+
+    #[rstest]
+    #[case::squares(WINDOW, 100, 100, TerminalRect { columns: 50, rows: 25 })]
+    #[case::squares_smaller(WINDOW, 50, 50, TerminalRect { columns: 25, rows: 13 })]
+    #[case::square_too_large(WINDOW, 400, 400, TerminalRect { columns: 100, rows: 50 })]
+    #[case::too_tall(WINDOW, 200, 400, TerminalRect { columns: 50, rows: 50 })]
+    #[case::too_wide(WINDOW, 400, 200, TerminalRect { columns: 100, rows: 25 })]
+    #[case::small(SMALL_WINDOW, 899, 872, TerminalRect { columns: 6, rows: 3 })]
+    #[case::other_ratio(OTHER_RATIO, 100, 100, TerminalRect { columns: 10, rows: 10 })]
+    fn image_fitting(
+        #[case] window: WindowSize,
+        #[case] width: u32,
+        #[case] height: u32,
+        #[case] expected: TerminalRect,
+    ) {
+        let cursor = CursorPosition::default();
+        let rect = ImageScaler { horizontal_margin: 0.0 }.fit_image_to_rect(&window, width, height, &cursor);
+        assert_eq!(rect, expected);
+    }
 }

--- a/src/third_party.rs
+++ b/src/third_party.rs
@@ -5,7 +5,7 @@ use crate::{
         elements::{Line, Percent, Text},
         text_style::{Color, Colors, TextStyle},
     },
-    presentation::{AsyncPresentationError, AsyncPresentationErrorHolder, builder::DEFAULT_IMAGE_Z_INDEX},
+    presentation::{AsyncPresentationError, AsyncPresentationErrorHolder},
     render::{
         operation::{
             AsRenderOperations, ImageRenderProperties, ImageSize, RenderAsync, RenderAsyncState, RenderOperation,
@@ -359,10 +359,9 @@ impl AsRenderOperations for RenderThirdParty {
                     None => Default::default(),
                 };
                 let properties = ImageRenderProperties {
-                    z_index: DEFAULT_IMAGE_Z_INDEX,
                     size,
-                    restore_cursor: false,
                     background_color: self.default_colors.background,
+                    ..Default::default()
                 };
 
                 vec![

--- a/src/ui/execution.rs
+++ b/src/ui/execution.rs
@@ -11,8 +11,7 @@ use crate::{
     },
     render::{
         operation::{
-            AsRenderOperations, BlockLine, ImageRenderProperties, ImageSize, RenderAsync, RenderAsyncState,
-            RenderOperation,
+            AsRenderOperations, BlockLine, ImageRenderProperties, RenderAsync, RenderAsyncState, RenderOperation,
         },
         properties::WindowSize,
     },
@@ -473,15 +472,7 @@ impl AsRenderOperations for RunImageSnippet {
         match state.deref() {
             RunImageSnippetState::NotStarted | RunImageSnippetState::Running(_) => vec![],
             RunImageSnippetState::Success(image) => {
-                vec![RenderOperation::RenderImage(
-                    image.clone(),
-                    ImageRenderProperties {
-                        z_index: 0,
-                        size: ImageSize::ShrinkIfNeeded,
-                        restore_cursor: false,
-                        background_color: None,
-                    },
-                )]
+                vec![RenderOperation::RenderImage(image.clone(), ImageRenderProperties::default())]
             }
             RunImageSnippetState::Failure(lines) => {
                 let mut output = Vec::new();

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -308,6 +308,7 @@ impl AsRenderOperations for CenterModalContent {
                 size: ImageSize::Specific(self.content_width, content_height),
                 restore_cursor: true,
                 background_color: None,
+                center: true,
             };
             operations.push(RenderOperation::RenderImage(image.clone(), properties));
         }


### PR DESCRIPTION
Images looked a little squashed vertically if the font being used in the terminal didn't have a 2:1 ratio between between columns and rows. This also adds some much needed tests around this code, and fixes some rounding issues when the image is small enough to only need a handful of columns/rows to be displayed.

Fixes #445