### PR TITLE
feat: allow using images on right in footer

### DIFF
--- a/src/render/operation.rs
+++ b/src/render/operation.rs
@@ -101,7 +101,7 @@ pub(crate) struct ImageRenderProperties {
     pub(crate) size: ImageSize,
     pub(crate) restore_cursor: bool,
     pub(crate) background_color: Option<Color>,
-    pub(crate) center: bool,
+    pub(crate) position: ImagePosition,
 }
 
 impl Default for ImageRenderProperties {
@@ -111,9 +111,16 @@ impl Default for ImageRenderProperties {
             size: Default::default(),
             restore_cursor: false,
             background_color: None,
-            center: true,
+            position: ImagePosition::Cursor,
         }
     }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum ImagePosition {
+    Cursor,
+    Center,
+    Right,
 }
 
 /// The size used when printing an image.

--- a/src/theme/clean.rs
+++ b/src/theme/clean.rs
@@ -474,7 +474,7 @@ pub(crate) enum FooterStyle {
     Template {
         left: Option<FooterContent>,
         center: Option<FooterContent>,
-        right: Option<FooterTemplate>,
+        right: Option<FooterContent>,
         style: TextStyle,
         height: u16,
     },
@@ -496,7 +496,7 @@ impl FooterStyle {
             raw::FooterStyle::Template { left, center, right, colors, height } => {
                 let left = left.as_ref().map(|t| FooterContent::new(t, resources)).transpose()?;
                 let center = center.as_ref().map(|t| FooterContent::new(t, resources)).transpose()?;
-                let right = right.clone();
+                let right = right.as_ref().map(|t| FooterContent::new(t, resources)).transpose()?;
                 let style = TextStyle::colored(colors.resolve(palette)?);
                 let height = height.unwrap_or(DEFAULT_FOOTER_HEIGHT);
                 Ok(Self::Template { left, center, right, style, height })

--- a/src/theme/raw.rs
+++ b/src/theme/raw.rs
@@ -412,7 +412,7 @@ pub(super) enum FooterStyle {
         center: Option<FooterContent>,
 
         /// The content to be put on the right.
-        right: Option<FooterTemplate>,
+        right: Option<FooterContent>,
 
         /// The colors to be used.
         #[serde(default)]

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -9,7 +9,9 @@ use crate::{
     },
     presentation::PresentationState,
     render::{
-        operation::{AsRenderOperations, ImageRenderProperties, ImageSize, MarginProperties, RenderOperation},
+        operation::{
+            AsRenderOperations, ImagePosition, ImageRenderProperties, ImageSize, MarginProperties, RenderOperation,
+        },
         properties::WindowSize,
     },
     terminal::image::Image,
@@ -307,7 +309,7 @@ impl AsRenderOperations for CenterModalContent {
                 size: ImageSize::Specific(self.content_width, content_height),
                 restore_cursor: true,
                 background_color: None,
-                center: true,
+                position: ImagePosition::Center,
             };
             operations.push(RenderOperation::RenderImage(image.clone(), properties));
         }


### PR DESCRIPTION
This adds support for footer images on the right, just like allowed for left/center. Now that there's tests for this and after being restructured fairly recently it's much easier to get _right_.

The following presentation now renders like the following:

```markdown
---
theme:
    override:
        footer:
            height: 5
            style: template
            left:
                image: ../examples/doge.png
            center:
                image: ../examples/doge.png
            right:
                image: ../examples/doge.png
---

Footer images
===
```

![image](https://github.com/user-attachments/assets/2dfeb096-eba6-43a2-973c-b3d187c14086)

Closes #549