### PR TITLE
fix: respect end slide shorthand in speaker notes mode

### DIFF
--- a/src/presentation/builder/mod.rs
+++ b/src/presentation/builder/mod.rs
@@ -315,6 +315,12 @@ impl<'a> PresentationBuilder<'a> {
         match element {
             MarkdownElement::Comment { comment, source_position } => self.process_comment(comment, source_position)?,
             MarkdownElement::SetexHeading { text } => self.push_slide_title(text)?,
+            MarkdownElement::ThematicBreak => {
+                if self.options.end_slide_shorthand {
+                    self.terminate_slide();
+                    self.slide_state.ignore_element_line_break = true;
+                }
+            }
             _ => {}
         }
         // Allows us to start the next speaker slide when a title is pushed and implicit_slide_ends is enabled.


### PR DESCRIPTION
This causes end slide shorthands to be respected when in speaker notes mode.

This speaker notes/presentation mode code needs some splitting, this currently makes it hard to know what needs to be done / is done in each case. But this does for now.

Fixes #491