### PR TITLE
chore: get rid of `TextProperties`

### DIFF
--- a/src/render/engine.rs
+++ b/src/render/engine.rs
@@ -446,7 +446,7 @@ mod tests {
     use super::*;
     use crate::{
         markdown::text_style::{Color, TextStyle},
-        terminal::printer::{TerminalError, TextProperties},
+        terminal::printer::TerminalError,
         theme::Margin,
     };
     use std::io;
@@ -499,7 +499,7 @@ mod tests {
             self.push(Instruction::MoveToNextLine)
         }
 
-        fn print_text(&mut self, content: &str, _style: &TextStyle, _properties: &TextProperties) -> io::Result<()> {
+        fn print_text(&mut self, content: &str, _style: &TextStyle) -> io::Result<()> {
             let content = content.to_string();
             if content.is_empty() {
                 return Ok(());
@@ -546,7 +546,7 @@ mod tests {
                 MoveToColumn(column) => self.move_to_column(*column)?,
                 MoveDown(amount) => self.move_down(*amount)?,
                 MoveToNextLine => self.move_to_next_line()?,
-                PrintText { content, style, properties } => self.print_text(content, style, properties)?,
+                PrintText { content, style } => self.print_text(content, style)?,
                 ClearScreen => self.clear_screen()?,
                 SetColors(colors) => self.set_colors(*colors)?,
                 SetBackgroundColor(color) => self.set_background_color(*color)?,

--- a/src/transitions/mod.rs
+++ b/src/transitions/mod.rs
@@ -1,9 +1,8 @@
-use std::fmt::Debug;
-
 use crate::{
     markdown::{elements::Line, text_style::Color},
-    terminal::printer::{TerminalCommand, TextProperties},
+    terminal::printer::TerminalCommand,
 };
+use std::fmt::Debug;
 use unicode_width::UnicodeWidthStr;
 
 pub(crate) mod slide_horizontal;
@@ -83,11 +82,7 @@ impl AnimationFrame for LinesFrame {
                     commands.push(MoveToColumn(column as u16));
                     is_in_column = true;
                 }
-                commands.push(PrintText {
-                    content: text,
-                    style: chunk.style,
-                    properties: TextProperties { height: chunk.style.size },
-                });
+                commands.push(PrintText { content: text, style: chunk.style });
                 column += text.width();
                 if white_after > 0 {
                     column += white_after;
@@ -120,16 +115,16 @@ mod tests {
             ClearScreen,
             MoveToRow(0),
             MoveToColumn(2),
-            PrintText { content: "hi", style: Default::default(), properties: TextProperties { height: 1 } },
+            PrintText { content: "hi", style: Default::default() },
             MoveToColumn(6),
-            PrintText { content: "bye", style: Default::default(), properties: TextProperties { height: 1 } },
-            PrintText { content: "s", style: Default::default(), properties: TextProperties { height: 1 } },
+            PrintText { content: "bye", style: Default::default() },
+            PrintText { content: "s", style: Default::default() },
             MoveToRow(1),
             MoveToColumn(0),
-            PrintText { content: "hello", style: Default::default(), properties: TextProperties { height: 1 } },
+            PrintText { content: "hello", style: Default::default() },
             MoveToColumn(6),
-            PrintText { content: "wor", style: Default::default(), properties: TextProperties { height: 1 } },
-            PrintText { content: "s", style: Default::default(), properties: TextProperties { height: 1 } },
+            PrintText { content: "wor", style: Default::default() },
+            PrintText { content: "s", style: Default::default() },
         ];
         assert_eq!(commands, expected);
     }


### PR DESCRIPTION
This was needed at some point because of how text styling worked but it's no longer the case.