### PR TITLE
feat: add `max_rows` configuration to cap vertical size

### DIFF
--- a/config-file-schema.json
+++ b/config-file-schema.json
@@ -79,6 +79,21 @@
             }
           ]
         },
+        "max_rows": {
+          "description": "A max height in rows that the presentation must always be capped to.",
+          "default": 65535,
+          "type": "integer",
+          "format": "uint16",
+          "minimum": 0.0
+        },
+        "max_rows_alignment": {
+          "description": "The alignment the presentation should have if `max_rows` is set and the terminal is larger than that.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/MaxRowsAlignment"
+            }
+          ]
+        },
         "terminal_font_size": {
           "description": "Override the terminal font size when in windows or when using sixel.",
           "default": 16,
@@ -382,6 +397,32 @@
           "type": "string",
           "enum": [
             "right"
+          ]
+        }
+      ]
+    },
+    "MaxRowsAlignment": {
+      "description": "The alignment to use when `defaults.max_rows` is set.",
+      "oneOf": [
+        {
+          "description": "Align the presentation to the top.",
+          "type": "string",
+          "enum": [
+            "top"
+          ]
+        },
+        {
+          "description": "Align the presentation on the center.",
+          "type": "string",
+          "enum": [
+            "center"
+          ]
+        },
+        {
+          "description": "Align the presentation to the bottom.",
+          "type": "string",
+          "enum": [
+            "bottom"
           ]
         }
       ]

--- a/src/config.rs
+++ b/src/config.rs
@@ -93,13 +93,22 @@ pub struct DefaultsConfig {
     pub validate_overflows: ValidateOverflows,
 
     /// A max width in columns that the presentation must always be capped to.
-    #[serde(default = "default_max_columns")]
+    #[serde(default = "default_u16_max")]
     pub max_columns: u16,
 
     /// The alignment the presentation should have if `max_columns` is set and the terminal is
     /// larger than that.
     #[serde(default)]
     pub max_columns_alignment: MaxColumnsAlignment,
+
+    /// A max height in rows that the presentation must always be capped to.
+    #[serde(default = "default_u16_max")]
+    pub max_rows: u16,
+
+    /// The alignment the presentation should have if `max_rows` is set and the terminal is
+    /// larger than that.
+    #[serde(default)]
+    pub max_rows_alignment: MaxRowsAlignment,
 
     /// The configuration for lists when incremental lists are enabled.
     #[serde(default)]
@@ -113,8 +122,10 @@ impl Default for DefaultsConfig {
             terminal_font_size: default_terminal_font_size(),
             image_protocol: Default::default(),
             validate_overflows: Default::default(),
-            max_columns: default_max_columns(),
+            max_columns: default_u16_max(),
             max_columns_alignment: Default::default(),
+            max_rows: default_u16_max(),
+            max_rows_alignment: Default::default(),
             incremental_lists: Default::default(),
         }
     }
@@ -150,6 +161,21 @@ pub enum MaxColumnsAlignment {
 
     /// Align the presentation to the right.
     Right,
+}
+
+/// The alignment to use when `defaults.max_rows` is set.
+#[derive(Clone, Copy, Debug, Default, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum MaxRowsAlignment {
+    /// Align the presentation to the top.
+    Top,
+
+    /// Align the presentation on the center.
+    #[default]
+    Center,
+
+    /// Align the presentation to the bottom.
+    Bottom,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, JsonSchema)]
@@ -277,7 +303,7 @@ pub(crate) fn default_mermaid_scale() -> u32 {
     2
 }
 
