### PR TITLE
feat: introduce `palette.classes` and use span.class to reference it

### DIFF
--- a/src/markdown/text_style.rs
+++ b/src/markdown/text_style.rs
@@ -293,8 +293,8 @@ impl<C> Default for Colors<C> {
 
 impl Colors<RawColor> {
     pub(crate) fn resolve(&self, palette: &ColorPalette) -> Result<Colors<Color>, UndefinedPaletteColorError> {
-        let background = self.background.clone().map(|c| c.resolve(palette)).transpose()?;
-        let foreground = self.foreground.clone().map(|c| c.resolve(palette)).transpose()?;
+        let background = self.background.clone().map(|c| c.resolve(palette)).transpose()?.flatten();
+        let foreground = self.foreground.clone().map(|c| c.resolve(palette)).transpose()?.flatten();
         Ok(Colors { foreground, background })
     }
 }

--- a/src/ui/footer.rs
+++ b/src/ui/footer.rs
@@ -270,8 +270,10 @@ mod tests {
         date: "now".into(),
     });
 
-    static PALETTE: Lazy<ColorPalette> =
-        Lazy::new(|| ColorPalette { colors: [("red".into(), Color::new(255, 0, 0))].into() });
+    static PALETTE: Lazy<ColorPalette> = Lazy::new(|| ColorPalette {
+        colors: [("red".into(), Color::new(255, 0, 0))].into(),
+        classes: Default::default(),
+    });
 
     #[rstest]
     #[case::literal(FooterTemplateChunk::Literal("hi".into()), &["hi".into()])]


### PR DESCRIPTION
This introduces a `palette.classes` entry in the theme that allows defining a class (a background and foreground color pair). This can then be referenced when using spans by using the `class` html attribute.

As an example. the following presentation:

~~~markdown
---
theme:
    override:
        palette:
            classes:
                bokita:
                    foreground: yellow
                    background: dark_blue
        footer:
            style: template
            left: "<span class=\"bokita\">hello</span>"
                
---

hi <span class="bokita">hello</span>
~~~

Renders liks:

![image](https://github.com/user-attachments/assets/40cdd57a-295d-4889-ab97-4618613eaf0f)
