### PR TITLE
fix: center overflow lines when using centered text

### DIFF
--- a/src/render/engine.rs
+++ b/src/render/engine.rs
@@ -240,6 +240,8 @@ where
         let positioning = layout.compute(dimensions, text.width() as u16);
         let prefix = "".into();
         let text_drawer = TextDrawer::new(&prefix, 0, text, positioning, &self.colors, MINIMUM_LINE_LENGTH)?;
+        let center_newlines = matches!(alignment, Alignment::Center { .. });
+        let text_drawer = text_drawer.center_newlines(center_newlines);
         text_drawer.draw(self.terminal)?;
         // Restore colors
         self.apply_colors()


### PR DESCRIPTION
This fixes an issue where centered text that overflowed had the lines 2+ start at the same column as the first one rather than being centered.

Fixes #545