### PR TITLE
feat: support images in footer

### DIFF
--- a/src/demo.rs
+++ b/src/demo.rs
@@ -102,7 +102,7 @@ impl ThemesDemo {
         theme: &PresentationTheme,
     ) -> Result<Presentation, BuildError> {
         let image_registry = ImageRegistry::default();
-        let resources = Resources::new("non_existent", image_registry.clone());
+        let resources = Resources::new("non_existent", "non_existent", image_registry.clone());
         let mut third_party = ThirdPartyRender::default();
         let options = PresentationBuilderOptions {
             font_size_supported: TerminalEmulator::capabilities().font_size,

--- a/src/export.rs
+++ b/src/export.rs
@@ -360,7 +360,7 @@ mod test {
         let arena = Arena::new();
         let parser = MarkdownParser::new(&arena);
         let theme = PresentationThemeSet::default().load_by_name("dark").unwrap();
-        let resources = Resources::new("examples", Default::default());
+        let resources = Resources::new("examples", "examples", Default::default());
         let third_party = ThirdPartyRender::default();
         let code_executor = Default::default();
         let themes = Themes::default();

--- a/src/render/operation.rs
+++ b/src/render/operation.rs
@@ -4,11 +4,12 @@ use crate::{
         text::{WeightedLine, WeightedText},
         text_style::{Color, Colors},
     },
-    presentation::builder::DEFAULT_IMAGE_Z_INDEX,
     terminal::image::Image,
     theme::{Alignment, Margin},
 };
 use std::{fmt::Debug, rc::Rc};
+
+const DEFAULT_IMAGE_Z_INDEX: i32 = -2;
 
 /// A line of preformatted text to be rendered.
 #[derive(Clone, Debug, PartialEq)]
@@ -46,6 +47,9 @@ pub(crate) enum RenderOperation {
     ///
     /// The index is zero based where 0 represents the bottom row.
     JumpToBottomRow { index: u16 },
+
+    /// Jump to the N-th column in the current layout.
+    JumpToColumn { index: u16 },
 
     /// Render text.
     RenderText { line: WeightedLine, alignment: Alignment },

--- a/src/terminal/emulator.rs
+++ b/src/terminal/emulator.rs
@@ -1,9 +1,8 @@
 use super::{GraphicsMode, capabilities::TerminalCapabilities, image::protocols::kitty::KittyMode};
-use once_cell::sync::Lazy;
-use std::env;
+use std::{env, sync::OnceLock};
 use strum::IntoEnumIterator;
 
-static CAPABILITIES: Lazy<TerminalCapabilities> = Lazy::new(|| TerminalCapabilities::query().unwrap_or_default());
+static CAPABILITIES: OnceLock<TerminalCapabilities> = OnceLock::new();
 
 #[derive(Debug, strum::EnumIter)]
 pub enum TerminalEmulator {
@@ -34,7 +33,11 @@ impl TerminalEmulator {
     }
 
     pub(crate) fn capabilities() -> TerminalCapabilities {
-        CAPABILITIES.clone()
+        CAPABILITIES.get_or_init(|| TerminalCapabilities::query().unwrap_or_default()).clone()
+    }
+
+    pub(crate) fn disable_capability_detection() {
+        CAPABILITIES.get_or_init(TerminalCapabilities::default);
     }
 
     pub fn preferred_protocol(&self) -> GraphicsMode {

--- a/src/terminal/image/printer.rs
+++ b/src/terminal/image/printer.rs
@@ -103,7 +103,7 @@ impl ImagePrinter {
     }
 
     fn new_iterm() -> Self {
-        Self::Iterm(ItermPrinter::default())
+        Self::Iterm(ItermPrinter)
     }
 
     fn new_ascii() -> Self {

--- a/src/terminal/image/protocols/iterm.rs
+++ b/src/terminal/image/protocols/iterm.rs
@@ -1,7 +1,7 @@
 use crate::terminal::image::printer::{ImageProperties, PrintImage, PrintImageError, PrintOptions, RegisterImageError};
 use base64::{Engine, engine::general_purpose::STANDARD};
 use image::{GenericImageView, ImageEncoder, codecs::png::PngEncoder};
-use std::{env, fs, path::Path};
+use std::{fs, path::Path};
 
 pub(crate) struct ItermImage {
     dimensions: (u32, u32),
@@ -23,23 +23,8 @@ impl ImageProperties for ItermImage {
     }
 }
 
-pub struct ItermPrinter {
-    // Whether this is iterm2. Otherwise it can be a terminal that _supports_ the iterm2 protocol.
-    is_iterm: bool,
-}
-
-impl Default for ItermPrinter {
-    fn default() -> Self {
-        for key in ["TERM_PROGRAM", "LC_TERMINAL"] {
-            if let Ok(value) = env::var(key) {
-                if value.contains("iTerm") {
-                    return Self { is_iterm: true };
-                }
-            }
-        }
-        Self { is_iterm: false }
-    }
-}
+#[derive(Default)]
+pub struct ItermPrinter;
 
 impl PrintImage for ItermPrinter {
     type Image = ItermImage;
@@ -68,13 +53,8 @@ impl PrintImage for ItermPrinter {
         let contents = &image.base64_contents;
         write!(
             writer,
-            "\x1b]1337;File=size={size};width={columns};height={rows};inline=1;preserveAspectRatio=0:{contents}\x07"
+            "\x1b]1337;File=size={size};width={columns};height={rows};inline=1;preserveAspectRatio=1:{contents}\x07"
         )?;
-        // iterm2 really respects what we say and leaves no space, whereas wezterm does leave an
-        // extra line here.
-        if self.is_iterm {
-            writeln!(writer)?;
-        }
         Ok(())
     }
 }

--- a/src/terminal/image/protocols/kitty.rs
+++ b/src/terminal/image/protocols/kitty.rs
@@ -398,7 +398,6 @@ impl PrintImage for KittyPrinter {
             GenericResource::Image(resource) => self.print_image(image.dimensions, resource, writer, options)?,
             GenericResource::Gif(frames) => self.print_gif(image.dimensions, frames, writer, options)?,
         };
-        writeln!(writer)?;
         Ok(())
     }
 }

--- a/src/third_party.rs
+++ b/src/third_party.rs
@@ -364,10 +364,7 @@ impl AsRenderOperations for RenderThirdParty {
                     ..Default::default()
                 };
 
-                vec![
-                    RenderOperation::RenderImage(image.clone(), properties),
-                    RenderOperation::SetColors(self.default_colors),
-                ]
+                vec![RenderOperation::RenderImage(image.clone(), properties)]
             }
             None => {
                 let text = Line::from(Text::new("Loading...", TextStyle::default().bold()));

--- a/src/ui/footer.rs
+++ b/src/ui/footer.rs
@@ -4,17 +4,22 @@ use crate::{
         text_style::{Colors, TextStyle},
     },
     render::{
-        operation::{AsRenderOperations, RenderOperation},
+        operation::{AsRenderOperations, ImageRenderProperties, MarginProperties, RenderOperation},
         properties::WindowSize,
     },
-    theme::{Alignment, FooterStyle, FooterTemplate, FooterTemplateChunk, Margin},
+    resource::Resources,
+    terminal::image::printer::RegisterImageError,
+    theme::{Alignment, FooterContent, FooterStyle, FooterTemplate, FooterTemplateChunk, Margin},
 };
 use std::{
     cell::RefCell,
     io::{BufWriter, Write},
+    path::Path,
     rc::Rc,
 };
 use unicode_width::UnicodeWidthStr;
+
+pub(crate) const DEFAULT_FOOTER_HEIGHT: u16 = 3;
 
 #[derive(Debug, Default)]
 pub(crate) struct FooterContext {
@@ -29,19 +34,38 @@ pub(crate) struct FooterContext {
 
 #[derive(Debug)]
 pub(crate) struct FooterGenerator {
-    pub(crate) current_slide: usize,
-    pub(crate) context: Rc<RefCell<FooterContext>>,
-    pub(crate) style: FooterStyle,
+    current_slide: usize,
+    context: Rc<RefCell<FooterContext>>,
+    style: FooterStyle,
+    resources: Resources,
 }
 
 impl FooterGenerator {
+    pub(crate) fn new(
+        current_slide: usize,
+        context: Rc<RefCell<FooterContext>>,
+        style: FooterStyle,
+        resources: Resources,
+    ) -> Result<Self, RegisterImageError> {
+        if let FooterStyle::Template { left, center, .. } = &style {
+            for content in [left, center].into_iter().flatten() {
+                // Load it to make sure we can
+                if let FooterContent::Image { path } = content {
+                    resources.theme_image(path)?;
+                }
+            }
+        }
+        Ok(Self { current_slide, context, style, resources })
+    }
+
     fn render_template(
         template: &FooterTemplate,
         current_slide: &str,
         context: &FooterContext,
         colors: Colors,
         alignment: Alignment,
-    ) -> RenderOperation {
+        operations: &mut Vec<RenderOperation>,
+    ) {
         use FooterTemplateChunk::*;
         let mut w = BufWriter::new(Vec::new());
         let FooterContext { total_slides, author, title, sub_title, event, location, date } = context;
@@ -61,7 +85,42 @@ impl FooterGenerator {
         }
         let contents = String::from_utf8(w.into_inner().unwrap()).expect("not utf8");
         let text = Text::new(contents, TextStyle::default().colors(colors));
-        RenderOperation::RenderText { line: vec![text].into(), alignment }
+        operations.extend([
+            RenderOperation::JumpToBottomRow { index: 1 },
+            RenderOperation::RenderText { line: vec![text].into(), alignment },
+        ]);
+    }
+
+    fn push_image(
+        &self,
+        path: &Path,
+        alignment: Alignment,
+        dimensions: &WindowSize,
+        operations: &mut Vec<RenderOperation>,
+    ) {
+        let image = self.resources.theme_image(path).expect("footer images should be loaded by now");
+        let mut properties = ImageRenderProperties { center: false, ..Default::default() };
+
+        operations.push(RenderOperation::ApplyMargin(MarginProperties {
+            horizontal: Margin::Fixed(0),
+            top: 0,
+            bottom: 1,
+        }));
+        match alignment {
+            Alignment::Left { .. } => {
+                operations.push(RenderOperation::JumpToColumn { index: 0 });
+            }
+            Alignment::Right { .. } => {
+                operations.push(RenderOperation::JumpToColumn { index: dimensions.columns.saturating_sub(1) });
+            }
+            Alignment::Center { .. } => properties.center = true,
+        };
+        operations.extend([
+            // Start printing the image at the top of the footer rect
+            RenderOperation::JumpToRow { index: 0 },
+            RenderOperation::RenderImage(image, properties),
+            RenderOperation::PopMargin,
+        ]);
     }
 }
 
@@ -69,21 +128,51 @@ impl AsRenderOperations for FooterGenerator {
     fn as_render_operations(&self, dimensions: &WindowSize) -> Vec<RenderOperation> {
         let context = self.context.borrow();
         match &self.style {
-            FooterStyle::Template { left, center, right, colors } => {
+            FooterStyle::Template { left, center, right, colors, height } => {
                 let current_slide = (self.current_slide + 1).to_string();
+                // Crate a margin for ourselves so we can jump to top without stepping over slide
+                // text.
+                let mut operations = vec![RenderOperation::ApplyMargin(MarginProperties {
+                    horizontal: Margin::Fixed(1),
+                    top: dimensions.rows.saturating_sub(height.unwrap_or(DEFAULT_FOOTER_HEIGHT)),
+                    bottom: 0,
+                })];
                 // We print this one row below the bottom so there's one row of padding.
-                let mut operations = vec![RenderOperation::JumpToBottomRow { index: 1 }];
-                let margin = Margin::Fixed(1);
                 let alignments = [
-                    Alignment::Left { margin: margin.clone() },
-                    Alignment::Center { minimum_size: 0, minimum_margin: margin.clone() },
-                    Alignment::Right { margin: margin.clone() },
+                    Alignment::Left { margin: Default::default() },
+                    Alignment::Center { minimum_size: 0, minimum_margin: Default::default() },
                 ];
-                for (text, alignment) in [left, center, right].iter().zip(alignments) {
-                    if let Some(text) = text {
-                        operations.push(Self::render_template(text, &current_slide, &context, *colors, alignment));
+                for (content, alignment) in [left, center].iter().zip(alignments) {
+                    if let Some(content) = content {
+                        match content {
+                            FooterContent::Template(template) => {
+                                Self::render_template(
+                                    template,
+                                    &current_slide,
+                                    &context,
+                                    *colors,
+                                    alignment,
+                                    &mut operations,
+                                );
+                            }
+                            FooterContent::Image { path } => {
+                                self.push_image(path, alignment, dimensions, &mut operations);
+                            }
+                        };
                     }
                 }
+                // We don't support images on the right so treat this differently
+                if let Some(template) = right {
+                    Self::render_template(
+                        template,
+                        &current_slide,
+                        &context,
+                        *colors,
+                        Alignment::Right { margin: Default::default() },
+                        &mut operations,
+                    );
+                }
+                operations.push(RenderOperation::PopMargin);
                 operations
             }
             FooterStyle::ProgressBar { character, colors } => {


### PR DESCRIPTION
This allows using images in a footer template. For now they can only be used in the left and center templates by using this syntax:

```yaml
footer:
  style: template
  left:
    image: path-to-image
  # the height of the footer. defaults to 3
  height: 3
```

Images will preserve aspect ratios and will expand to take up as much of the `height` attribute as possible. Therefore, to scale images, simply bump that number up/down.

Images are looked up:
* Relative to the presentation's file, just like any other image.
* Inside the themes directory (~/.config/presenterm/themes).

Example using random logo:

![image](https://github.com/user-attachments/assets/f04dc955-8103-4c13-b617-307267a617ed)

Fixes #437