### PR TITLE
feat: allow configuring alignment when max columns is hit

### DIFF
--- a/config-file-schema.json
+++ b/config-file-schema.json
@@ -50,6 +50,14 @@
           "format": "uint16",
           "minimum": 0.0
         },
+        "max_columns_alignment": {
+          "description": "The alignment the presentation should have if `max_columns` is set and the terminal is larger than that.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/MaxColumnsAlignment"
+            }
+          ]
+        },
         "terminal_font_size": {
           "description": "Override the terminal font size when in windows or when using sixel.",
           "default": 16,
@@ -266,6 +274,32 @@
           ]
         }
       }
+    },
+    "MaxColumnsAlignment": {
+      "description": "The alignment to use when `defaults.max_columns` is set.",
+      "oneOf": [
+        {
+          "description": "Align the presentation to the left.",
+          "type": "string",
+          "enum": [
+            "left"
+          ]
+        },
+        {
+          "description": "Align the presentation on the center.",
+          "type": "string",
+          "enum": [
+            "center"
+          ]
+        },
+        {
+          "description": "Align the presentation to the right.",
+          "type": "string",
+          "enum": [
+            "right"
+          ]
+        }
+      ]
     },
     "MermaidConfig": {
       "type": "object",

--- a/src/config.rs
+++ b/src/config.rs
@@ -74,7 +74,7 @@ pub struct DefaultsConfig {
     pub theme: Option<String>,
 
     /// Override the terminal font size when in windows or when using sixel.
-    #[serde(default = "default_font_size")]
+    #[serde(default = "default_terminal_font_size")]
     #[validate(range(min = 1))]
     pub terminal_font_size: u8,
 
@@ -89,22 +89,43 @@ pub struct DefaultsConfig {
     /// A max width in columns that the presentation must always be capped to.
     #[serde(default = "default_max_columns")]
     pub max_columns: u16,
+
+    /// The alignment the presentation should have if `max_columns` is set and the terminal is
+    /// larger than that.
+    #[serde(default)]
+    pub max_columns_alignment: MaxColumnsAlignment,
 }
 
 impl Default for DefaultsConfig {
     fn default() -> Self {
         Self {
             theme: Default::default(),
-            terminal_font_size: default_font_size(),
+            terminal_font_size: default_terminal_font_size(),
             image_protocol: Default::default(),
             validate_overflows: Default::default(),
             max_columns: default_max_columns(),
+            max_columns_alignment: Default::default(),
         }
     }
 }
 
-fn default_font_size() -> u8 {
+fn default_terminal_font_size() -> u8 {
     16
+}
+
+/// The alignment to use when `defaults.max_columns` is set.
+#[derive(Clone, Copy, Debug, Default, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum MaxColumnsAlignment {
+    /// Align the presentation to the left.
+    Left,
+
+    /// Align the presentation on the center.
+    #[default]
+    Center,
+
+    /// Align the presentation to the right.
+    Right,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, JsonSchema)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -418,6 +418,7 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             bindings: config.bindings,
             validate_overflows,
             max_columns: config.defaults.max_columns,
+            max_columns_alignment: config.defaults.max_columns_alignment,
         };
         let presenter = Presenter::new(
             &default_theme,

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -4,7 +4,7 @@ use crate::{
         listener::{Command, CommandListener},
         speaker_notes::{SpeakerNotesEvent, SpeakerNotesEventPublisher},
     },
-    config::KeyBindingsConfig,
+    config::{KeyBindingsConfig, MaxColumnsAlignment},
     export::ImageReplacer,
     markdown::parse::{MarkdownParser, ParseError},
     presentation::{
@@ -43,6 +43,7 @@ pub struct PresenterOptions {
     pub bindings: KeyBindingsConfig,
     pub validate_overflows: bool,
     pub max_columns: u16,
+    pub max_columns_alignment: MaxColumnsAlignment,
 }
 
 /// A slideshow presenter.
@@ -105,6 +106,7 @@ impl<'a> Presenter<'a> {
         let drawer_options = TerminalDrawerOptions {
             font_size_fallback: self.options.font_size_fallback,
             max_columns: self.options.max_columns,
+            max_columns_alignment: self.options.max_columns_alignment,
         };
         let mut drawer = TerminalDrawer::new(self.image_printer.clone(), drawer_options)?;
         loop {

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod text;
 pub(crate) mod validate;
 
 use crate::{
+    config::MaxColumnsAlignment,
     markdown::{
         elements::Text,
         text::WeightedLine,
@@ -28,16 +29,14 @@ use std::{
 pub(crate) type RenderResult = Result<(), RenderError>;
 
 pub(crate) struct TerminalDrawerOptions {
-    /// The font size to fall back to if we can't find the window size in pixels.
     pub(crate) font_size_fallback: u8,
-
-    /// The max width in columns that the presentation should be capped to.
     pub(crate) max_columns: u16,
+    pub(crate) max_columns_alignment: MaxColumnsAlignment,
 }
 
 impl Default for TerminalDrawerOptions {
     fn default() -> Self {
-        Self { font_size_fallback: 1, max_columns: u16::MAX }
+        Self { font_size_fallback: 1, max_columns: u16::MAX, max_columns_alignment: Default::default() }
     }
 }
 
@@ -98,7 +97,11 @@ impl TerminalDrawer {
     }
 
     fn create_engine(&mut self, dimensions: WindowSize) -> RenderEngine<Terminal<Stdout>> {
-        let options = RenderEngineOptions { max_columns: self.options.max_columns, ..Default::default() };
+        let options = RenderEngineOptions {
+            max_columns: self.options.max_columns,
+            max_columns_alignment: self.options.max_columns_alignment,
+            ..Default::default()
+        };
         RenderEngine::new(&mut self.terminal, dimensions, options)
     }
 }


### PR DESCRIPTION
This introduces a new `defaults.max_columns_alignment` that can have values `left`, `center`, and `right`. This works along with `max_columns` and allows specifying how to align the presentation if the terminal size is greater than it. Before this change, this would behave like `max_columns_alignment: center` does now so that's the default if not set.

e.g. setting this to `left` will cause look like this on a wide terminal:

![image](https://github.com/user-attachments/assets/026b5943-6e22-4450-ae22-3e1e6af84058)
