### PR TITLE
perf: cache resized ascii images

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,8 @@ vte = "0.15"
 rstest = { version = "0.25", default-features = false }
 
 [features]
-default = []
+# TODO
+default = ["sixel"]
 sixel = ["sixel-rs"]
 
 [profile.dev]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,7 @@ vte = "0.15"
 rstest = { version = "0.25", default-features = false }
 
 [features]
-# TODO
-default = ["sixel"]
+default = []
 sixel = ["sixel-rs"]
 
 [profile.dev]

--- a/src/main.rs
+++ b/src/main.rs
@@ -230,7 +230,7 @@ impl CoreComponents {
         }
         let graphics_mode = Self::select_graphics_mode(cli, &config);
         let printer = Arc::new(ImagePrinter::new(graphics_mode.clone())?);
-        let registry = ImageRegistry(printer.clone());
+        let registry = ImageRegistry::new(printer.clone());
         let resources = Resources::new(
             resources_path.clone(),
             themes_path.unwrap_or_else(|| resources_path.clone()),

--- a/src/presentation/builder/mod.rs
+++ b/src/presentation/builder/mod.rs
@@ -22,7 +22,7 @@ use crate::{
     resource::Resources,
     terminal::image::{
         Image,
-        printer::{ImageRegistry, RegisterImageError},
+        printer::{ImageRegistry, ImageSpec, RegisterImageError},
     },
     theme::{
         Alignment, AuthorPositioning, ElementType, PresentationTheme, ProcessingThemeError, ThemeOptions,
@@ -246,7 +246,7 @@ impl<'a> PresentationBuilder<'a> {
         };
         let mut image = DynamicImage::new_rgba8(1, 1);
         image.as_mut_rgba8().unwrap().get_pixel_mut(0, 0).0 = rgba;
-        let image = self.image_registry.register_image(image)?;
+        let image = self.image_registry.register(ImageSpec::Generated(image))?;
         Ok(image)
     }
 

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -425,13 +425,14 @@ impl<'a> Presenter<'a> {
         let Some(config) = self.options.transition.clone() else {
             return Ok(());
         };
+        let registry = self.resources.image_registry();
         let options = drawer.render_engine_options();
         let presentation = self.state.presentation_mut();
         let dimensions = WindowSize::current(self.options.font_size_fallback)?;
         presentation.jump_previous();
-        let left = Self::virtual_render(presentation.current_slide(), dimensions.clone(), &options)?;
+        let left = Self::virtual_render(presentation.current_slide(), dimensions.clone(), &options, registry.clone())?;
         presentation.jump_next();
-        let right = Self::virtual_render(presentation.current_slide(), dimensions.clone(), &options)?;
+        let right = Self::virtual_render(presentation.current_slide(), dimensions.clone(), &options, registry)?;
         let direction = TransitionDirection::Next;
         self.animate_transition(drawer, left, right, direction, dimensions, config)
     }
@@ -440,13 +441,14 @@ impl<'a> Presenter<'a> {
         let Some(config) = self.options.transition.clone() else {
             return Ok(());
         };
+        let registry = self.resources.image_registry();
         let options = drawer.render_engine_options();
         let presentation = self.state.presentation_mut();
         let dimensions = WindowSize::current(self.options.font_size_fallback)?;
         presentation.jump_next();
-        let right = Self::virtual_render(presentation.current_slide(), dimensions.clone(), &options)?;
+        let right = Self::virtual_render(presentation.current_slide(), dimensions.clone(), &options, registry.clone())?;
         presentation.jump_previous();
-        let left = Self::virtual_render(presentation.current_slide(), dimensions.clone(), &options)?;
+        let left = Self::virtual_render(presentation.current_slide(), dimensions.clone(), &options, registry)?;
         let direction = TransitionDirection::Previous;
         self.animate_transition(drawer, left, right, direction, dimensions, config)
     }
@@ -526,8 +528,9 @@ impl<'a> Presenter<'a> {
         slide: &Slide,
         dimensions: WindowSize,
         options: &RenderEngineOptions,
+        registry: ImageRegistry,
     ) -> Result<TerminalGrid, RenderError> {
-        let mut term = VirtualTerminal::new(dimensions.clone(), ImageBehavior::PrintAscii);
+        let mut term = VirtualTerminal::new(dimensions.clone(), ImageBehavior::PrintAscii(registry));
         let engine = RenderEngine::new(&mut term, dimensions.clone(), options.clone());
         engine.render(slide.iter_visible_operations())?;
         Ok(term.into_contents())

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -382,7 +382,7 @@ impl<'a> Presenter<'a> {
             &mut self.third_party,
             self.code_executor.clone(),
             &self.themes,
-            ImageRegistry(self.image_printer.clone()),
+            ImageRegistry::new(self.image_printer.clone()),
             self.options.bindings.clone(),
             self.options.builder_options.clone(),
         )?

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -133,6 +133,10 @@ impl Resources {
         inner.image_registry.clear();
         inner.themes.clear();
     }
+
+    pub(crate) fn image_registry(&self) -> ImageRegistry {
+        self.inner.borrow().image_registry.clone()
+    }
 }
 
 /// Watches for file changes.

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -1,7 +1,7 @@
 use crate::{
     terminal::image::{
         Image,
-        printer::{ImageRegistry, RegisterImageError},
+        printer::{ImageRegistry, ImageSpec, RegisterImageError},
     },
     theme::{raw::PresentationTheme, registry::LoadThemeError},
 };
@@ -79,7 +79,7 @@ impl Resources {
             return Ok(image.clone());
         }
 
-        let image = inner.image_registry.register_resource(path.clone())?;
+        let image = inner.image_registry.register(ImageSpec::Filesystem(path.clone()))?;
         inner.images.insert(path, image.clone());
         Ok(image)
     }
@@ -97,7 +97,7 @@ impl Resources {
             return Ok(image.clone());
         }
 
-        let image = inner.image_registry.register_resource(path.clone())?;
+        let image = inner.image_registry.register(ImageSpec::Filesystem(path.clone()))?;
         inner.theme_images.insert(path, image.clone());
         Ok(image)
     }

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -24,8 +24,6 @@ const LOOP_INTERVAL: Duration = Duration::from_millis(250);
 
 #[derive(Debug)]
 struct ResourcesInner {
-    images: HashMap<PathBuf, Image>,
-    theme_images: HashMap<PathBuf, Image>,
     themes: HashMap<PathBuf, PresentationTheme>,
     external_snippets: HashMap<PathBuf, String>,
     base_path: PathBuf,
@@ -56,8 +54,6 @@ impl Resources {
         let inner = ResourcesInner {
             base_path: base_path.into(),
             themes_path: themes_path.into(),
-            images: Default::default(),
-            theme_images: Default::default(),
             themes: Default::default(),
             external_snippets: Default::default(),
             image_registry,
@@ -73,14 +69,9 @@ impl Resources {
 
     /// Get the image at the given path.
     pub(crate) fn image<P: AsRef<Path>>(&self, path: P) -> Result<Image, RegisterImageError> {
-        let mut inner = self.inner.borrow_mut();
+        let inner = self.inner.borrow();
         let path = inner.base_path.join(path);
-        if let Some(image) = inner.images.get(&path) {
-            return Ok(image.clone());
-        }
-
         let image = inner.image_registry.register(ImageSpec::Filesystem(path.clone()))?;
-        inner.images.insert(path, image.clone());
         Ok(image)
     }
 
@@ -91,14 +82,9 @@ impl Resources {
             _ => (),
         };
 
-        let mut inner = self.inner.borrow_mut();
+        let inner = self.inner.borrow();
         let path = inner.themes_path.join(path);
-        if let Some(image) = inner.theme_images.get(&path) {
-            return Ok(image.clone());
-        }
-
         let image = inner.image_registry.register(ImageSpec::Filesystem(path.clone()))?;
-        inner.theme_images.insert(path, image.clone());
         Ok(image)
     }
 
@@ -144,7 +130,7 @@ impl Resources {
     /// Clears all resources.
     pub(crate) fn clear(&self) {
         let mut inner = self.inner.borrow_mut();
-        inner.images.clear();
+        inner.image_registry.clear();
         inner.themes.clear();
     }
 }

--- a/src/terminal/image/protocols/ascii.rs
+++ b/src/terminal/image/protocols/ascii.rs
@@ -5,26 +5,34 @@ use crate::{
         printer::{TerminalCommand, TerminalIo},
     },
 };
-use image::{DynamicImage, GenericImageView, Pixel, Rgba, imageops::FilterType};
+use image::{DynamicImage, GenericImageView, Pixel, Rgba, RgbaImage, imageops::FilterType};
 use itertools::Itertools;
-use std::{fs, ops::Deref, sync::Arc};
+use std::{
+    collections::HashMap,
+    fs,
+    ops::Deref,
+    sync::{Arc, Mutex},
+};
 
 const TOP_CHAR: &str = "▀";
 const BOTTOM_CHAR: &str = "▄";
 
 #[derive(Clone)]
-pub(crate) struct AsciiImage(Arc<DynamicImage>);
+pub(crate) struct AsciiImage {
+    image: Arc<DynamicImage>,
+    cached_sizes: Arc<Mutex<HashMap<(u16, u16), RgbaImage>>>,
+}
 
 impl ImageProperties for AsciiImage {
     fn dimensions(&self) -> (u32, u32) {
-        self.0.dimensions()
+        self.image.dimensions()
     }
 }
 
 impl From<DynamicImage> for AsciiImage {
     fn from(image: DynamicImage) -> Self {
         let image = image.into_rgba8();
-        Self(Arc::new(image.into()))
+        Self { image: Arc::new(image.into()), cached_sizes: Default::default() }
     }
 }
 
@@ -32,7 +40,7 @@ impl Deref for AsciiImage {
     type Target = DynamicImage;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        &self.image
     }
 }
 
@@ -74,18 +82,29 @@ impl PrintImage for AsciiPrinter {
                 image::load_from_memory(&contents)?
             }
         };
