### PR TITLE
chore: bump sixel-rs version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1181,9 +1181,9 @@ checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "sixel-rs"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fdcaca72707076e90144c669774282aeed367998c7cc04083fbc12de861c71c"
+checksum = "29059f94eafb4ace543bb8777c7e2fdac7c6aeadca9adb28ef2eab977a62f7f8"
 dependencies = [
  "sixel-sys",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ hex = "0.4"
 fastrand = "2.3"
 flate2 = "1.0"
 image = { version = "0.25", features = ["gif", "jpeg", "png"], default-features = false }
-sixel-rs = { version = "0.4", optional = true }
+sixel-rs = { version = "0.4.1", optional = true }
 merge-struct = "0.1.0"
 itertools = "0.14"
 once_cell = "1.19"


### PR DESCRIPTION
Includes https://github.com/orhun/sixel-rs/pull/6 to fix build on aarch64 and riscv64.

If possible, please make a new release so downstream maintainers like Arch Linux RISC-V won't need to maintain this patch for an extended period. :P