### PR TITLE
feat: allow specifying export dimensions in config file

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -36,6 +36,26 @@ jobs:
       - name: Run cargo fmt
         run: cargo +nightly fmt --all -- --check
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install weasyprint
+        run: |
+          uv venv
+          source ./.venv/bin/activate
+          uv pip install weasyprint
+
+      - name: Export demo presentation as PDF
+        run: |
+          cat >/tmp/config.yaml <<EOL
+          export:
+            dimensions:
+              rows: 35
+              columns: 135
+          EOL
+          source ./.venv/bin/activate
+          cargo run -- -e -c /tmp/config.yaml examples/demo.md
+
   nix-flake:
     name: Validate nix flake
     runs-on: ubuntu-latest

--- a/config-file-schema.json
+++ b/config-file-schema.json
@@ -14,6 +14,9 @@
         }
       ]
     },
+    "export": {
+      "$ref": "#/definitions/ExportConfig"
+    },
     "mermaid": {
       "$ref": "#/definitions/MermaidConfig"
     },
@@ -87,6 +90,47 @@
               "$ref": "#/definitions/ValidateOverflows"
             }
           ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "ExportConfig": {
+      "description": "The export configuration.",
+      "type": "object",
+      "properties": {
+        "dimensions": {
+          "description": "The dimensions to use for presentation exports.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ExportDimensionsConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "ExportDimensionsConfig": {
+      "description": "The dimensions to use for presentation exports.",
+      "type": "object",
+      "required": [
+        "columns",
+        "rows"
+      ],
+      "properties": {
+        "columns": {
+          "description": "The number of columns.",
+          "type": "integer",
+          "format": "uint16",
+          "minimum": 0.0
+        },
+        "rows": {
+          "description": "The number of rows.",
+          "type": "integer",
+          "format": "uint16",
+          "minimum": 0.0
         }
       },
       "additionalProperties": false

--- a/src/config.rs
+++ b/src/config.rs
@@ -40,6 +40,9 @@ pub struct Config {
 
     #[serde(default)]
     pub speaker_notes: SpeakerNotesConfig,
+
+    #[serde(default)]
+    pub export: ExportConfig,
 }
 
 impl Config {
@@ -457,6 +460,25 @@ impl Default for SpeakerNotesConfig {
             always_publish: false,
         }
     }
+}
+
+/// The export configuration.
+#[derive(Clone, Debug, Default, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ExportConfig {
+    /// The dimensions to use for presentation exports.
+    pub dimensions: Option<ExportDimensionsConfig>,
+}
+
+/// The dimensions to use for presentation exports.
+#[derive(Clone, Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ExportDimensionsConfig {
+    /// The number of rows.
+    pub rows: u16,
+
+    /// The number of columns.
+    pub columns: u16,
 }
 
 fn make_keybindings<const N: usize>(raw_bindings: [&str; N]) -> Vec<KeyBinding> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,8 @@ mod tools;
 mod ui;
 
 const DEFAULT_THEME: &str = "dark";
+const DEFAULT_EXPORT_PIXELS_PER_COLUMN: u16 = 20;
+const DEFAULT_EXPORT_PIXELS_PER_ROW: u16 = DEFAULT_EXPORT_PIXELS_PER_COLUMN * 2;
 
 /// Run slideshows from your terminal.
 #[derive(Parser)]
@@ -386,7 +388,15 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
     let validate_overflows =
         overflow_validation_enabled(&present_mode, &config.defaults.validate_overflows) || cli.validate_overflows;
     if cli.export_pdf {
-        let dimensions = WindowSize::current(config.defaults.terminal_font_size)?;
+        let dimensions = match config.export.dimensions {
+            Some(dimensions) => WindowSize {
+                rows: dimensions.rows,
+                columns: dimensions.columns,
+                height: dimensions.rows * DEFAULT_EXPORT_PIXELS_PER_ROW,
+                width: dimensions.columns * DEFAULT_EXPORT_PIXELS_PER_COLUMN,
+            },
+            None => WindowSize::current(config.defaults.terminal_font_size)?,
+        };
         let exporter = Exporter::new(
             parser,
             &default_theme,


### PR DESCRIPTION
This allows specifying the dimensions to use when exporting a presentation to PDF. This allows exporting to PDF in contexts without a tty which should help people write scripts that automatically export presentations. This now also adds a step in the CI that tries to export the default presentation as PDF, which couldn't be tested before because of the tty restriction.

```yaml
export:
  dimensions:
    rows: 35
    columns: 135
```