### PR TITLE
fix: snippet execution output colors in terminal-* themes

### DIFF
--- a/themes/terminal-dark.yaml
+++ b/themes/terminal-dark.yaml
@@ -24,19 +24,20 @@ code:
   padding:
     horizontal: 2
     vertical: 1
+  background: false
 
 execution_output:
   colors:
-    background: grey
+    foreground: white
   status:
     running:
-      foreground: "blue"
+      foreground: blue
     success:
-      foreground: "green"
+      foreground: green
     failure:
-      foreground: "red"
+      foreground: red
     not_started:
-      foreground: "yellow"
+      foreground: yellow
 
 inline_code:
   colors:

--- a/themes/terminal-light.yaml
+++ b/themes/terminal-light.yaml
@@ -24,10 +24,11 @@ code:
   padding:
     horizontal: 2
     vertical: 1
+  background: false
 
 execution_output:
   colors:
-    background: grey
+    foreground: black
   status:
     running:
       foreground: dark_blue


### PR DESCRIPTION
For some reason terminal-light and terminal-dark were using bright background/text in snippet execution outputs.