-        Ok(AsciiImage(image.into()))
+        Ok(AsciiImage::from(image))
     }
 
     fn print<T>(&self, image: &Self::Image, options: &PrintOptions, terminal: &mut T) -> Result<(), PrintImageError>
     where
         T: TerminalIo,
     {
+        let columns = options.columns;
+        let rows = options.rows * 2;
+        let mut cached_sizes = image.cached_sizes.lock().unwrap();
+        // lookup on cache/resize the image and store it in cache
+        let cache_key = (columns, rows);
+        let image = match cached_sizes.get(&cache_key) {
+            Some(image) => image,
+            None => {
+                let image = image.image.resize_exact(columns as u32, rows as u32, FilterType::Triangle);
+                cached_sizes.insert(cache_key, image.into_rgba8());
+                cached_sizes.get(&cache_key).unwrap()
+            }
+        };
         // The strategy here is taken from viuer: use half vertical ascii blocks in combination
         // with foreground/background colors to fit 2 vertical pixels per cell. That is, cell (x, y)
         // will contain the pixels at (x, y) and (x, y + 1) combined.
-        let image = image.0.resize_exact(options.columns as u32, 2 * options.rows as u32, FilterType::Triangle);
-        let image = image.into_rgba8();
         let default_background = options.background_color.map(Color::from);
 
         // Iterate pixel rows in pairs to be able to merge both pixels in a single iteration.

--- a/src/terminal/image/protocols/ascii.rs
+++ b/src/terminal/image/protocols/ascii.rs
@@ -1,7 +1,7 @@
 use crate::{
     markdown::text_style::{Color, Colors, TextStyle},
     terminal::{
-        image::printer::{ImageProperties, PrintImage, PrintImageError, PrintOptions, RegisterImageError},
+        image::printer::{ImageProperties, ImageSpec, PrintImage, PrintImageError, PrintOptions, RegisterImageError},
         printer::{TerminalCommand, TerminalIo},
     },
 };
@@ -65,13 +65,14 @@ impl AsciiPrinter {
 impl PrintImage for AsciiPrinter {
     type Image = AsciiImage;
 
-    fn register(&self, image: image::DynamicImage) -> Result<Self::Image, RegisterImageError> {
-        Ok(AsciiImage(image))
-    }
-
-    fn register_from_path<P: AsRef<std::path::Path>>(&self, path: P) -> Result<Self::Image, RegisterImageError> {
-        let contents = fs::read(path)?;
-        let image = image::load_from_memory(&contents)?;
+    fn register(&self, spec: ImageSpec) -> Result<Self::Image, RegisterImageError> {
+        let image = match spec {
+            ImageSpec::Generated(image) => image,
+            ImageSpec::Filesystem(path) => {
+                let contents = fs::read(path)?;
+                image::load_from_memory(&contents)?
+            }
+        };
         Ok(AsciiImage(image))
     }
 

--- a/src/terminal/image/protocols/ascii.rs
+++ b/src/terminal/image/protocols/ascii.rs
@@ -7,12 +7,13 @@ use crate::{
 };
 use image::{DynamicImage, GenericImageView, Pixel, Rgba, imageops::FilterType};
 use itertools::Itertools;
-use std::{fs, ops::Deref};
+use std::{fs, ops::Deref, sync::Arc};
 
 const TOP_CHAR: &str = "▀";
 const BOTTOM_CHAR: &str = "▄";
 
-pub(crate) struct AsciiImage(DynamicImage);
+#[derive(Clone)]
+pub(crate) struct AsciiImage(Arc<DynamicImage>);
 
 impl ImageProperties for AsciiImage {
     fn dimensions(&self) -> (u32, u32) {
@@ -23,7 +24,7 @@ impl ImageProperties for AsciiImage {
 impl From<DynamicImage> for AsciiImage {
     fn from(image: DynamicImage) -> Self {
         let image = image.into_rgba8();
-        Self(image.into())
+        Self(Arc::new(image.into()))
     }
 }
 
@@ -73,7 +74,7 @@ impl PrintImage for AsciiPrinter {
                 image::load_from_memory(&contents)?
             }
         };
-        Ok(AsciiImage(image))
+        Ok(AsciiImage(image.into()))
     }
 
     fn print<T>(&self, image: &Self::Image, options: &PrintOptions, terminal: &mut T) -> Result<(), PrintImageError>

--- a/src/terminal/image/protocols/sixel.rs
+++ b/src/terminal/image/protocols/sixel.rs
@@ -1,6 +1,6 @@
 use crate::terminal::{
     image::printer::{
-        CreatePrinterError, ImageProperties, PrintImage, PrintImageError, PrintOptions, RegisterImageError,
+        CreatePrinterError, ImageProperties, ImageSpec, PrintImage, PrintImageError, PrintOptions, RegisterImageError,
     },
     printer::{TerminalCommand, TerminalIo},
 };
@@ -38,14 +38,15 @@ impl SixelPrinter {
 impl PrintImage for SixelPrinter {
     type Image = SixelImage;
 
-    fn register(&self, image: image::DynamicImage) -> Result<Self::Image, RegisterImageError> {
-        Ok(SixelImage(image))
-    }
-
-    fn register_from_path<P: AsRef<std::path::Path>>(&self, path: P) -> Result<Self::Image, RegisterImageError> {
-        let contents = fs::read(path)?;
-        let image = image::load_from_memory(&contents)?;
-        Ok(SixelImage(image))
+    fn register(&self, spec: ImageSpec) -> Result<Self::Image, RegisterImageError> {
+        match spec {
+            ImageSpec::Generated(image) => Ok(SixelImage(image)),
+            ImageSpec::Filesystem(path) => {
+                let contents = fs::read(path)?;
+                let image = image::load_from_memory(&contents)?;
+                Ok(SixelImage(image))
+            }
+        }
     }
 
     fn print<T>(&self, image: &Self::Image, options: &PrintOptions, terminal: &mut T) -> Result<(), PrintImageError>

--- a/src/third_party.rs
+++ b/src/third_party.rs
@@ -12,7 +12,10 @@ use crate::{
         },
         properties::WindowSize,
     },
-    terminal::image::{Image, printer::RegisterImageError},
+    terminal::image::{
+        Image,
+        printer::{ImageSpec, RegisterImageError},
+    },
     theme::{Alignment, MermaidStyle, PresentationTheme, TypstStyle, raw::RawColor},
     tools::{ExecutionError, ThirdPartyTools},
 };
@@ -269,7 +272,7 @@ impl Worker {
     fn load_image(&self, snippet: ImageSnippet, path: &Path) -> Result<Image, ThirdPartyRenderError> {
         let contents = fs::read(path)?;
         let image = image::load_from_memory(&contents)?;
-        let image = self.state.lock().unwrap().image_registry.register_image(image)?;
+        let image = self.state.lock().unwrap().image_registry.register(ImageSpec::Generated(image))?;
         self.state.lock().unwrap().cache.insert(snippet, image.clone());
         Ok(image)
     }

--- a/src/ui/execution.rs
+++ b/src/ui/execution.rs
@@ -17,7 +17,10 @@ use crate::{
     },
     terminal::{
         ansi::AnsiSplitter,
-        image::{Image, printer::ImageRegistry},
+        image::{
+            Image,
+            printer::{ImageRegistry, ImageSpec},
+        },
         should_hide_cursor,
     },
     theme::{Alignment, ExecutionOutputBlockStyle, ExecutionStatusBlockStyle, Margin},
@@ -404,7 +407,7 @@ impl RunImageSnippet {
                 return Err(e.to_string());
             }
         };
-        self.image_registry.register_image(image).map_err(|e| e.to_string())
+        self.image_registry.register(ImageSpec::Generated(image)).map_err(|e| e.to_string())
     }
 }
 


### PR DESCRIPTION
This caches:
* Ascii images so we don't reload them every time we're doing slide transitions.
* Ascii image resizes, so if we go to a slide that contains an image and we're using slide transitions, the next transition that includes that image won't require resizing it to that same sizes.

The one performance "issue" still present when using slide transitions is that we still need to pay for that first image -> ascii image conversion and that first ascii image resize the first time we transition to a slide that contains an image. This is currently noticeable in debug mode and not in release mode (at least in my machine ™️), but it would be sweet if it wasn't there ever. For this we need to run through all slides, find all images, ascii convert them and resize them to the current terminal size. The same should be done when the terminal is resized.