### PR TITLE
fix: jump to right slide on code attribute change

### DIFF
--- a/src/presentation/builder.rs
+++ b/src/presentation/builder.rs
@@ -874,6 +874,8 @@ impl<'a> PresentationBuilder<'a> {
             snippet = self.load_external_snippet(snippet, source_position)?;
         }
         self.push_differ(snippet.contents.clone());
+        // Redraw slide if attributes change
+        self.push_differ(format!("{:?}", snippet.attributes));
 
         if snippet.attributes.render || self.options.auto_render_languages.contains(&snippet.language) {
             return self.push_rendered_code(snippet, source_position);


### PR DESCRIPTION
Changing attributes like `+line_numbers` wasn't causing the code's slide to be jumped-to.