### PR TITLE
Correctly include layout pic

### DIFF
--- a/docs/src/features/layout.md
+++ b/docs/src/features/layout.md
@@ -93,7 +93,7 @@ Because we just reset the layout, this text is now below both of the columns.
 
 This would render the following way:
 
-![](../../assets/layouts.png)
+![](../assets/layouts.png)
 
 ## Other uses
 


### PR DESCRIPTION
Seems like the example layout picture wasn't referred correctly and hence doesn't show up when visiting https://mfontanini.github.io/presenterm/features/layout.html . 

This change should probably fix it.