### PR TITLE
fix: respect lists that start at non 1 indexes

### DIFF
--- a/src/markdown/elements.rs
+++ b/src/markdown/elements.rs
@@ -171,10 +171,10 @@ pub(crate) enum ListItemType {
     Unordered,
 
     /// A list item for an ordered list that uses parenthesis after the list item number.
-    OrderedParens,
+    OrderedParens(usize),
 
     /// A list item for an ordered list that uses a period after the list item number.
-    OrderedPeriod,
+    OrderedPeriod(usize),
 }
 
 /// A table.

--- a/src/presentation/builder.rs
+++ b/src/presentation/builder.rs
@@ -714,12 +714,12 @@ impl<'a> PresentationBuilder<'a> {
                 };
                 prefix.push(delimiter);
             }
-            ListItemType::OrderedParens => {
-                prefix.push_str(&(index + 1).to_string());
+            ListItemType::OrderedParens(value) => {
+                prefix.push_str(&value.to_string());
                 prefix.push_str(") ");
             }
-            ListItemType::OrderedPeriod => {
-                prefix.push_str(&(index + 1).to_string());
+            ListItemType::OrderedPeriod(value) => {
+                prefix.push_str(&value.to_string());
                 prefix.push_str(". ");
             }
         };
@@ -1735,15 +1735,15 @@ mod test {
     fn ordered_list_with_pauses() {
         let elements = vec![
             MarkdownElement::List(vec![
-                ListItem { depth: 0, contents: "one".into(), item_type: ListItemType::OrderedPeriod },
-                ListItem { depth: 1, contents: "one_one".into(), item_type: ListItemType::OrderedPeriod },
-                ListItem { depth: 1, contents: "one_two".into(), item_type: ListItemType::OrderedPeriod },
+                ListItem { depth: 0, contents: "one".into(), item_type: ListItemType::OrderedPeriod(1) },
+                ListItem { depth: 1, contents: "one_one".into(), item_type: ListItemType::OrderedPeriod(1) },
+                ListItem { depth: 1, contents: "one_two".into(), item_type: ListItemType::OrderedPeriod(2) },
             ]),
             build_pause(),
             MarkdownElement::List(vec![ListItem {
                 depth: 0,
                 contents: "two".into(),
-                item_type: ListItemType::OrderedPeriod,
+                item_type: ListItemType::OrderedPeriod(2),
             }]),
         ];
         let slides = build_presentation(elements).into_slides();
@@ -1772,14 +1772,14 @@ mod test {
             MarkdownElement::List(vec![ListItem {
                 depth: 0,
                 contents: "one".into(),
-                item_type: ListItemType::OrderedPeriod,
+                item_type: ListItemType::OrderedPeriod(1),
             }]),
             build_pause(),
             MarkdownElement::Heading { level: 1, text: "hi".into() },
             MarkdownElement::List(vec![ListItem {
                 depth: 0,
                 contents: "two".into(),
-                item_type: ListItemType::OrderedPeriod,
+                item_type: ListItemType::OrderedPeriod(2),
             }]),
         ];
         let slides = build_presentation(elements).into_slides();


### PR DESCRIPTION
This makes ordered lists that don't start at 1 to respect the number they're prefixed with. e.g.

```markdown
5. hi
6. mom
```

Will be now rendered as expected, whereas before it would show indexes 1. and 2. for each item.

Fixes #457