### PR TITLE
feat: allow letting pauses become new slides when exporting

### DIFF
--- a/config-file-schema.json
+++ b/config-file-schema.json
@@ -133,6 +133,14 @@
               "type": "null"
             }
           ]
+        },
+        "pauses": {
+          "description": "Whether pauses should create new slides.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/PauseExportPolicy"
+            }
+          ]
         }
       },
       "additionalProperties": false
@@ -494,6 +502,25 @@
         }
       },
       "additionalProperties": false
+    },
+    "PauseExportPolicy": {
+      "description": "The policy for pauses when exporting.",
+      "oneOf": [
+        {
+          "description": "Whether to ignore pauses.",
+          "type": "string",
+          "enum": [
+            "ignore"
+          ]
+        },
+        {
+          "description": "Create a new slide when a pause is found.",
+          "type": "string",
+          "enum": [
+            "new_slide"
+          ]
+        }
+      ]
     },
     "SlideTransitionConfig": {
       "type": "object",

--- a/src/config.rs
+++ b/src/config.rs
@@ -497,6 +497,22 @@ impl Default for SpeakerNotesConfig {
 pub struct ExportConfig {
     /// The dimensions to use for presentation exports.
     pub dimensions: Option<ExportDimensionsConfig>,
+
+    /// Whether pauses should create new slides.
+    #[serde(default)]
+    pub pauses: PauseExportPolicy,
+}
+
+/// The policy for pauses when exporting.
+#[derive(Clone, Debug, Default, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub enum PauseExportPolicy {
+    /// Whether to ignore pauses.
+    #[default]
+    Ignore,
+
+    /// Create a new slide when a pause is found.
+    NewSlide,
 }
 
 /// The dimensions to use for presentation exports.

--- a/src/main.rs
+++ b/src/main.rs
@@ -282,6 +282,7 @@ impl CoreComponents {
             theme_options: ThemeOptions { font_size_supported: TerminalEmulator::capabilities().font_size },
             pause_before_incremental_lists: config.defaults.incremental_lists.pause_before.unwrap_or(true),
             pause_after_incremental_lists: config.defaults.incremental_lists.pause_after.unwrap_or(true),
+            pause_create_new_slide: false,
         }
     }
 
@@ -415,6 +416,7 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             themes,
             builder_options,
             dimensions,
+            config.export.pauses,
         );
         let output_directory = match cli.export_temporary_path {
             Some(path) => OutputDirectory::external(path),

--- a/src/presentation/mod.rs
+++ b/src/presentation/mod.rs
@@ -298,7 +298,7 @@ impl Slide {
         self.current_chunk().reset_mutations();
     }
 
-    fn show_all_chunks(&mut self) {
+    pub(crate) fn show_all_chunks(&mut self) {
         self.visible_chunks = self.chunks.len();
         for chunk in &self.chunks {
             chunk.apply_all_mutations();


### PR DESCRIPTION
This introduces the config property `export.pauses` which when defaults to `ignore` but when set to `new_slide` causes the PDF export to contain a new slide every time a pause is found.

Closes #555