### PR TITLE
fix: use no typst background in terminal-* built in themes

### DIFF
--- a/themes/terminal-dark.yaml
+++ b/themes/terminal-dark.yaml
@@ -125,7 +125,6 @@ alert:
 typst:
   colors:
     foreground: "f0f0f0"
-    background: "292e42"
 
 footer:
   style: template

--- a/themes/terminal-light.yaml
+++ b/themes/terminal-light.yaml
@@ -125,7 +125,6 @@ alert:
 typst:
   colors:
     foreground: "212529"
-    background: "e9ecef"
 
 footer:
   style: template


### PR DESCRIPTION
This sets no background for typst renders in the terminal-light and terminal-dark built in themes. This requires a reasonably recent version of typst (probably 0.12+) as they changed the meaning of `none` as a fill background at some point around then. 