-pub(crate) fn default_max_columns() -> u16 {
+pub(crate) fn default_u16_max() -> u16 {
     u16::MAX
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ use crossterm::{
 };
 use directories::ProjectDirs;
 use export::exporter::OutputDirectory;
-use render::properties::WindowSize;
+use render::{engine::MaxSize, properties::WindowSize};
 use std::{
     env::{self, current_dir},
     io,
@@ -434,8 +434,12 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             font_size_fallback: config.defaults.terminal_font_size,
             bindings: config.bindings,
             validate_overflows,
-            max_columns: config.defaults.max_columns,
-            max_columns_alignment: config.defaults.max_columns_alignment,
+            max_size: MaxSize {
+                max_columns: config.defaults.max_columns,
+                max_columns_alignment: config.defaults.max_columns_alignment,
+                max_rows: config.defaults.max_rows,
+                max_rows_alignment: config.defaults.max_rows_alignment,
+            },
             transition: config.transition,
         };
         let presenter = Presenter::new(

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -4,7 +4,7 @@ use crate::{
         listener::{Command, CommandListener},
         speaker_notes::{SpeakerNotesEvent, SpeakerNotesEventPublisher},
     },
-    config::{KeyBindingsConfig, MaxColumnsAlignment, SlideTransitionConfig, SlideTransitionStyleConfig},
+    config::{KeyBindingsConfig, SlideTransitionConfig, SlideTransitionStyleConfig},
     markdown::parse::{MarkdownParser, ParseError},
     presentation::{
         Presentation, Slide,
@@ -13,7 +13,7 @@ use crate::{
     },
     render::{
         ErrorSource, RenderError, RenderResult, TerminalDrawer, TerminalDrawerOptions,
-        engine::{RenderEngine, RenderEngineOptions},
+        engine::{MaxSize, RenderEngine, RenderEngineOptions},
         operation::RenderAsyncState,
         properties::WindowSize,
         validate::OverflowValidator,
@@ -47,8 +47,7 @@ pub struct PresenterOptions {
     pub font_size_fallback: u8,
     pub bindings: KeyBindingsConfig,
     pub validate_overflows: bool,
-    pub max_columns: u16,
-    pub max_columns_alignment: MaxColumnsAlignment,
+    pub max_size: MaxSize,
     pub transition: Option<SlideTransitionConfig>,
 }
 
@@ -111,8 +110,7 @@ impl<'a> Presenter<'a> {
 
         let drawer_options = TerminalDrawerOptions {
             font_size_fallback: self.options.font_size_fallback,
-            max_columns: self.options.max_columns,
-            max_columns_alignment: self.options.max_columns_alignment,
+            max_size: self.options.max_size.clone(),
         };
         let mut drawer = TerminalDrawer::new(self.image_printer.clone(), drawer_options)?;
         loop {

--- a/src/render/text.rs
+++ b/src/render/text.rs
@@ -218,6 +218,7 @@ mod tests {
                 | MoveToNextLine
                 | MoveTo { .. }
                 | MoveRight(_)
+                | MoveLeft(_)
                 | PrintImage { .. } => {
                     unimplemented!()
                 }

--- a/src/terminal/image/printer.rs
+++ b/src/terminal/image/printer.rs
@@ -8,7 +8,6 @@ use super::{
 };
 use crate::{
     markdown::text_style::{Color, PaletteColorError},
-    render::properties::CursorPosition,
     terminal::{
         GraphicsMode,
         printer::{TerminalError, TerminalIo},
@@ -40,11 +39,10 @@ pub(crate) trait ImageProperties {
     fn dimensions(&self) -> (u32, u32);
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub(crate) struct PrintOptions {
     pub(crate) columns: u16,
     pub(crate) rows: u16,
-    pub(crate) cursor_position: CursorPosition,
     pub(crate) z_index: i32,
     pub(crate) background_color: Option<Color>,
     // Width/height in pixels.

--- a/src/terminal/image/protocols/ascii.rs
+++ b/src/terminal/image/protocols/ascii.rs
@@ -89,8 +89,6 @@ impl PrintImage for AsciiPrinter {
         // Iterate pixel rows in pairs to be able to merge both pixels in a single iteration.
         // Note that may not have a second row if there's an odd number of them.
         for mut rows in &image.rows().chunks(2) {
-            terminal.execute(&TerminalCommand::MoveToColumn(options.cursor_position.column))?;
-
             let top_row = rows.next().unwrap();
             let mut bottom_row = rows.next();
             for top_pixel in top_row {
@@ -120,6 +118,7 @@ impl PrintImage for AsciiPrinter {
                 terminal.execute(&command)?;
             }
             terminal.execute(&TerminalCommand::MoveDown(1))?;
+            terminal.execute(&TerminalCommand::MoveLeft(options.columns))?;
         }
         Ok(())
     }

--- a/src/terminal/image/protocols/kitty.rs
+++ b/src/terminal/image/protocols/kitty.rs
@@ -366,9 +366,9 @@ impl KittyPrinter {
                 terminal.execute(&TerminalCommand::PrintText { content: &content, style })?;
             }
             if row != options.rows - 1 {
-                terminal.execute(&TerminalCommand::MoveToNextLine)?;
+                terminal.execute(&TerminalCommand::MoveDown(1))?;
             }
-            terminal.execute(&TerminalCommand::MoveToColumn(options.cursor_position.column))?;
+            terminal.execute(&TerminalCommand::MoveLeft(options.columns))?;
         }
         Ok(())
     }

--- a/src/terminal/image/scale.rs
+++ b/src/terminal/image/scale.rs
@@ -1,12 +1,32 @@
 use crate::render::properties::{CursorPosition, WindowSize};
 
+pub(crate) trait ScaleImage {
+    /// Scale an image to a specific size.
+    fn scale_image(
+        &self,
+        scale_size: &WindowSize,
+        window_dimensions: &WindowSize,
+        image_width: u32,
+        image_height: u32,
+        position: &CursorPosition,
+    ) -> TerminalRect;
+
+    /// Shrink an image so it fits the dimensions of the layout it's being displayed in.
+    fn fit_image_to_rect(
+        &self,
+        dimensions: &WindowSize,
+        image_width: u32,
+        image_height: u32,
+        position: &CursorPosition,
+    ) -> TerminalRect;
+}
+
 pub(crate) struct ImageScaler {
     horizontal_margin: f64,
 }
 
-impl ImageScaler {
-    /// Scale an image to a specific size.
-    pub(crate) fn scale_image(
+impl ScaleImage for ImageScaler {
+    fn scale_image(
         &self,
         scale_size: &WindowSize,
         window_dimensions: &WindowSize,
@@ -23,8 +43,7 @@ impl ImageScaler {
         self.fit_image_to_rect(window_dimensions, image_width as u32, image_height as u32, position)
     }
 
-    /// Shrink an image so it fits the dimensions of the layout it's being displayed in.
-    pub(crate) fn fit_image_to_rect(
+    fn fit_image_to_rect(
         &self,
         dimensions: &WindowSize,
         image_width: u32,

--- a/src/terminal/printer.rs
+++ b/src/terminal/printer.rs
@@ -23,6 +23,7 @@ pub(crate) enum TerminalCommand<'a> {
     MoveToColumn(u16),
     MoveDown(u16),
     MoveRight(u16),
+    MoveLeft(u16),
     MoveToNextLine,
     PrintText { content: &'a str, style: TextStyle },
     ClearScreen,
@@ -98,6 +99,11 @@ impl<I: TerminalWrite> Terminal<I> {
         Ok(())
     }
 
+    fn move_left(&mut self, amount: u16) -> io::Result<()> {
+        self.writer.queue(cursor::MoveLeft(amount))?;
+        Ok(())
+    }
+
     fn move_to_next_line(&mut self) -> io::Result<()> {
         let amount = self.current_row_height;
         self.writer.queue(cursor::MoveToNextLine(amount))?;
@@ -139,7 +145,6 @@ impl<I: TerminalWrite> Terminal<I> {
     }
 
     fn print_image(&mut self, image: &Image, options: &PrintOptions) -> Result<(), PrintImageError> {
-        self.move_to_column(options.cursor_position.column)?;
         let image_printer = self.image_printer.clone();
         image_printer.print(&image.image, options, self)?;
         self.cursor_row += options.rows;
@@ -166,6 +171,7 @@ impl<I: TerminalWrite> TerminalIo for Terminal<I> {
             MoveToColumn(column) => self.move_to_column(*column)?,
             MoveDown(amount) => self.move_down(*amount)?,
             MoveRight(amount) => self.move_right(*amount)?,
+            MoveLeft(amount) => self.move_left(*amount)?,
             MoveToNextLine => self.move_to_next_line()?,
             PrintText { content, style } => self.print_text(content, style)?,
             ClearScreen => self.clear_screen()?,

--- a/src/terminal/virt.rs
+++ b/src/terminal/virt.rs
@@ -129,6 +129,11 @@ impl VirtualTerminal {
         Ok(())
     }
 
+    fn move_left(&mut self, amount: u16) -> io::Result<()> {
+        self.column = self.column.saturating_sub(amount);
+        Ok(())
+    }
+
     fn move_to_next_line(&mut self) -> io::Result<()> {
         let amount = self.current_row_height();
         self.row += amount;
@@ -179,7 +184,7 @@ impl VirtualTerminal {
     fn print_image(&mut self, image: &Image, options: &PrintOptions) -> Result<(), PrintImageError> {
         match &self.image_behavior {
             ImageBehavior::Store => {
-                let key = (options.cursor_position.row, options.cursor_position.column);
+                let key = (self.row, self.column);
                 let image = PrintedImage { image: image.clone(), width_columns: options.columns };
                 self.images.insert(key, image);
             }
@@ -217,6 +222,7 @@ impl TerminalIo for VirtualTerminal {
             MoveToColumn(column) => self.move_to_column(*column)?,
             MoveDown(amount) => self.move_down(*amount)?,
             MoveRight(amount) => self.move_right(*amount)?,
+            MoveLeft(amount) => self.move_left(*amount)?,
             MoveToNextLine => self.move_to_next_line()?,
             PrintText { content, style } => self.print_text(content, style)?,
             ClearScreen => self.clear_screen()?,


### PR DESCRIPTION
Similar to `max_columns` this adds a `max_rows` and `max_rows_alignment` (valid values are `top`, `center`, `bottom`, the default is `center`) that cap the vertical presentation size and aligns it accordingly. 