### PR TITLE
ci: revert build with sixel enabled

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -64,7 +64,7 @@ jobs:
         with:
           use-cross: true
           command: build
-          args: --release --locked --target ${{ matrix.config.TARGET }} --features sixel
+          args: --release --locked --target ${{ matrix.config.TARGET }}
 
       - name: Prepare release assets
         shell: bash

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -68,7 +68,7 @@ jobs:
         with:
           use-cross: true
           command: build
-          args: --release --locked --target ${{ matrix.config.TARGET }} --features sixel
+          args: --release --locked --target ${{ matrix.config.TARGET }}
 
       - name: Prepare release assets
         shell: bash


### PR DESCRIPTION
This causes builds to fail. This should maybe be moved to use some sixel crate that's pure rust and not based on libsixel.