### PR TITLE
fix: ansi escape code parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,16 +33,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi-parser"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43e7fd8284f025d0bd143c2855618ecdf697db55bde39211e5c9faec7669173"
-dependencies = [
- "heapless",
- "nom",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,6 +89,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b964d184e89d9b6b67dd2715bc8e74cf3107fb2b529990c90cf517326150bf4"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,12 +141,6 @@ name = "bytemuck"
 version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "byteorder-lite"
@@ -467,15 +457,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
-name = "hash32"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,16 +467,6 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
-
-[[package]]
-name = "heapless"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
-dependencies = [
- "hash32",
- "stable_deref_trait",
-]
 
 [[package]]
 name = "heck"
@@ -668,12 +639,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -693,16 +658,6 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -829,7 +784,6 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 name = "presenterm"
 version = "0.11.0"
 dependencies = [
- "ansi-parser",
  "anyhow",
  "base64",
  "bincode",
@@ -861,6 +815,7 @@ dependencies = [
  "thiserror 2.0.11",
  "tl",
  "unicode-width",
+ "vte",
 ]
 
 [[package]]
@@ -1224,12 +1179,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1438,6 +1387,16 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "vte"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5924018406ce0063cd67f8e008104968b74b563ee1b85dde3ed1f7cb87d3dbd"
+dependencies = [
+ "arrayvec",
+ "memchr",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
-ansi-parser = "0.9"
 base64 = "0.22"
 bincode = "1.3"
 clap = { version = "4.4", features = ["derive", "string"] }
@@ -39,6 +38,7 @@ thiserror = "2"
 unicode-width = "0.2"
 os_pipe = "1.1.5"
 libc = "0.2"
+vte = "0.15"
 
 [dev-dependencies]
 rstest = { version = "0.25", default-features = false }

--- a/src/markdown/elements.rs
+++ b/src/markdown/elements.rs
@@ -151,6 +151,12 @@ pub(crate) struct Text<C = Color> {
     pub(crate) style: TextStyle<C>,
 }
 
+impl<C> Default for Text<C> {
+    fn default() -> Self {
+        Self { content: Default::default(), style: TextStyle::default() }
+    }
+}
+
 impl<C> Text<C> {
     /// Construct a new styled text.
     pub(crate) fn new<S: Into<String>>(content: S, style: TextStyle<C>) -> Self {

--- a/src/terminal/ansi.rs
+++ b/src/terminal/ansi.rs
@@ -3,114 +3,61 @@ use crate::markdown::{
     text::WeightedLine,
     text_style::{Color, TextStyle},
 };
-use ansi_parser::{AnsiParser, AnsiSequence, Output};
+use std::mem;
+use vte::{ParamsIter, Parser, Perform};
 
 pub(crate) struct AnsiSplitter {
-    lines: Vec<WeightedLine>,
-    current_line: Line,
-    current_style: TextStyle,
+    starting_style: TextStyle,
 }
 
 impl AnsiSplitter {
     pub(crate) fn new(current_style: TextStyle) -> Self {
-        Self { lines: Default::default(), current_line: Default::default(), current_style }
+        Self { starting_style: current_style }
     }
 
-    pub(crate) fn split_lines(mut self, lines: &[String]) -> (Vec<WeightedLine>, TextStyle) {
+    pub(crate) fn split_lines<I, S>(self, lines: I) -> (Vec<WeightedLine>, TextStyle)
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let mut output_lines = Vec::new();
+        let mut style = self.starting_style;
         for line in lines {
-            for p in line.ansi_parse() {
-                match p {
-                    Output::TextBlock(text) => {
-                        self.current_line.0.push(Text::new(text, self.current_style));
-                    }
-                    Output::Escape(s) => self.handle_escape(&s),
-                }
-            }
-            let current_line = std::mem::take(&mut self.current_line);
-            self.lines.push(current_line.into());
-        }
-        (self.lines, self.current_style)
-    }
+            let mut handler = Handler::new(style);
+            let mut parser = Parser::new();
+            parser.advance(&mut handler, line.as_ref().as_bytes());
 
-    fn handle_escape(&mut self, s: &AnsiSequence) {
-        match s {
-            AnsiSequence::SetGraphicsMode(code) => {
-                let code = GraphicsCode(code);
-                code.update(&mut self.current_style);
-            }
-            AnsiSequence::EraseDisplay => {
-                self.lines.clear();
-                self.current_line.0.clear();
-            }
-            _ => (),
+            let (line, ending_style) = handler.into_parts();
+            output_lines.push(line.into());
+            style = ending_style;
         }
+        (output_lines, style)
     }
 }
 
-struct GraphicsCode<'a>(&'a [u8]);
+struct Handler {
+    line: Line,
+    pending_text: Text,
+    style: TextStyle,
+}
 
-impl GraphicsCode<'_> {
-    fn update(&self, style: &mut TextStyle) {
-        let codes = self.0;
-        match codes {
-            [] | [0] => *style = Default::default(),
-            [1] => *style = style.bold(),
-            [3] => *style = style.italics(),
-            [4] => *style = style.underlined(),
-            [9] => *style = style.strikethrough(),
-            [39] => style.colors.foreground = None,
-            [49] => style.colors.background = None,
-            [value] | [1, value] => match value {
-                30..=37 => {
-                    if let Some(color) = Self::as_standard_color(value - 30) {
-                        *style = style.fg_color(color);
-                    }
-                }
-                40..=47 => {
-                    if let Some(color) = Self::as_standard_color(value - 40) {
-                        *style = style.bg_color(color);
-                    }
-                }
-                _ => (),
-            },
-            [38, 2, r, g, b] => {
-                *style = style.fg_color(Color::new(*r, *g, *b));
-            }
-            [38, 5, value] => {
-                if let Some(color) = Self::parse_color(*value) {
-                    *style = style.fg_color(color);
-                }
-            }
-            [48, 2, r, g, b] => {
-                *style = style.bg_color(Color::new(*r, *g, *b));
-            }
-            [48, 5, value] => {
-                if let Some(color) = Self::parse_color(*value) {
-                    *style = style.bg_color(color);
-                }
-            }
-            _ => (),
-        };
+impl Handler {
+    fn new(style: TextStyle) -> Self {
+        Self { line: Default::default(), pending_text: Default::default(), style }
     }
 
-    fn parse_color(value: u8) -> Option<Color> {
-        match value {
-            0..=15 => Self::as_standard_color(value),
-            16..=231 => {
-                let mapping = [0, 95, 95 + 40, 95 + 80, 95 + 120, 95 + 160];
-                let mut value = value - 16;
-                let b = (value % 6) as usize;
-                value /= 6;
-                let g = (value % 6) as usize;
-                value /= 6;
-                let r = (value % 6) as usize;
-                Some(Color::new(mapping[r], mapping[g], mapping[b]))
-            }
-            _ => None,
+    fn into_parts(mut self) -> (Line, TextStyle) {
+        self.save_pending_text();
+        (self.line, self.style)
+    }
+
+    fn save_pending_text(&mut self) {
+        if !self.pending_text.content.is_empty() {
+            self.line.0.push(mem::take(&mut self.pending_text));
         }
     }
 
-    fn as_standard_color(value: u8) -> Option<Color> {
+    fn parse_standard_color(value: u16) -> Option<Color> {
         let color = match value {
             0 | 8 => Color::Black,
             1 | 9 => Color::Red,
@@ -123,5 +70,205 @@ impl GraphicsCode<'_> {
             _ => return None,
         };
         Some(color)
+    }
+
+    fn parse_color(iter: &mut ParamsIter) -> Option<Color> {
+        match iter.next()? {
+            [2] => {
+                let r = iter.next()?.first()?;
+                let g = iter.next()?.first()?;
+                let b = iter.next()?.first()?;
+                Self::try_build_rgb_color(*r, *g, *b)
+            }
+            [5] => {
+                let color = *iter.next()?.first()?;
+                match color {
+                    0..=15 => Self::parse_standard_color(color),
+                    16..=231 => {
+                        let mapping = [0, 95, 95 + 40, 95 + 80, 95 + 120, 95 + 160];
+                        let mut value = color - 16;
+                        let b = (value % 6) as usize;
+                        value /= 6;
+                        let g = (value % 6) as usize;
+                        value /= 6;
+                        let r = (value % 6) as usize;
+                        Some(Color::new(mapping[r], mapping[g], mapping[b]))
+                    }
+                    _ => None,
+                }
+            }
+            _ => None,
+        }
+    }
+
+    fn try_build_rgb_color(r: u16, g: u16, b: u16) -> Option<Color> {
+        let r = r.try_into().ok()?;
+        let g = g.try_into().ok()?;
+        let b = b.try_into().ok()?;
+        Some(Color::new(r, g, b))
+    }
+
+    fn update_style(&self, mut codes: ParamsIter) -> TextStyle {
+        let mut style = self.style;
+        loop {
+            let Some(&[next]) = codes.next() else {
+                break;
+            };
+            match next {
+                0 => style = Default::default(),
+                1 => style = style.bold(),
+                3 => style = style.italics(),
+                4 => style = style.underlined(),
+                9 => style = style.strikethrough(),
+                39 => {
+                    style.colors.foreground = None;
+                }
+                49 => {
+                    style.colors.background = None;
+                }
+                30..=37 => {
+                    if let Some(color) = Self::parse_standard_color(next - 30) {
+                        style = style.fg_color(color);
+                    }
+                }
+                40..=47 => {
+                    if let Some(color) = Self::parse_standard_color(next - 40) {
+                        style = style.bg_color(color);
+                    }
+                }
+                38 => {
+                    if let Some(color) = Self::parse_color(&mut codes) {
+                        style = style.fg_color(color);
+                    }
+                }
+                48 => {
+                    if let Some(color) = Self::parse_color(&mut codes) {
+                        style = style.bg_color(color);
+                    }
+                }
+                _ => (),
+            };
+        }
+        style
+    }
+}
+
+impl Perform for Handler {
+    fn print(&mut self, c: char) {
+        self.pending_text.content.push(c);
+    }
+
+    fn csi_dispatch(&mut self, params: &vte::Params, _intermediates: &[u8], _ignore: bool, action: char) {
+        if action == 'm' {
+            self.save_pending_text();
+            self.style = self.update_style(params.iter());
+            self.pending_text.style = self.style;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::text("hi", Line::from("hi"))]
+    #[case::single_attribute("\x1b[1mhi", Line::from(Text::new("hi", TextStyle::default().bold())))]
+    #[case::two_attributes("\x1b[1;3mhi", Line::from(Text::new("hi", TextStyle::default().bold().italics())))]
+    #[case::three_attributes("\x1b[1;3;4mhi", Line::from(Text::new("hi", TextStyle::default().bold().italics().underlined())))]
+    #[case::four_attributes(
+        "\x1b[1;3;4;9mhi", 
+        Line::from(Text::new("hi", TextStyle::default().bold().italics().underlined().strikethrough()))
+    )]
+    #[case::standard_foreground1(
+        "\x1b[38;5;1mhi", 
+        Line::from(Text::new("hi", TextStyle::default().fg_color(Color::Red)))
+    )]
+    #[case::standard_foreground2(
+        "\x1b[31mhi", 
+        Line::from(Text::new("hi", TextStyle::default().fg_color(Color::Red)))
+    )]
+    #[case::rgb_foreground(
+        "\x1b[38;2;3;4;5mhi", 
+        Line::from(Text::new("hi", TextStyle::default().fg_color(Color::new(3, 4, 5))))
+    )]
+    #[case::standard_background1(
+        "\x1b[48;5;1mhi", 
+        Line::from(Text::new("hi", TextStyle::default().bg_color(Color::Red)))
+    )]
+    #[case::standard_background2(
+        "\x1b[41mhi", 
+        Line::from(Text::new("hi", TextStyle::default().bg_color(Color::Red)))
+    )]
+    #[case::rgb_background(
+        "\x1b[48;2;3;4;5mhi", 
+        Line::from(Text::new("hi", TextStyle::default().bg_color(Color::new(3, 4, 5))))
+    )]
+    #[case::accumulate(
+        "\x1b[1mhi\x1b[3mbye", 
+        Line(vec![
+            Text::new("hi", TextStyle::default().bold()),
+            Text::new("bye", TextStyle::default().bold().italics())
+        ])
+    )]
+    #[case::reset(
+        "\x1b[1mhi\x1b[0;3mbye", 
+        Line(vec![
+            Text::new("hi", TextStyle::default().bold()),
+            Text::new("bye", TextStyle::default().italics())
+        ])
+    )]
+    #[case::different_action(
+        "\x1b[01m\x1b[Khi",
+        Line::from(Text::new("hi", TextStyle::default().bold()))
+    )]
+    fn parse_single(#[case] input: &str, #[case] expected: Line) {
+        let splitter = AnsiSplitter::new(Default::default());
+        let (lines, _) = splitter.split_lines(&[input]);
+        assert_eq!(lines, vec![expected.into()]);
+    }
+
+    #[rstest]
+    #[case::reset_all("\x1b[0mhi", Line::from("hi"))]
+    #[case::reset_foreground(
+        "\x1b[39mhi", 
+        Line::from(
+            Text::new(
+                "hi", 
+                TextStyle::default()
+                    .bold()
+                    .italics()
+                    .underlined()
+                    .strikethrough()
+                    .bg_color(Color::Black)
+            )
+        )
+    )]
+    #[case::reset_background(
+        "\x1b[49mhi", 
+        Line::from(
+            Text::new(
+                "hi", 
+                TextStyle::default()
+                    .bold()
+                    .italics()
+                    .underlined()
+                    .strikethrough()
+                    .fg_color(Color::Red)
+            )
+        )
+    )]
+    fn resets(#[case] input: &str, #[case] expected: Line) {
+        let style = TextStyle::default()
+            .bold()
+            .italics()
+            .underlined()
+            .strikethrough()
+            .fg_color(Color::Red)
+            .bg_color(Color::Black);
+        let splitter = AnsiSplitter::new(style);
+        let (lines, _) = splitter.split_lines(&[input]);
+        assert_eq!(lines, vec![expected.into()]);
     }
 }


### PR DESCRIPTION
Changes in 0.10.0 were made to fix some incorrect ansi escape code parsing when processing snippet execution output. However, those changes were still not handling parsing properly and ended up causing it to break in other cases.

This change hopefully fixes that. This also removes ansi-parser and starts using vte to parse escape codes as ansi-parser doesn't let you have more than 5 segments in an escape code. As an added bonus this also removes a bunch of dependencies.

Fixes #499