### PR TITLE
feat: allow footer to be styled via markdown

### DIFF
--- a/src/ui/footer.rs
+++ b/src/ui/footer.rs
@@ -1,21 +1,23 @@
 use crate::{
-    markdown::{elements::Text, text_style::TextStyle},
+    markdown::{
+        elements::{Line, Text},
+        parse::MarkdownParser,
+        text_style::TextStyle,
+    },
     render::{
         operation::{AsRenderOperations, ImageRenderProperties, MarginProperties, RenderOperation},
         properties::WindowSize,
     },
     terminal::image::Image,
-    theme::{Alignment, FooterContent, FooterStyle, FooterTemplate, FooterTemplateChunk, Margin},
+    theme::{Alignment, ColorPalette, FooterContent, FooterStyle, FooterTemplate, FooterTemplateChunk, Margin},
 };
-use std::{
-    cell::RefCell,
-    io::{BufWriter, Write},
-    rc::Rc,
-};
+use comrak::Arena;
+use std::borrow::Cow;
 use unicode_width::UnicodeWidthStr;
 
 #[derive(Debug, Default)]
-pub(crate) struct FooterContext {
+pub(crate) struct FooterVariables {
+    pub(crate) current_slide: usize,
     pub(crate) total_slides: usize,
     pub(crate) author: String,
     pub(crate) title: String,
@@ -28,45 +30,26 @@ pub(crate) struct FooterContext {
 #[derive(Debug)]
 pub(crate) struct FooterGenerator {
     current_slide: usize,
-    context: Rc<RefCell<FooterContext>>,
-    style: FooterStyle,
+    total_slides: u64,
+    style: RenderedFooterStyle,
 }
 
 impl FooterGenerator {
-    pub(crate) fn new(current_slide: usize, context: Rc<RefCell<FooterContext>>, style: FooterStyle) -> Self {
-        Self { current_slide, context, style }
+    pub(crate) fn new(
+        style: FooterStyle,
+        vars: &FooterVariables,
+        palette: &ColorPalette,
+    ) -> Result<Self, InvalidFooterTemplateError> {
+        let style = RenderedFooterStyle::new(style, vars, palette)?;
+        let current_slide = vars.current_slide;
+        let total_slides = vars.total_slides as u64;
+        Ok(Self { current_slide, total_slides, style })
     }
 
-    fn render_template(
-        template: &FooterTemplate,
-        current_slide: &str,
-        context: &FooterContext,
-        style: TextStyle,
-        alignment: Alignment,
-        operations: &mut Vec<RenderOperation>,
-    ) {
-        use FooterTemplateChunk::*;
-        let mut w = BufWriter::new(Vec::new());
-        let FooterContext { total_slides, author, title, sub_title, event, location, date } = context;
-        for chunk in &template.0 {
-            match chunk {
-                Literal(l) => write!(w, "{l}"),
-                CurrentSlide => write!(w, "{current_slide}"),
-                TotalSlides => write!(w, "{total_slides}"),
-                Author => write!(w, "{author}"),
-                Title => write!(w, "{title}"),
-                SubTitle => write!(w, "{sub_title}"),
-                Event => write!(w, "{event}"),
-                Location => write!(w, "{location}"),
-                Date => write!(w, "{date}"),
-            }
-            .unwrap();
-        }
-        let contents = String::from_utf8(w.into_inner().unwrap()).expect("not utf8");
-        let text = Text::new(contents, style);
+    fn render_line(line: &FooterLine, alignment: Alignment, operations: &mut Vec<RenderOperation>) {
         operations.extend([
             RenderOperation::JumpToBottomRow { index: 1 },
-            RenderOperation::RenderText { line: vec![text].into(), alignment },
+            RenderOperation::RenderText { line: line.0.clone().into(), alignment },
         ]);
     }
 
@@ -104,10 +87,9 @@ impl FooterGenerator {
 
 impl AsRenderOperations for FooterGenerator {
     fn as_render_operations(&self, dimensions: &WindowSize) -> Vec<RenderOperation> {
-        let context = self.context.borrow();
+        use RenderedFooterStyle::*;
         match &self.style {
-            FooterStyle::Template { left, center, right, style, height } => {
-                let current_slide = (self.current_slide + 1).to_string();
+            Template { left, center, right, height } => {
                 // Crate a margin for ourselves so we can jump to top without stepping over slide
                 // text.
                 let mut operations = vec![RenderOperation::ApplyMargin(MarginProperties {
@@ -123,40 +105,26 @@ impl AsRenderOperations for FooterGenerator {
                 for (content, alignment) in [left, center].iter().zip(alignments) {
                     if let Some(content) = content {
                         match content {
-                            FooterContent::Template(template) => {
-                                Self::render_template(
-                                    template,
-                                    &current_slide,
-                                    &context,
-                                    *style,
-                                    alignment,
-                                    &mut operations,
-                                );
+                            RenderedFooterContent::Line(line) => {
+                                Self::render_line(line, alignment, &mut operations);
                             }
-                            FooterContent::Image(image) => {
+                            RenderedFooterContent::Image(image) => {
                                 self.push_image(image, alignment, dimensions, &mut operations);
                             }
                         };
                     }
                 }
                 // We don't support images on the right so treat this differently
-                if let Some(template) = right {
-                    Self::render_template(
-                        template,
-                        &current_slide,
-                        &context,
-                        *style,
-                        Alignment::Right { margin: Default::default() },
-                        &mut operations,
-                    );
+                if let Some(line) = right {
+                    Self::render_line(line, Alignment::Right { margin: Default::default() }, &mut operations);
                 }
                 operations.push(RenderOperation::PopMargin);
                 operations
             }
-            FooterStyle::ProgressBar { character, style } => {
+            ProgressBar { character, style } => {
                 let character = character.to_string();
                 let total_columns = dimensions.columns as usize / character.width();
-                let progress_ratio = (self.current_slide + 1) as f64 / context.total_slides as f64;
+                let progress_ratio = (self.current_slide + 1) as f64 / self.total_slides as f64;
                 let columns_ratio = (total_columns as f64 * progress_ratio).ceil();
                 let bar = character.repeat(columns_ratio as usize);
                 let bar = Text::new(bar, *style);
@@ -168,7 +136,173 @@ impl AsRenderOperations for FooterGenerator {
                     },
                 ]
             }
-            FooterStyle::Empty => vec![],
+            Empty => vec![],
         }
+    }
+}
+
+#[derive(Debug)]
+enum RenderedFooterStyle {
+    Template {
+        left: Option<RenderedFooterContent>,
+        center: Option<RenderedFooterContent>,
+        right: Option<FooterLine>,
+        height: u16,
+    },
+    ProgressBar {
+        character: char,
+        style: TextStyle,
+    },
+    Empty,
+}
+
+impl RenderedFooterStyle {
+    fn new(
+        style: FooterStyle,
+        vars: &FooterVariables,
+        palette: &ColorPalette,
+    ) -> Result<Self, InvalidFooterTemplateError> {
+        match style {
+            FooterStyle::Template { left, center, right, style, height } => {
+                let left = left.map(|c| RenderedFooterContent::new(c, &style, vars, palette)).transpose()?;
+                let center = center.map(|c| RenderedFooterContent::new(c, &style, vars, palette)).transpose()?;
+                let right = right.map(|c| FooterLine::new(c, &style, vars, palette)).transpose()?;
+                Ok(Self::Template { left, center, right, height })
+            }
+            FooterStyle::ProgressBar { character, style } => Ok(Self::ProgressBar { character, style }),
+            FooterStyle::Empty => Ok(Self::Empty),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct FooterLine(Line);
+
+impl FooterLine {
+    fn new(
+        template: FooterTemplate,
+        style: &TextStyle,
+        vars: &FooterVariables,
+        palette: &ColorPalette,
+    ) -> Result<Self, InvalidFooterTemplateError> {
+        let mut line = Line::default();
+        let FooterVariables { current_slide, total_slides, author, title, sub_title, event, location, date } = vars;
+        let arena = Arena::default();
+        let parser = MarkdownParser::new(&arena);
+        for chunk in template.0 {
+            let raw_text = match chunk {
+                FooterTemplateChunk::CurrentSlide => Cow::Owned(current_slide.to_string()),
+                FooterTemplateChunk::Literal(text) => Cow::Owned(text),
+                FooterTemplateChunk::TotalSlides => Cow::Owned(total_slides.to_string()),
+                FooterTemplateChunk::Author => Cow::Borrowed(author),
+                FooterTemplateChunk::Title => Cow::Borrowed(title),
+                FooterTemplateChunk::SubTitle => Cow::Borrowed(sub_title),
+                FooterTemplateChunk::Event => Cow::Borrowed(event),
+                FooterTemplateChunk::Location => Cow::Borrowed(location),
+                FooterTemplateChunk::Date => Cow::Borrowed(date),
+            };
+            if raw_text.lines().count() != 1 {
+                return Err(InvalidFooterTemplateError("footer cannot contain newlines".into()));
+            }
+            let starting_length = raw_text.len();
+            let raw_text = raw_text.trim_start();
+            let left_whitespace = starting_length - raw_text.len();
+            let raw_text = raw_text.trim_end();
+            let right_whitespace = starting_length - raw_text.len() - left_whitespace;
+            let inlines = parser.parse_inlines(raw_text).map_err(|e| InvalidFooterTemplateError(e.to_string()))?;
+            let mut contents = inlines.resolve(palette).map_err(|e| InvalidFooterTemplateError(e.to_string()))?;
+            if left_whitespace != 0 {
+                contents.0.insert(0, " ".repeat(left_whitespace).into());
+            }
+            if right_whitespace != 0 {
+                contents.0.push(" ".repeat(right_whitespace).into());
+            }
+            line.0.extend(contents.0);
+        }
+        line.apply_style(style);
+        Ok(Self(line))
+    }
+}
+
+#[derive(Clone, Debug)]
+enum RenderedFooterContent {
+    Line(FooterLine),
+    Image(Image),
+}
+
+impl RenderedFooterContent {
+    fn new(
+        content: FooterContent,
+        style: &TextStyle,
+        vars: &FooterVariables,
+        palette: &ColorPalette,
+    ) -> Result<Self, InvalidFooterTemplateError> {
+        Ok(match content {
+            FooterContent::Template(template) => Self::Line(FooterLine::new(template, style, vars, palette)?),
+            FooterContent::Image(image) => Self::Image(image),
+        })
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("invalid footer template: {0}")]
+pub(crate) struct InvalidFooterTemplateError(String);
+
+#[cfg(test)]
+mod tests {
+    use crate::markdown::text_style::Color;
+
+    use super::*;
+    use once_cell::sync::Lazy;
+    use rstest::rstest;
+
+    static VARIABLES: Lazy<FooterVariables> = Lazy::new(|| FooterVariables {
+        current_slide: 1,
+        total_slides: 5,
+        author: "bob".into(),
+        title: "hi".into(),
+        sub_title: "bye".into(),
+        event: "test".into(),
+        location: "here".into(),
+        date: "now".into(),
+    });
+
+    static PALETTE: Lazy<ColorPalette> =
+        Lazy::new(|| ColorPalette { colors: [("red".into(), Color::new(255, 0, 0))].into() });
+
+    #[rstest]
+    #[case::literal(FooterTemplateChunk::Literal("hi".into()), &["hi".into()])]
+    #[case::literal_whitespaced(FooterTemplateChunk::Literal("  hi  ".into()), &["  ".into(), "hi".into(), "  ".into()])]
+    #[case::author(FooterTemplateChunk::Author, &["bob".into()])]
+    #[case::title(FooterTemplateChunk::Title, &["hi".into()])]
+    #[case::sub_title(FooterTemplateChunk::SubTitle, &["bye".into()])]
+    #[case::event(FooterTemplateChunk::Event, &["test".into()])]
+    #[case::location(FooterTemplateChunk::Location, &["here".into()])]
+    #[case::date(FooterTemplateChunk::Date, &["now".into()])]
+    #[case::bold(
+        FooterTemplateChunk::Literal("**hi** mom".into()),
+        &[Text::new("hi", TextStyle::default().bold()), " mom".into()]
+    )]
+    #[case::colored(
+        FooterTemplateChunk::Literal("<span style=\"color: palette:red\">hi</span> mom".into()),
+        &[Text::new("hi", TextStyle::default().fg_color(Color::new(255, 0, 0))), " mom".into()]
+    )]
+    fn render_valid(#[case] chunk: FooterTemplateChunk, #[case] expected: &[Text]) {
+        let template = FooterTemplate(vec![chunk]);
+        let line = FooterLine::new(template, &Default::default(), &VARIABLES, &PALETTE).expect("render failed");
+        assert_eq!(line.0.0, expected);
+    }
+
+    #[rstest]
+    #[case::non_paragraph(
+        FooterTemplateChunk::Literal("* hi".into()),
+    )]
+    #[case::invalid_palette_color(
+        FooterTemplateChunk::Literal("<span style=\"color: palette:hi\">hi</span> mom".into()),
+    )]
+    #[case::newlines(FooterTemplateChunk::Literal("hi\nmom".into()))]
+    fn render_invalid(#[case] chunk: FooterTemplateChunk) {
+        let template = FooterTemplate(vec![chunk]);
+        FooterLine::new(template, &Default::default(), &VARIABLES, &PALETTE).expect_err("render succeeded");
     }
 }


### PR DESCRIPTION
This allows styling the template footer using markdown, including colors from the theme palette. If the front matter contains the `title` entry and that contains markdown, it is also rendered as expected.

Example:

~~~markdown
---
theme:
    override:
        footer:
            style: template
            left: "_how_ to <span style=\"color: red\">chop</span> **onions**"
---
~~~

![image](https://github.com/user-attachments/assets/0e8807c5-6488-4ba0-956d-1837ec32ae63)
