### PR TITLE
feat: set font size on code execution components

### DIFF
--- a/src/ui/execution.rs
+++ b/src/ui/execution.rs
@@ -58,9 +58,11 @@ pub(crate) struct RunSnippetOperation {
     inner: Rc<RefCell<RunSnippetOperationInner>>,
     state_description: RefCell<Text>,
     separator: DisplaySeparator,
+    font_size: u8,
 }
 
 impl RunSnippetOperation {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         code: Snippet,
         executor: Rc<SnippetExecutor>,
@@ -69,6 +71,7 @@ impl RunSnippetOperation {
         block_length: u16,
         separator: DisplaySeparator,
         alignment: Alignment,
+        font_size: u8,
     ) -> Self {
         let block_colors = execution_output_style.colors;
         let status_colors = execution_output_style.status.clone();
@@ -82,7 +85,7 @@ impl RunSnippetOperation {
             output_lines: Vec::new(),
             state: RenderAsyncState::default(),
             max_line_length: 0,
-            starting_style: TextStyle::default(),
+            starting_style: TextStyle::default().size(font_size),
             last_length: 0,
         };
         Self {
@@ -96,6 +99,7 @@ impl RunSnippetOperation {
             inner: Rc::new(RefCell::new(inner)),
             state_description: Text::new("not started", TextStyle::default().colors(not_started_colors)).into(),
             separator,
+            font_size,
         }
     }
 }
@@ -119,7 +123,7 @@ impl AsRenderOperations for RunSnippetOperation {
                     // word-wrapped and looks bad.
                     Alignment::Center { .. } => SeparatorWidth::Fixed(self.block_length.max(MINIMUM_SEPARATOR_WIDTH)),
                 };
-                let separator = RenderSeparator::new(heading, separator_width);
+                let separator = RenderSeparator::new(heading, separator_width, self.font_size);
                 vec![
                     RenderOperation::RenderLineBreak,
                     RenderOperation::RenderDynamic(Rc::new(separator)),
@@ -293,6 +297,7 @@ pub(crate) struct RunAcquireTerminalSnippet {
     executor: Rc<SnippetExecutor>,
     colors: ExecutionStatusBlockStyle,
     state: RefCell<AcquireTerminalSnippetState>,
+    font_size: u8,
 }
 
 impl RunAcquireTerminalSnippet {
@@ -301,8 +306,9 @@ impl RunAcquireTerminalSnippet {
         executor: Rc<SnippetExecutor>,
         colors: ExecutionStatusBlockStyle,
         block_length: u16,
+        font_size: u8,
     ) -> Self {
-        Self { snippet, block_length, executor, colors, state: Default::default() }
+        Self { snippet, block_length, executor, colors, state: Default::default(), font_size }
     }
 }
 
@@ -343,7 +349,7 @@ impl AsRenderOperations for RunAcquireTerminalSnippet {
 
         let heading = Line(vec![" [".into(), separator_text, "] ".into()]);
         let separator_width = SeparatorWidth::Fixed(self.block_length.max(MINIMUM_SEPARATOR_WIDTH));
-        let separator = RenderSeparator::new(heading, separator_width);
+        let separator = RenderSeparator::new(heading, separator_width, self.font_size);
         let mut ops = vec![
             RenderOperation::RenderLineBreak,
             RenderOperation::RenderDynamic(Rc::new(separator)),

--- a/src/ui/separator.rs
+++ b/src/ui/separator.rs
@@ -1,5 +1,8 @@
 use crate::{
-    markdown::elements::Line,
+    markdown::{
+        elements::{Line, Text},
+        text_style::TextStyle,
+    },
     render::{
         layout::{Layout, Positioning},
         operation::{AsRenderOperations, BlockLine, RenderOperation},
@@ -17,15 +20,18 @@ pub(crate) enum SeparatorWidth {
     FitToWindow,
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub(crate) struct RenderSeparator {
     heading: Line,
     width: SeparatorWidth,
+    font_size: u8,
 }
 
 impl RenderSeparator {
-    pub(crate) fn new<S: Into<Line>>(heading: S, width: SeparatorWidth) -> Self {
-        Self { heading: heading.into(), width }
+    pub(crate) fn new<S: Into<Line>>(heading: S, width: SeparatorWidth, font_size: u8) -> Self {
+        let mut heading: Line = heading.into();
+        heading.apply_style(&TextStyle::default().size(font_size));
+        Self { heading, width, font_size }
     }
 }
 
@@ -42,24 +48,26 @@ impl AsRenderOperations for RenderSeparator {
             SeparatorWidth::Fixed(width) => {
                 let Positioning { max_line_length, .. } =
                     Layout::new(Alignment::Center { minimum_margin: Margin::Fixed(0), minimum_size: 0 })
+                        .with_font_size(self.font_size)
                         .compute(dimensions, width);
                 max_line_length.min(width) as usize
             }
             SeparatorWidth::FitToWindow => dimensions.columns as usize,
         };
+        let style = TextStyle::default().size(self.font_size);
         let separator = match self.heading.width() == 0 {
-            true => Line::from(character.repeat(width)),
+            true => Line::from(Text::new(character.repeat(width / self.font_size as usize), style)),
             false => {
                 let width = width.saturating_sub(self.heading.width());
                 let (dashes_len, remainder) = (width / 2, width % 2);
                 let mut dashes = character.repeat(dashes_len);
-                let mut line = Line::from(dashes.clone());
+                let mut line = Line::from(Text::new(dashes.clone(), style));
                 line.0.extend(self.heading.0.iter().cloned());
 
                 if remainder > 0 {
                     dashes.push_str(character);
                 }
-                line.0.push(dashes.into());
+                line.0.push(Text::new(dashes, style));
                 line
             }
         };


### PR DESCRIPTION
After #458 most components were allowed to have a font size except a couple. This expands that list to include code execution components (the separator bar and the output).

This code has turned quite gore after all these changes and will be refactored soon. Markdown tables still don't respect the font size but that should hopefully be easier after the refactor.