### PR TITLE
fix: don't err if auto_render_languages isn't set

### DIFF
--- a/config-file-schema.json
+++ b/config-file-schema.json
@@ -282,9 +282,6 @@
     },
     "OptionsConfig": {
       "type": "object",
-      "required": [
-        "auto_render_languages"
-      ],
       "properties": {
         "auto_render_languages": {
           "description": "Assume snippets for these languages contain `+render` and render them automatically.",

--- a/src/config.rs
+++ b/src/config.rs
@@ -136,6 +136,7 @@ pub struct OptionsConfig {
     pub strict_front_matter_parsing: Option<bool>,
 
     /// Assume snippets for these languages contain `+render` and render them automatically.
+    #[serde(default)]
     pub auto_render_languages: Vec<SnippetLanguage>,
 }
 
@@ -509,5 +510,10 @@ mod test {
     fn default_bindings() {
         let config = KeyBindingsConfig::default();
         CommandKeyBindings::try_from(config).expect("construction failed");
+    }
+
+    #[test]
+    fn default_options_serde() {
+        serde_yaml::from_str::<'_, OptionsConfig>("implicit_slide_ends: true").expect("failed to parse");
     }
 }


### PR DESCRIPTION
Fixes #453