### PR TITLE
feat: add slide horizontally slide transition animation

### DIFF
--- a/config-file-schema.json
+++ b/config-file-schema.json
@@ -29,6 +29,16 @@
     "speaker_notes": {
       "$ref": "#/definitions/SpeakerNotesConfig"
     },
+    "transition": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SlideTransitionConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "typst": {
       "$ref": "#/definitions/TypstConfig"
     }
@@ -443,6 +453,57 @@
         }
       },
       "additionalProperties": false
+    },
+    "SlideTransitionConfig": {
+      "type": "object",
+      "required": [
+        "animation"
+      ],
+      "properties": {
+        "animation": {
+          "description": "The slide transition style.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SlideTransitionStyleConfig"
+            }
+          ]
+        },
+        "duration_millis": {
+          "description": "The amount of time to take to perform the transition.",
+          "default": 1000,
+          "type": "integer",
+          "format": "uint16",
+          "minimum": 0.0
+        },
+        "frames": {
+          "description": "The number of frames in a transition.",
+          "default": 30,
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        }
+      },
+      "additionalProperties": false
+    },
+    "SlideTransitionStyleConfig": {
+      "oneOf": [
+        {
+          "description": "Slide horizontally.",
+          "type": "object",
+          "required": [
+            "style"
+          ],
+          "properties": {
+            "style": {
+              "type": "string",
+              "enum": [
+                "slide_horizontal"
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
     },
     "SnippetConfig": {
       "type": "object",

--- a/src/config.rs
+++ b/src/config.rs
@@ -43,6 +43,9 @@ pub struct Config {
 
     #[serde(default)]
     pub export: ExportConfig,
+
+    #[serde(default)]
+    pub transition: Option<SlideTransitionConfig>,
 }
 
 impl Config {
@@ -481,6 +484,32 @@ pub struct ExportDimensionsConfig {
     pub columns: u16,
 }
 
+// The slide transition configuration.
+#[derive(Clone, Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+#[serde(tag = "style")]
+pub struct SlideTransitionConfig {
+    /// The amount of time to take to perform the transition.
+    #[serde(default = "default_transition_duration_millis")]
+    pub duration_millis: u16,
+
+    /// The number of frames in a transition.
+    #[serde(default = "default_transition_frames")]
+    pub frames: usize,
+
+    /// The slide transition style.
+    pub animation: SlideTransitionStyleConfig,
+}
+
+// The slide transition style configuration.
+#[derive(Clone, Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+#[serde(tag = "style", rename_all = "snake_case")]
+pub enum SlideTransitionStyleConfig {
+    /// Slide horizontally.
+    SlideHorizontal,
+}
+
 fn make_keybindings<const N: usize>(raw_bindings: [&str; N]) -> Vec<KeyBinding> {
     let mut bindings = Vec::new();
     for binding in raw_bindings {
@@ -543,6 +572,14 @@ fn default_exit_bindings() -> Vec<KeyBinding> {
 
 fn default_suspend_bindings() -> Vec<KeyBinding> {
     make_keybindings(["<c-z>"])
+}
+
+fn default_transition_duration_millis() -> u16 {
+    1000
+}
+
+fn default_transition_frames() -> usize {
+    30
 }
 
 #[cfg(target_os = "linux")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,7 @@ mod terminal;
 mod theme;
 mod third_party;
 mod tools;
+mod transitions;
 mod ui;
 
 const DEFAULT_THEME: &str = "dark";
@@ -435,6 +436,7 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             validate_overflows,
             max_columns: config.defaults.max_columns,
             max_columns_alignment: config.defaults.max_columns_alignment,
+            transition: config.transition,
         };
         let presenter = Presenter::new(
             &default_theme,

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -16,10 +16,7 @@ use crate::{
         properties::WindowSize, validate::OverflowValidator,
     },
     resource::Resources,
-    terminal::{
-        image::printer::{ImagePrinter, ImageRegistry},
-        printer::TerminalIo,
-    },
+    terminal::image::printer::{ImagePrinter, ImageRegistry},
     theme::{ProcessingThemeError, raw::PresentationTheme},
     third_party::ThirdPartyRender,
 };

--- a/src/render/engine.rs
+++ b/src/render/engine.rs
@@ -24,7 +24,7 @@ use std::mem;
 
 const MINIMUM_LINE_LENGTH: u16 = 10;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) struct RenderEngineOptions {
     pub(crate) validate_overflows: bool,
     pub(crate) max_columns: u16,

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -16,6 +16,7 @@ use crate::{
     terminal::{
         Terminal,
         image::printer::{ImagePrinter, PrintImageError},
+        printer::TerminalError,
     },
     theme::{Alignment, Margin},
 };
@@ -111,6 +112,9 @@ impl TerminalDrawer {
 pub(crate) enum RenderError {
     #[error("io: {0}")]
     Io(#[from] io::Error),
+
+    #[error("terminal: {0}")]
+    Terminal(#[from] TerminalError),
 
     #[error("screen is too small")]
     TerminalTooSmall,

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -97,12 +97,16 @@ impl TerminalDrawer {
         Ok(())
     }
 
-    fn create_engine(&mut self, dimensions: WindowSize) -> RenderEngine<Terminal<Stdout>> {
-        let options = RenderEngineOptions {
+    pub(crate) fn render_engine_options(&self) -> RenderEngineOptions {
+        RenderEngineOptions {
             max_columns: self.options.max_columns,
             max_columns_alignment: self.options.max_columns_alignment,
             ..Default::default()
-        };
+        }
+    }
+
+    fn create_engine(&mut self, dimensions: WindowSize) -> RenderEngine<Terminal<Stdout>> {
+        let options = self.render_engine_options();
         RenderEngine::new(&mut self.terminal, dimensions, options)
     }
 }

--- a/src/render/properties.rs
+++ b/src/render/properties.rs
@@ -92,7 +92,7 @@ impl From<(u16, u16)> for WindowSize {
 }
 
 /// The cursor's position.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub(crate) struct CursorPosition {
     pub(crate) column: u16,
     pub(crate) row: u16,

--- a/src/terminal/image/printer.rs
+++ b/src/terminal/image/printer.rs
@@ -37,7 +37,7 @@ pub(crate) trait ImageProperties {
     fn dimensions(&self) -> (u32, u32);
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub(crate) struct PrintOptions {
     pub(crate) columns: u16,
     pub(crate) rows: u16,

--- a/src/terminal/printer.rs
+++ b/src/terminal/printer.rs
@@ -14,6 +14,7 @@ use std::{
     sync::Arc,
 };
 
+#[derive(Debug, PartialEq)]
 pub(crate) enum TerminalCommand<'a> {
     BeginUpdate,
     EndUpdate,
@@ -109,6 +110,7 @@ impl<I: TerminalWrite> Terminal<I> {
     fn clear_screen(&mut self) -> io::Result<()> {
         self.writer.queue(terminal::Clear(terminal::ClearType::All))?;
         self.cursor_row = 0;
+        self.current_row_height = 1;
         Ok(())
     }
 
@@ -178,7 +180,7 @@ impl<I: TerminalWrite> Drop for Terminal<I> {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub(crate) struct TextProperties {
     pub(crate) height: u8,
 }

--- a/src/terminal/printer.rs
+++ b/src/terminal/printer.rs
@@ -14,23 +14,34 @@ use std::{
     sync::Arc,
 };
 
+pub(crate) enum TerminalCommand<'a> {
+    BeginUpdate,
+    EndUpdate,
+    MoveTo { column: u16, row: u16 },
+    MoveToRow(u16),
+    MoveToColumn(u16),
+    MoveDown(u16),
+    MoveToNextLine,
+    PrintText { content: &'a str, style: TextStyle, properties: TextProperties },
+    ClearScreen,
+    SetColors(Colors),
+    SetBackgroundColor(Color),
+    Flush,
+    PrintImage { image: Image, options: PrintOptions },
+}
+
 pub(crate) trait TerminalIo {
-    fn begin_update(&mut self) -> io::Result<()>;
-    fn end_update(&mut self) -> io::Result<()>;
+    fn execute(&mut self, command: &TerminalCommand<'_>) -> Result<(), TerminalError>;
     fn cursor_row(&self) -> u16;
-    fn move_to(&mut self, column: u16, row: u16) -> io::Result<()>;
-    fn move_to_row(&mut self, row: u16) -> io::Result<()>;
-    fn move_to_column(&mut self, column: u16) -> io::Result<()>;
-    fn move_down(&mut self, amount: u16) -> io::Result<()>;
-    fn move_to_next_line(&mut self) -> io::Result<()>;
-    fn print_text(&mut self, content: &str, style: &TextStyle, properties: &TextProperties) -> io::Result<()>;
-    fn clear_screen(&mut self) -> io::Result<()>;
-    fn set_colors(&mut self, colors: Colors) -> io::Result<()>;
-    fn set_background_color(&mut self, color: Color) -> io::Result<()>;
-    fn flush(&mut self) -> io::Result<()>;
-    fn print_image(&mut self, image: &Image, options: &PrintOptions) -> Result<(), PrintImageError>;
-    fn suspend(&mut self);
-    fn resume(&mut self);
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum TerminalError {
+    #[error("io: {0}")]
+    Io(#[from] io::Error),
+
+    #[error("image: {0}")]
+    Image(#[from] PrintImageError),
 }
 
 /// A wrapper over the terminal write handle.
@@ -46,9 +57,7 @@ impl<I: TerminalWrite> Terminal<I> {
         writer.init()?;
         Ok(Self { writer, image_printer, cursor_row: 0, current_row_height: 1 })
     }
-}
 
-impl<I: TerminalWrite> TerminalIo for Terminal<I> {
     fn begin_update(&mut self) -> io::Result<()> {
         self.writer.queue(terminal::BeginSynchronizedUpdate)?;
         Ok(())
@@ -57,10 +66,6 @@ impl<I: TerminalWrite> TerminalIo for Terminal<I> {
     fn end_update(&mut self) -> io::Result<()> {
         self.writer.queue(terminal::EndSynchronizedUpdate)?;
         Ok(())
-    }
-
-    fn cursor_row(&self) -> u16 {
-        self.cursor_row
     }
 
     fn move_to(&mut self, column: u16, row: u16) -> io::Result<()> {
@@ -132,12 +137,38 @@ impl<I: TerminalWrite> TerminalIo for Terminal<I> {
         Ok(())
     }
 
-    fn suspend(&mut self) {
+    pub(crate) fn suspend(&mut self) {
         self.writer.deinit();
     }
 
-    fn resume(&mut self) {
+    pub(crate) fn resume(&mut self) {
         let _ = self.writer.init();
+    }
+}
+
+impl<I: TerminalWrite> TerminalIo for Terminal<I> {
+    fn execute(&mut self, command: &TerminalCommand<'_>) -> Result<(), TerminalError> {
+        use TerminalCommand::*;
+        match command {
+            BeginUpdate => self.begin_update()?,
+            EndUpdate => self.end_update()?,
+            MoveTo { column, row } => self.move_to(*column, *row)?,
+            MoveToRow(row) => self.move_to_row(*row)?,
+            MoveToColumn(column) => self.move_to_column(*column)?,
+            MoveDown(amount) => self.move_down(*amount)?,
+            MoveToNextLine => self.move_to_next_line()?,
+            PrintText { content, style, properties } => self.print_text(content, style, properties)?,
+            ClearScreen => self.clear_screen()?,
+            SetColors(colors) => self.set_colors(*colors)?,
+            SetBackgroundColor(color) => self.set_background_color(*color)?,
+            Flush => self.flush()?,
+            PrintImage { image, options } => self.print_image(image, options)?,
+        };
+        Ok(())
+    }
+
+    fn cursor_row(&self) -> u16 {
+        self.cursor_row
     }
 }
 
@@ -147,7 +178,7 @@ impl<I: TerminalWrite> Drop for Terminal<I> {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub(crate) struct TextProperties {
     pub(crate) height: u8,
 }

--- a/src/transitions/mod.rs
+++ b/src/transitions/mod.rs
@@ -1,0 +1,136 @@
+use std::fmt::Debug;
+
+use crate::{
+    markdown::{elements::Line, text_style::Color},
+    terminal::printer::{TerminalCommand, TextProperties},
+};
+use unicode_width::UnicodeWidthStr;
+
+pub(crate) mod slide_horizontal;
+
+#[derive(Clone, Debug)]
+pub(crate) enum TransitionDirection {
+    Next,
+    Previous,
+}
+
+pub(crate) trait AnimateTransition {
+    type Frame: AnimationFrame + Debug;
+
+    fn build_frame(&self, frame: usize, direction: TransitionDirection) -> Self::Frame;
+    fn total_frames(&self) -> usize;
+}
+
+pub(crate) trait AnimationFrame {
+    fn build_commands(&self) -> Vec<TerminalCommand>;
+}
+
+#[derive(Debug)]
+pub(crate) struct LinesFrame {
+    pub(crate) lines: Vec<Line>,
+    pub(crate) background_color: Option<Color>,
+}
+
+impl LinesFrame {
+    fn skip_whitespace(mut text: &str) -> (&str, usize, usize) {
+        let mut trimmed_before = 0;
+        while let Some(' ') = text.chars().next() {
+            text = &text[1..];
+            trimmed_before += 1;
+        }
+        let mut trimmed_after = 0;
+        let mut rev = text.chars().rev();
+        while let Some(' ') = rev.next() {
+            text = &text[..text.len() - 1];
+            trimmed_after += 1;
+        }
+        (text, trimmed_before, trimmed_after)
+    }
+}
+
+impl AnimationFrame for LinesFrame {
+    fn build_commands(&self) -> Vec<TerminalCommand> {
+        use TerminalCommand::*;
+        let mut commands = vec![];
+        if let Some(color) = self.background_color {
+            commands.push(SetBackgroundColor(color));
+        }
+        commands.push(ClearScreen);
+        for (row, line) in self.lines.iter().enumerate() {
+            let mut column = 0;
+            let mut is_in_column = false;
+            let mut is_in_row = false;
+            for chunk in &line.0 {
+                let (text, white_before, white_after) = match chunk.style.colors.background {
+                    Some(_) => (chunk.content.as_str(), 0, 0),
+                    None => Self::skip_whitespace(&chunk.content),
+                };
+                // If this is an empty line just skip it
+                if text.is_empty() {
+                    column += chunk.content.width();
+                    is_in_column = false;
+                    continue;
+                }
+                if !is_in_row {
+                    commands.push(MoveToRow(row as u16));
+                    is_in_row = true;
+                }
+                if white_before > 0 {
+                    column += white_before;
+                    is_in_column = false;
+                }
+                if !is_in_column {
+                    commands.push(MoveToColumn(column as u16));
+                    is_in_column = true;
+                }
+                commands.push(PrintText {
+                    content: text,
+                    style: chunk.style,
+                    properties: TextProperties { height: chunk.style.size },
+                });
+                column += text.width();
+                if white_after > 0 {
+                    column += white_after;
+                    is_in_column = false;
+                }
+            }
+        }
+        commands
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::markdown::elements::Text;
+
+    #[test]
+    fn commands() {
+        let animation = LinesFrame {
+            lines: vec![
+                Line(vec![Text::from("  hi  "), Text::from("bye"), Text::from("s")]),
+                Line(vec![Text::from("hello"), Text::from(" wor"), Text::from("s")]),
+            ],
+            background_color: Some(Color::Red),
+        };
+        let commands = animation.build_commands();
+        use TerminalCommand::*;
+        let expected = &[
+            SetBackgroundColor(Color::Red),
+            ClearScreen,
+            MoveToRow(0),
+            MoveToColumn(2),
+            PrintText { content: "hi", style: Default::default(), properties: TextProperties { height: 1 } },
+            MoveToColumn(6),
+            PrintText { content: "bye", style: Default::default(), properties: TextProperties { height: 1 } },
+            PrintText { content: "s", style: Default::default(), properties: TextProperties { height: 1 } },
+            MoveToRow(1),
+            MoveToColumn(0),
+            PrintText { content: "hello", style: Default::default(), properties: TextProperties { height: 1 } },
+            MoveToColumn(6),
+            PrintText { content: "wor", style: Default::default(), properties: TextProperties { height: 1 } },
+            PrintText { content: "s", style: Default::default(), properties: TextProperties { height: 1 } },
+        ];
+        assert_eq!(commands, expected);
+    }
+}

--- a/src/transitions/slide_horizontal.rs
+++ b/src/transitions/slide_horizontal.rs
@@ -1,0 +1,102 @@
+use super::{AnimateTransition, LinesFrame, TransitionDirection};
+use crate::{
+    WindowSize,
+    markdown::elements::Line,
+    terminal::virt::{TerminalGrid, TerminalRowIterator},
+};
+
+pub(crate) struct SlideHorizontalAnimation {
+    grid: TerminalGrid,
+    dimensions: WindowSize,
+}
+
+impl SlideHorizontalAnimation {
+    pub(crate) fn new(left: TerminalGrid, right: TerminalGrid, dimensions: WindowSize) -> Self {
+        assert!(left.rows.len() == right.rows.len(), "different row count");
+        assert!(left.rows[0].len() == right.rows[0].len(), "different column count");
+        assert!(left.background_color == right.background_color, "different background color");
+
+        let mut rows = Vec::new();
+        for (mut row, right) in left.rows.into_iter().zip(right.rows) {
+            row.extend(right);
+            rows.push(row);
+        }
+        let grid = TerminalGrid { rows, background_color: left.background_color, images: Default::default() };
+        Self { grid, dimensions }
+    }
+}
+
+impl AnimateTransition for SlideHorizontalAnimation {
+    type Frame = LinesFrame;
+
+    fn build_frame(&self, frame: usize, direction: TransitionDirection) -> Self::Frame {
+        let total = self.total_frames();
+        let frame = frame.min(total);
+        let index = match direction {
+            TransitionDirection::Next => frame,
+            TransitionDirection::Previous => total.saturating_sub(frame),
+        };
+        let mut lines = Vec::new();
+        for row in &self.grid.rows {
+            let row = &row[index..index + self.dimensions.columns as usize];
+            let mut line = Vec::new();
+            let max_width = self.dimensions.columns as usize;
+            let mut width = 0;
+            for mut text in TerminalRowIterator::new(row) {
+                let text_width = text.width() * text.style.size as usize;
+                if width + text_width > max_width {
+                    let capped_width = max_width.saturating_sub(width) / text.style.size as usize;
+                    if capped_width == 0 {
+                        continue;
+                    }
+                    text.content = text.content.chars().take(capped_width).collect();
+                }
+                width += text_width;
+                line.push(text);
+            }
+            lines.push(Line(line));
+        }
+        LinesFrame { lines, background_color: self.grid.background_color }
+    }
+
+    fn total_frames(&self) -> usize {
+        self.grid.rows[0].len().saturating_sub(self.dimensions.columns as usize)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::terminal::virt::StyledChar;
+    use rstest::rstest;
+
+    fn as_text(line: Line) -> String {
+        line.0.into_iter().map(|l| l.content).collect()
+    }
+
+    fn build_grid(rows: &[&str]) -> TerminalGrid {
+        let rows = rows
+            .iter()
+            .map(|r| r.chars().map(|c| StyledChar { character: c, style: Default::default() }).collect())
+            .collect();
+        TerminalGrid { rows, background_color: None, images: Default::default() }
+    }
+
+    #[rstest]
+    #[case::next_frame0(0, TransitionDirection::Next, &["AB", "CD"])]
+    #[case::next_frame1(1, TransitionDirection::Next, &["BE", "DG"])]
+    #[case::next_frame2(2, TransitionDirection::Next, &["EF", "GH"])]
+    #[case::next_way_past(100, TransitionDirection::Next, &["EF", "GH"])]
+    #[case::previous_frame0(0, TransitionDirection::Previous, &["EF", "GH"])]
+    #[case::previous_frame1(1, TransitionDirection::Previous, &["BE", "DG"])]
+    #[case::previous_frame2(2, TransitionDirection::Previous, &["AB", "CD"])]
+    #[case::previous_way_past(100, TransitionDirection::Previous, &["AB", "CD"])]
+    fn build_frame(#[case] frame: usize, #[case] direction: TransitionDirection, #[case] expected: &[&str]) {
+        let left = build_grid(&["AB", "CD"]);
+        let right = build_grid(&["EF", "GH"]);
+        let dimensions = WindowSize { rows: 2, columns: 2, height: 0, width: 0 };
+        let transition = SlideHorizontalAnimation::new(left, right, dimensions);
+        let lines: Vec<_> = transition.build_frame(frame, direction).lines.into_iter().map(as_text).collect();
+        assert_eq!(lines, expected);
+    }
+}


### PR DESCRIPTION
This adds support for the first slide transition animation that swaps between slides horizontally. This is still a work in progress; it's functional but is missing a few things like dealing with images. The configuration currently looks like the following, but it will likely be changed slightly once another type of transition is supported (will happen before next release).

```yaml
transition:
 duration_millis: 750
 animation:
   style: slide_horizontal
```

This looks like the following:

https://github.com/user-attachments/assets/9475caf9-0538-4ffd-8858-115aac348bd1




Relates to #364