### PR TITLE
feat: allow escaped braces in footer

### DIFF
--- a/src/markdown/parse.rs
+++ b/src/markdown/parse.rs
@@ -66,7 +66,10 @@ impl<'a> MarkdownParser<'a> {
     /// Parse inlines in a markdown input.
     pub(crate) fn parse_inlines(&self, line: &str) -> Result<Line<RawColor>, ParseInlinesError> {
         let node = parse_document(self.arena, line, &self.options);
-        if node.children().count() != 1 {
+        if node.children().count() == 0 {
+            return Ok(Default::default());
+        }
+        if node.children().count() > 1 {
             return Err(ParseInlinesError("inline must be simple text".into()));
         }
         let node = node.first_child().expect("must have one child");

--- a/src/ui/footer.rs
+++ b/src/ui/footer.rs
@@ -185,21 +185,24 @@ impl FooterLine {
         vars: &FooterVariables,
         palette: &ColorPalette,
     ) -> Result<Self, InvalidFooterTemplateError> {
+        use FooterTemplateChunk::*;
         let mut line = Line::default();
         let FooterVariables { current_slide, total_slides, author, title, sub_title, event, location, date } = vars;
         let arena = Arena::default();
         let parser = MarkdownParser::new(&arena);
         for chunk in template.0 {
             let raw_text = match chunk {
-                FooterTemplateChunk::CurrentSlide => Cow::Owned(current_slide.to_string()),
-                FooterTemplateChunk::Literal(text) => Cow::Owned(text),
-                FooterTemplateChunk::TotalSlides => Cow::Owned(total_slides.to_string()),
-                FooterTemplateChunk::Author => Cow::Borrowed(author),
-                FooterTemplateChunk::Title => Cow::Borrowed(title),
-                FooterTemplateChunk::SubTitle => Cow::Borrowed(sub_title),
-                FooterTemplateChunk::Event => Cow::Borrowed(event),
-                FooterTemplateChunk::Location => Cow::Borrowed(location),
-                FooterTemplateChunk::Date => Cow::Borrowed(date),
+                CurrentSlide => Cow::Owned(current_slide.to_string()),
+                OpenBrace => Cow::Borrowed("{"),
+                ClosedBrace => Cow::Borrowed("}"),
+                Literal(text) => Cow::Owned(text),
+                TotalSlides => Cow::Owned(total_slides.to_string()),
+                Author => Cow::Borrowed(author.as_str()),
+                Title => Cow::Borrowed(title.as_str()),
+                SubTitle => Cow::Borrowed(sub_title.as_str()),
+                Event => Cow::Borrowed(event.as_str()),
+                Location => Cow::Borrowed(location.as_str()),
+                Date => Cow::Borrowed(date.as_str()),
             };
             if raw_text.lines().count() != 1 {
                 return Err(InvalidFooterTemplateError("footer cannot contain newlines".into()));


### PR DESCRIPTION
After #442 you could no longer use braces unless it was to refer to a variable. This PR softens that restriction by letting you use double braces as an "escaped brace" to let you use them anywhere.

e.g. this footer "{title} {{potato}}" will render as "<title> {{potato}}"