### PR TITLE
feat: include images in slide transitions

### DIFF
--- a/src/export/pdf.rs
+++ b/src/export/pdf.rs
@@ -132,7 +132,7 @@ impl PdfRender {
     }
 
     pub(crate) fn process_slide(&mut self, slide: Slide) -> Result<(), ExportError> {
-        let mut terminal = VirtualTerminal::new(self.dimensions.clone());
+        let mut terminal = VirtualTerminal::new(self.dimensions.clone(), Default::default());
         let engine = RenderEngine::new(&mut terminal, self.dimensions.clone(), Default::default());
         engine.render(slide.iter_operations())?;
 

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -22,7 +22,7 @@ use crate::{
     terminal::{
         image::printer::{ImagePrinter, ImageRegistry},
         printer::{TerminalCommand, TerminalIo},
-        virt::{TerminalGrid, VirtualTerminal},
+        virt::{ImageBehavior, TerminalGrid, VirtualTerminal},
     },
     theme::{ProcessingThemeError, raw::PresentationTheme},
     third_party::ThirdPartyRender,
@@ -506,7 +506,7 @@ impl<'a> Presenter<'a> {
         dimensions: WindowSize,
         options: &RenderEngineOptions,
     ) -> Result<TerminalGrid, RenderError> {
-        let mut term = VirtualTerminal::new(dimensions.clone());
+        let mut term = VirtualTerminal::new(dimensions.clone(), ImageBehavior::PrintAscii);
         let engine = RenderEngine::new(&mut term, dimensions.clone(), options.clone());
         engine.render(slide.iter_visible_operations())?;
         Ok(term.into_contents())

--- a/src/render/engine.rs
+++ b/src/render/engine.rs
@@ -458,6 +458,7 @@ mod tests {
         MoveToRow(u16),
         MoveToColumn(u16),
         MoveDown(u16),
+        MoveRight(u16),
         MoveToNextLine,
         PrintText(String),
         ClearScreen,
@@ -493,6 +494,10 @@ mod tests {
 
         fn move_down(&mut self, amount: u16) -> std::io::Result<()> {
             self.push(Instruction::MoveDown(amount))
+        }
+
+        fn move_right(&mut self, amount: u16) -> std::io::Result<()> {
+            self.push(Instruction::MoveRight(amount))
         }
 
         fn move_to_next_line(&mut self) -> std::io::Result<()> {
@@ -545,6 +550,7 @@ mod tests {
                 MoveToRow(row) => self.move_to_row(*row)?,
                 MoveToColumn(column) => self.move_to_column(*column)?,
                 MoveDown(amount) => self.move_down(*amount)?,
+                MoveRight(amount) => self.move_right(*amount)?,
                 MoveToNextLine => self.move_to_next_line()?,
                 PrintText { content, style } => self.print_text(content, style)?,
                 ClearScreen => self.clear_screen()?,

--- a/src/render/text.rs
+++ b/src/render/text.rs
@@ -212,7 +212,13 @@ mod tests {
         fn execute(&mut self, command: &TerminalCommand<'_>) -> Result<(), TerminalError> {
             use TerminalCommand::*;
             match command {
-                BeginUpdate | EndUpdate | MoveToRow(_) | MoveToNextLine | MoveTo { .. } | PrintImage { .. } => {
+                BeginUpdate
+                | EndUpdate
+                | MoveToRow(_)
+                | MoveToNextLine
+                | MoveTo { .. }
+                | MoveRight(_)
+                | PrintImage { .. } => {
                     unimplemented!()
                 }
                 MoveToColumn(column) => self.move_to_column(*column)?,

--- a/src/terminal/image/protocols/iterm.rs
+++ b/src/terminal/image/protocols/iterm.rs
@@ -3,7 +3,7 @@ use crate::terminal::{
     printer::{TerminalCommand, TerminalIo},
 };
 use base64::{Engine, engine::general_purpose::STANDARD};
-use image::{GenericImageView, ImageEncoder, codecs::png::PngEncoder};
+use image::{GenericImageView, ImageEncoder, RgbaImage, codecs::png::PngEncoder};
 use std::{fs, path::Path};
 
 pub(crate) struct ItermImage {
@@ -17,6 +17,12 @@ impl ItermImage {
         let raw_length = contents.len();
         let base64_contents = STANDARD.encode(&contents);
         Self { dimensions, raw_length, base64_contents }
+    }
+
+    pub(crate) fn as_rgba8(&self) -> RgbaImage {
+        let contents = STANDARD.decode(&self.base64_contents).expect("base64 must be valid");
+        let image = image::load_from_memory(&contents).expect("image must have been originally valid");
+        image.to_rgba8()
     }
 }
 

--- a/src/terminal/image/protocols/kitty.rs
+++ b/src/terminal/image/protocols/kitty.rs
@@ -1,14 +1,16 @@
 use crate::{
-    markdown::text_style::Color,
-    terminal::image::printer::{ImageProperties, PrintImage, PrintImageError, PrintOptions, RegisterImageError},
+    markdown::text_style::{Color, TextStyle},
+    terminal::{
+        image::printer::{ImageProperties, PrintImage, PrintImageError, PrintOptions, RegisterImageError},
+        printer::{TerminalCommand, TerminalIo},
+    },
 };
 use base64::{Engine, engine::general_purpose::STANDARD};
-use crossterm::{QueueableCommand, cursor::MoveToColumn, style::SetForegroundColor};
 use image::{AnimationDecoder, Delay, DynamicImage, EncodableLayout, ImageReader, RgbaImage, codecs::gif::GifDecoder};
 use std::{
     fmt,
     fs::{self, File},
-    io::{self, BufReader, Write},
+    io::{self, BufReader},
     path::{Path, PathBuf},
     sync::atomic::{AtomicU32, Ordering},
 };
@@ -147,15 +149,15 @@ impl KittyPrinter {
         fastrand::u32(1..u32::MAX)
     }
 
-    fn print_image<W>(
+    fn print_image<T>(
         &self,
         dimensions: (u32, u32),
         buffer: &KittyBuffer,
-        writer: &mut W,
+        terminal: &mut T,
         print_options: &PrintOptions,
     ) -> Result<(), PrintImageError>
     where
-        W: io::Write,
+        T: TerminalIo,
     {
         let mut options = vec![
             ControlOption::Format(ImageFormat::Rgba),
@@ -174,25 +176,25 @@ impl KittyPrinter {
         }
 
         match &buffer {
-            KittyBuffer::Filesystem(path) => self.print_local(options, path, writer)?,
-            KittyBuffer::Memory(buffer) => self.print_remote(options, buffer, writer, false)?,
+            KittyBuffer::Filesystem(path) => self.print_local(options, path, terminal)?,
+            KittyBuffer::Memory(buffer) => self.print_remote(options, buffer, terminal, false)?,
         };
         if self.tmux {
-            self.print_unicode_placeholders(writer, print_options, image_id)?;
+            self.print_unicode_placeholders(terminal, print_options, image_id)?;
         }
 
         Ok(())
     }
 
-    fn print_gif<W>(
+    fn print_gif<T>(
         &self,
         dimensions: (u32, u32),
         frames: &[GifFrame<KittyBuffer>],
-        writer: &mut W,
+        terminal: &mut T,
         print_options: &PrintOptions,
     ) -> Result<(), PrintImageError>
     where
-        W: io::Write,
+        T: TerminalIo,
     {
         let image_id = Self::generate_image_id();
         for (frame_id, frame) in frames.iter().enumerate() {
@@ -222,8 +224,8 @@ impl KittyPrinter {
 
             let is_frame = frame_id > 0;
             match &frame.buffer {
-                KittyBuffer::Filesystem(path) => self.print_local(options, path, writer)?,
-                KittyBuffer::Memory(buffer) => self.print_remote(options, buffer, writer, is_frame)?,
+                KittyBuffer::Filesystem(path) => self.print_local(options, path, terminal)?,
+                KittyBuffer::Memory(buffer) => self.print_remote(options, buffer, terminal, is_frame)?,
             };
 
             if frame_id == 0 {
@@ -233,8 +235,8 @@ impl KittyPrinter {
                     ControlOption::FrameId(1),
                     ControlOption::Loops(1),
                 ];
-                let command = self.make_command(options, "");
-                write!(writer, "{command}")?;
+                let command = self.make_command(options, "").to_string();
+                terminal.execute(&TerminalCommand::PrintText { content: &command, style: Default::default() })?;
             } else if frame_id == 1 {
                 let options = &[
                     ControlOption::Action(Action::Animate),
@@ -242,12 +244,12 @@ impl KittyPrinter {
                     ControlOption::FrameId(1),
                     ControlOption::AnimationState(2),
                 ];
-                let command = self.make_command(options, "");
-                write!(writer, "{command}")?;
+                let command = self.make_command(options, "").to_string();
+                terminal.execute(&TerminalCommand::PrintText { content: &command, style: Default::default() })?;
             }
         }
         if self.tmux {
-            self.print_unicode_placeholders(writer, print_options, image_id)?;
+            self.print_unicode_placeholders(terminal, print_options, image_id)?;
         }
         let options = &[
             ControlOption::Action(Action::Animate),
@@ -257,8 +259,8 @@ impl KittyPrinter {
             ControlOption::Loops(1),
             ControlOption::Quiet(2),
         ];
-        let command = self.make_command(options, "");
-        write!(writer, "{command}")?;
+        let command = self.make_command(options, "").to_string();
+        terminal.execute(&TerminalCommand::PrintText { content: &command, style: Default::default() })?;
         Ok(())
     }
 
@@ -266,14 +268,14 @@ impl KittyPrinter {
         ControlCommand { options, payload, tmux: self.tmux }
     }
 
-    fn print_local<W>(
+    fn print_local<T>(
         &self,
         mut options: Vec<ControlOption>,
         path: &Path,
-        writer: &mut W,
+        terminal: &mut T,
     ) -> Result<(), PrintImageError>
     where
-        W: io::Write,
+        T: TerminalIo,
     {
         let Some(path) = path.to_str() else {
             return Err(PrintImageError::other("path is not valid utf8"));
@@ -281,20 +283,20 @@ impl KittyPrinter {
         let encoded_path = STANDARD.encode(path);
         options.push(ControlOption::Medium(TransmissionMedium::LocalFile));
 
-        let command = self.make_command(&options, &encoded_path);
-        write!(writer, "{command}")?;
+        let command = self.make_command(&options, &encoded_path).to_string();
+        terminal.execute(&TerminalCommand::PrintText { content: &command, style: Default::default() })?;
         Ok(())
     }
 
-    fn print_remote<W>(
+    fn print_remote<T>(
         &self,
         mut options: Vec<ControlOption>,
         frame: &[u8],
-        writer: &mut W,
+        terminal: &mut T,
         is_frame: bool,
     ) -> Result<(), PrintImageError>
     where
-        W: io::Write,
+        T: TerminalIo,
     {
         options.push(ControlOption::Medium(TransmissionMedium::Direct));
 
@@ -310,8 +312,8 @@ impl KittyPrinter {
             options.push(ControlOption::MoreData(more));
 
             let payload = &payload[start..end];
-            let command = self.make_command(&options, payload);
-            write!(writer, "{command}")?;
+            let command = self.make_command(&options, payload).to_string();
+            terminal.execute(&TerminalCommand::PrintText { content: &command, style: Default::default() })?;
 
             options.clear();
             if is_frame {
@@ -321,14 +323,17 @@ impl KittyPrinter {
         Ok(())
     }
 
-    fn print_unicode_placeholders<W: Write>(
+    fn print_unicode_placeholders<T>(
         &self,
-        writer: &mut W,
+        terminal: &mut T,
         options: &PrintOptions,
         image_id: u32,
-    ) -> Result<(), PrintImageError> {
+    ) -> Result<(), PrintImageError>
+    where
+        T: TerminalIo,
+    {
         let color = Color::new((image_id >> 16) as u8, (image_id >> 8) as u8, image_id as u8);
-        writer.queue(SetForegroundColor(color.into()))?;
+        let style = TextStyle::default().fg_color(color);
         if options.rows.max(options.columns) >= DIACRITICS.len() as u16 {
             return Err(PrintImageError::other("image is too large to fit in tmux"));
         }
@@ -338,12 +343,13 @@ impl KittyPrinter {
             let row_diacritic = char::from_u32(DIACRITICS[row as usize]).unwrap();
             for column in 0..options.columns {
                 let column_diacritic = char::from_u32(DIACRITICS[column as usize]).unwrap();
-                write!(writer, "{IMAGE_PLACEHOLDER}{row_diacritic}{column_diacritic}{last_byte}")?;
+                let content = format!("{IMAGE_PLACEHOLDER}{row_diacritic}{column_diacritic}{last_byte}");
+                terminal.execute(&TerminalCommand::PrintText { content: &content, style })?;
             }
             if row != options.rows - 1 {
-                writeln!(writer)?;
+                terminal.execute(&TerminalCommand::MoveToNextLine)?;
             }
-            writer.queue(MoveToColumn(options.cursor_position.column))?;
+            terminal.execute(&TerminalCommand::MoveToColumn(options.cursor_position.column))?;
         }
         Ok(())
     }
@@ -388,15 +394,13 @@ impl PrintImage for KittyPrinter {
         Ok(resource)
     }
 
-    fn print<W: std::io::Write>(
-        &self,
-        image: &Self::Image,
-        options: &PrintOptions,
-        writer: &mut W,
-    ) -> Result<(), PrintImageError> {
+    fn print<T>(&self, image: &Self::Image, options: &PrintOptions, terminal: &mut T) -> Result<(), PrintImageError>
+    where
+        T: TerminalIo,
+    {
         match &image.resource {
-            GenericResource::Image(resource) => self.print_image(image.dimensions, resource, writer, options)?,
-            GenericResource::Gif(frames) => self.print_gif(image.dimensions, frames, writer, options)?,
+            GenericResource::Image(resource) => self.print_image(image.dimensions, resource, terminal, options)?,
+            GenericResource::Gif(frames) => self.print_gif(image.dimensions, frames, terminal, options)?,
         };
         Ok(())
     }

--- a/src/terminal/image/protocols/kitty.rs
+++ b/src/terminal/image/protocols/kitty.rs
@@ -73,6 +73,25 @@ pub(crate) struct KittyImage {
     resource: GenericResource<KittyBuffer>,
 }
 
+impl KittyImage {
+    pub(crate) fn as_rgba8(&self) -> RgbaImage {
+        let first_frame = match &self.resource {
+            GenericResource::Image(buffer) => buffer,
+            GenericResource::Gif(gif_frames) => &gif_frames[0].buffer,
+        };
+        let buffer = match first_frame {
+            KittyBuffer::Filesystem(path) => {
+                let Ok(contents) = fs::read(path) else {
+                    return RgbaImage::default();
+                };
+                contents
+            }
+            KittyBuffer::Memory(buffer) => buffer.clone(),
+        };
+        RgbaImage::from_raw(self.dimensions.0, self.dimensions.1, buffer).unwrap_or_default()
+    }
+}
+
 impl ImageProperties for KittyImage {
     fn dimensions(&self) -> (u32, u32) {
         self.dimensions

--- a/src/terminal/virt.rs
+++ b/src/terminal/virt.rs
@@ -120,6 +120,11 @@ impl VirtualTerminal {
         Ok(())
     }
 
+    fn move_right(&mut self, amount: u16) -> io::Result<()> {
+        self.column += amount;
+        Ok(())
+    }
+
     fn move_to_next_line(&mut self) -> io::Result<()> {
         let amount = self.current_row_height();
         self.row += amount;
@@ -184,6 +189,7 @@ impl TerminalIo for VirtualTerminal {
             MoveToRow(row) => self.move_to_row(*row)?,
             MoveToColumn(column) => self.move_to_column(*column)?,
             MoveDown(amount) => self.move_down(*amount)?,
+            MoveRight(amount) => self.move_right(*amount)?,
             MoveToNextLine => self.move_to_next_line()?,
             PrintText { content, style } => self.print_text(content, style)?,
             ClearScreen => self.clear_screen()?,


### PR DESCRIPTION
This includes images when transitioning between slides; this was the one detail remaining after #528. This could probably be made a bit more efficient as it currently causes us to potentially read the image from disk and decode it. In practice I don't know if it matters though so I'd rather have this merged now and look at optimizations in the future if needed.

In this implementation, images are turned into ascii via the ascii printer and that is used during the transition. I don't think it's viable/makes sense to print the actual image that many times just for the transition.

Relates to #364

https://github.com/user-attachments/assets/1f5d13df-d928-4789-87ee-b73824728609

