### PR TITLE
feat: add --output option for PDF exports

### DIFF
--- a/src/export/exporter.rs
+++ b/src/export/exporter.rs
@@ -100,6 +100,7 @@ impl<'a> Exporter<'a> {
         mut self,
         presentation_path: &Path,
         output_directory: OutputDirectory,
+        output_path: Option<&Path>,
     ) -> Result<(), ExportError> {
         println!(
             "exporting using rows={}, columns={}, width={}, height={}",
@@ -138,7 +139,10 @@ impl<'a> Exporter<'a> {
         }
         Self::log("invoking weasyprint...")?;
 
-        let pdf_path = presentation_path.with_extension("pdf");
+        let pdf_path = match output_path {
+            Some(path) => path.to_path_buf(),
+            None => presentation_path.with_extension("pdf"),
+        };
         render.generate(&pdf_path)?;
 
         execute!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,6 +74,10 @@ struct Cli {
     #[clap(long, requires = "export_pdf")]
     export_temporary_path: Option<PathBuf>,
 
+    /// The output path for the exported PDF.
+    #[clap(short = 'o', long = "output", requires = "export_pdf")]
+    export_output: Option<PathBuf>,
+
     /// Generate a JSON schema for the configuration file.
     #[clap(long)]
     generate_config_file_schema: bool,
@@ -416,7 +420,7 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             Some(path) => OutputDirectory::external(path),
             None => OutputDirectory::temporary(),
         }?;
-        exporter.export_pdf(&path, output_directory)?;
+        exporter.export_pdf(&path, output_directory, cli.export_output.as_deref())?;
     } else {
         let SpeakerNotesComponents { events_listener, events_publisher } =
             SpeakerNotesComponents::new(&cli, &config, &path)?;


### PR DESCRIPTION
## Summary
Adds a new command-line option (`--output`/`-o`) allowing users to specify custom output paths when exporting presentations to PDF. Previously, presenterm automatically generated PDFs in the same location as the input file.

## Motivation
This feature simplifies multi-theme exports without requiring manual file renaming or temporary copies. It enables clean parallel exports with different themes (light/dark) to distinct output files.

### Before:
```bash
generate_pdf() {
  local dir="$1"
  local theme="$2"
  cd "$dir" || exit
  # Generate PDF then rename immediately
  "$PRESENTERM_PATH" -e -t "$theme" --export-temporary-path "$TEMP_DIR" slide.md
  mv slide.pdf "slide_${theme}.pdf"
  cd - >/dev/null || exit
}
```

### After:
```bash
generate_pdf() {
  local dir="$1"
  local theme="$2"
  cd "$dir" || exit
  # Directly specify output file with theme name
  "$PRESENTERM_PATH" -e -t "$theme" --output "slide_${theme}.pdf" slide.md
  cd - >/dev/null || exit
}
```

## Example Usage
```
presenterm --export-pdf --output my-slides.pdf presentation.md
```

@mfontanini my rust skills are literally nil, I just copy pasted base on your code.