### PR TITLE
feat: respect font sizes in generated PDF

### DIFF
--- a/src/export/exporter.rs
+++ b/src/export/exporter.rs
@@ -53,6 +53,7 @@ impl<'a> Exporter<'a> {
     ) -> Self {
         // We don't want dynamically highlighted code blocks.
         options.allow_mutations = false;
+        options.theme_options.font_size_supported = true;
 
         // Make sure we have a 1:2 aspect ratio.
         let width = (0.5 * dimensions.columns as f64) / (dimensions.rows as f64 / dimensions.height as f64);

--- a/src/export/pdf.rs
+++ b/src/export/pdf.rs
@@ -98,6 +98,10 @@ impl HtmlSlide {
             let color = Self::color_to_html(color);
             css_styles.push(format!("color: {color}").into());
         }
+        if style.size > 1 {
+            let font_size = FONT_SIZE * style.size as u16;
+            css_styles.push(format!("font-size: {font_size}px").into());
+        }
         let css_style = css_styles.join("; ");
         format!("<span style=\"{css_style}\">{s}</span>")
     }


### PR DESCRIPTION
This respects font sizes in the generated PDF. The one thing that is not yet supported here is text with font size > 1 _and_ with a background color. The background color only shows up in the line where the text is. But this should be rarer (e.g. a font size > 1 code block?) so this works for most cases.

Fixes https://github.com/mfontanini/presenterm-export/issues/17