### PR TITLE
feat!: hide JSON schema generation behind feature flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,21 +18,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,19 +158,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chrono"
-version = "0.4.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
-dependencies = [
- "android-tzdata",
- "iana-time-zone",
- "num-traits",
- "serde",
- "windows-link",
-]
-
-[[package]]
 name = "clap"
 version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,12 +224,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,48 +259,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
- "serde",
 ]
 
 [[package]]
@@ -458,12 +388,6 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
@@ -479,36 +403,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.63"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "image"
@@ -528,24 +422,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
- "serde",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
- "serde",
+ "hashbrown",
 ]
 
 [[package]]
@@ -568,16 +450,6 @@ name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
-
-[[package]]
-name = "js-sys"
-version = "0.3.77"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
-dependencies = [
- "once_cell",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "libc"
@@ -756,7 +628,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42cf17e9a1800f5f396bc67d193dc9411b59012a5876445ef450d449881e1016"
 dependencies = [
  "base64",
- "indexmap 2.7.1",
+ "indexmap",
  "quick-xml",
  "serde",
  "time",
@@ -805,7 +677,6 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "serde_with",
  "serde_yaml",
  "sixel-rs",
  "socket2",
@@ -1050,42 +921,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_with"
-version = "3.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
-dependencies = [
- "base64",
- "chrono",
- "hex",
- "indexmap 1.9.3",
- "indexmap 2.7.1",
- "serde",
- "serde_derive",
- "serde_json",
- "serde_with_macros",
- "time",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "3.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
@@ -1508,65 +1349,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-core"
-version = "0.61.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-link"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
-
-[[package]]
-name = "windows-result"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
-dependencies = [
- "windows-link",
-]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,9 +294,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -304,9 +304,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
 dependencies = [
  "fnv",
  "ident_case",
@@ -318,9 +318,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
@@ -482,14 +482,15 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.61"
+version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
+ "log",
  "wasm-bindgen",
  "windows-core",
 ]
@@ -1510,18 +1511,62 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.52.0"
+version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
 dependencies = [
- "windows-targets",
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-result"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ schemars = { version = "0.8", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 serde_json = "1.0"
-serde_with = "3.6"
 syntect = { version = "5.2", features = ["parsing", "default-themes", "regex-onig", "plist-load"], default-features = false }
 socket2 = "0.5.8"
 strum = { version = "0.27", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ sixel-rs = { version = "0.4.1", optional = true }
 merge-struct = "0.1.0"
 itertools = "0.14"
 once_cell = "1.19"
-schemars = "0.8"
+schemars = { version = "0.8", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 serde_json = "1.0"
@@ -45,6 +45,7 @@ rstest = { version = "0.25", default-features = false }
 [features]
 default = []
 sixel = ["sixel-rs"]
+json-schema = ["dep:schemars"]
 
 [profile.dev]
 opt-level = 0

--- a/scripts/validate-config-file-schema.sh
+++ b/scripts/validate-config-file-schema.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
+set -euo pipefail
+
 script_dir=$(dirname "$0")
 root_dir="${script_dir}/../"
 
 current_schema=$(mktemp)
-cargo run -q -- --generate-config-file-schema >"$current_schema"
+cargo run --features json-schema -q -- --generate-config-file-schema >"$current_schema"
 
 diff=$(diff --color=always -u "${root_dir}/config-file-schema.json" "$current_schema")
 if [ $? -ne 0 ]; then

--- a/src/code/snippet.rs
+++ b/src/code/snippet.rs
@@ -16,7 +16,6 @@ use crate::{
     theme::{Alignment, CodeBlockStyle},
 };
 use serde::Deserialize;
-use serde_with::DeserializeFromStr;
 use std::{cell::RefCell, convert::Infallible, fmt::Write, ops::Range, path::PathBuf, rc::Rc, str::FromStr};
 use strum::{EnumDiscriminants, EnumIter};
 use unicode_width::UnicodeWidthStr;
@@ -439,7 +438,7 @@ impl Snippet {
 }
 
 /// The language of a code snippet.
-#[derive(Clone, Debug, PartialEq, Eq, EnumIter, PartialOrd, Ord, DeserializeFromStr)]
+#[derive(Clone, Debug, PartialEq, Eq, EnumIter, PartialOrd, Ord)]
 #[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum SnippetLanguage {
     Ada,
@@ -508,6 +507,8 @@ pub enum SnippetLanguage {
     Zig,
     Zsh,
 }
+
+crate::utils::impl_deserialize_from_str!(SnippetLanguage);
 
 impl FromStr for SnippetLanguage {
     type Err = Infallible;

--- a/src/code/snippet.rs
+++ b/src/code/snippet.rs
@@ -15,7 +15,6 @@ use crate::{
     },
     theme::{Alignment, CodeBlockStyle},
 };
-use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_with::DeserializeFromStr;
 use std::{cell::RefCell, convert::Infallible, fmt::Write, ops::Range, path::PathBuf, rc::Rc, str::FromStr};
@@ -440,7 +439,8 @@ impl Snippet {
 }
 
 /// The language of a code snippet.
-#[derive(Clone, Debug, PartialEq, Eq, EnumIter, PartialOrd, Ord, DeserializeFromStr, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, EnumIter, PartialOrd, Ord, DeserializeFromStr)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum SnippetLanguage {
     Ada,
     Asp,

--- a/src/commands/keyboard.rs
+++ b/src/commands/keyboard.rs
@@ -1,7 +1,6 @@
 use super::listener::{Command, CommandDiscriminants};
 use crate::config::KeyBindingsConfig;
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, poll, read};
-use schemars::JsonSchema;
 use serde_with::DeserializeFromStr;
 use std::{fmt, io, iter, mem, str::FromStr, time::Duration};
 
@@ -162,8 +161,9 @@ enum BindingMatch {
     None,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, DeserializeFromStr, JsonSchema)]
-pub struct KeyBinding(#[schemars(with = "String")] Vec<KeyMatcher>);
+#[derive(Clone, Debug, PartialEq, Eq, DeserializeFromStr)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
+pub struct KeyBinding(#[cfg_attr(feature = "json-schema", schemars(with = "String"))] Vec<KeyMatcher>);
 
 impl KeyBinding {
     fn match_events(&self, mut events: &[KeyEvent]) -> BindingMatch {

--- a/src/commands/keyboard.rs
+++ b/src/commands/keyboard.rs
@@ -1,7 +1,6 @@
 use super::listener::{Command, CommandDiscriminants};
 use crate::config::KeyBindingsConfig;
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, poll, read};
-use serde_with::DeserializeFromStr;
 use std::{fmt, io, iter, mem, str::FromStr, time::Duration};
 
 /// A keyboard command listener.
@@ -161,9 +160,11 @@ enum BindingMatch {
     None,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, DeserializeFromStr)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct KeyBinding(#[cfg_attr(feature = "json-schema", schemars(with = "String"))] Vec<KeyMatcher>);
+
+crate::utils::impl_deserialize_from_str!(KeyBinding);
 
 impl KeyBinding {
     fn match_events(&self, mut events: &[KeyEvent]) -> BindingMatch {

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,7 +7,6 @@ use crate::{
     },
 };
 use clap::ValueEnum;
-use schemars::JsonSchema;
 use serde::Deserialize;
 use std::{
     collections::{BTreeMap, HashMap},
@@ -16,7 +15,8 @@ use std::{
     path::Path,
 };
 
-#[derive(Clone, Debug, Default, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Default, Deserialize)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 #[serde(deny_unknown_fields)]
 pub struct Config {
     /// The default configuration for the presentation.
@@ -73,7 +73,8 @@ pub enum ConfigLoadError {
     Invalid(#[from] serde_yaml::Error),
 }
 
-#[derive(Clone, Debug, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 #[serde(deny_unknown_fields)]
 pub struct DefaultsConfig {
     /// The theme to use by default in every presentation unless overridden.
@@ -81,7 +82,7 @@ pub struct DefaultsConfig {
 
     /// Override the terminal font size when in windows or when using sixel.
     #[serde(default = "default_terminal_font_size")]
-    #[validate(range(min = 1))]
+    #[cfg_attr(feature = "json-schema", validate(range(min = 1)))]
     pub terminal_font_size: u8,
 
     /// The image protocol to use.
@@ -132,7 +133,8 @@ impl Default for DefaultsConfig {
 }
 
 /// The configuration for lists when incremental lists are enabled.
-#[derive(Clone, Debug, Default, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Default, Deserialize)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 #[serde(deny_unknown_fields)]
 pub struct IncrementalListsConfig {
     /// Whether to pause before a list begins.
@@ -149,7 +151,8 @@ fn default_terminal_font_size() -> u8 {
 }
 
 /// The alignment to use when `defaults.max_columns` is set.
-#[derive(Clone, Copy, Debug, Default, Deserialize, JsonSchema)]
+#[derive(Clone, Copy, Debug, Default, Deserialize)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum MaxColumnsAlignment {
     /// Align the presentation to the left.
@@ -164,7 +167,8 @@ pub enum MaxColumnsAlignment {
 }
 
 /// The alignment to use when `defaults.max_rows` is set.
-#[derive(Clone, Copy, Debug, Default, Deserialize, JsonSchema)]
+#[derive(Clone, Copy, Debug, Default, Deserialize)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum MaxRowsAlignment {
     /// Align the presentation to the top.
@@ -178,7 +182,8 @@ pub enum MaxRowsAlignment {
     Bottom,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Default, Deserialize)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum ValidateOverflows {
     #[default]
@@ -188,7 +193,8 @@ pub enum ValidateOverflows {
     WhenDeveloping,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Default, Deserialize)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 #[serde(deny_unknown_fields)]
 pub struct OptionsConfig {
     /// Whether slides are automatically terminated when a slide title is found.
@@ -214,7 +220,8 @@ pub struct OptionsConfig {
     pub auto_render_languages: Vec<SnippetLanguage>,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Default, Deserialize)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 #[serde(deny_unknown_fields)]
 pub struct SnippetConfig {
     /// The properties for snippet execution.
@@ -230,7 +237,8 @@ pub struct SnippetConfig {
     pub render: SnippetRenderConfig,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Default, Deserialize)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 #[serde(deny_unknown_fields)]
 pub struct SnippetExecConfig {
     /// Whether to enable snippet execution.
@@ -241,7 +249,8 @@ pub struct SnippetExecConfig {
     pub custom: BTreeMap<SnippetLanguage, LanguageSnippetExecutionConfig>,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Default, Deserialize)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 #[serde(deny_unknown_fields)]
 pub struct SnippetExecReplaceConfig {
     /// Whether to enable snippet replace-executions, which automatically run code snippets without
@@ -249,7 +258,8 @@ pub struct SnippetExecReplaceConfig {
     pub enable: bool,
 }
 
-#[derive(Clone, Debug, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 #[serde(deny_unknown_fields)]
 pub struct SnippetRenderConfig {
     /// The number of threads to use when rendering.
@@ -267,7 +277,8 @@ pub(crate) fn default_snippet_render_threads() -> usize {
     2
 }
 
-#[derive(Clone, Debug, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 #[serde(deny_unknown_fields)]
 pub struct TypstConfig {
     /// The pixels per inch when rendering latex/typst formulas.
@@ -285,7 +296,8 @@ pub(crate) fn default_typst_ppi() -> u32 {
     300
 }
 
-#[derive(Clone, Debug, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 #[serde(deny_unknown_fields)]
 pub struct MermaidConfig {
     /// The scaling parameter to be used in the mermaid CLI.
@@ -308,7 +320,8 @@ pub(crate) fn default_u16_max() -> u16 {
 }
 
 /// The snippet execution configuration for a specific programming language.
-#[derive(Clone, Debug, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct LanguageSnippetExecutionConfig {
     /// The filename to use for the snippet input file.
     pub filename: String,
@@ -324,7 +337,8 @@ pub struct LanguageSnippetExecutionConfig {
     pub hidden_line_prefix: Option<String>,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, ValueEnum, JsonSchema)]
+#[derive(Clone, Debug, Default, Deserialize, ValueEnum)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "kebab-case")]
 pub enum ImageProtocol {
     /// Automatically detect the best image protocol to use.
@@ -378,7 +392,8 @@ impl TryFrom<&ImageProtocol> for GraphicsMode {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 #[serde(deny_unknown_fields)]
 pub struct KeyBindingsConfig {
     /// The keys that cause the presentation to move forwards.
@@ -465,7 +480,8 @@ impl Default for KeyBindingsConfig {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 #[serde(deny_unknown_fields)]
 pub struct SpeakerNotesConfig {
     /// The address in which to listen for speaker note events.
@@ -492,7 +508,8 @@ impl Default for SpeakerNotesConfig {
 }
 
 /// The export configuration.
-#[derive(Clone, Debug, Default, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Default, Deserialize)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 #[serde(deny_unknown_fields)]
 pub struct ExportConfig {
     /// The dimensions to use for presentation exports.
@@ -504,7 +521,8 @@ pub struct ExportConfig {
 }
 
 /// The policy for pauses when exporting.
-#[derive(Clone, Debug, Default, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Default, Deserialize)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub enum PauseExportPolicy {
     /// Whether to ignore pauses.
@@ -516,7 +534,8 @@ pub enum PauseExportPolicy {
 }
 
 /// The dimensions to use for presentation exports.
-#[derive(Clone, Debug, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 #[serde(deny_unknown_fields)]
 pub struct ExportDimensionsConfig {
     /// The number of rows.
@@ -527,9 +546,9 @@ pub struct ExportDimensionsConfig {
 }
 
 // The slide transition configuration.
-#[derive(Clone, Debug, Deserialize, JsonSchema)]
-#[serde(deny_unknown_fields)]
-#[serde(tag = "style")]
+#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
+#[serde(tag = "style", deny_unknown_fields)]
 pub struct SlideTransitionConfig {
     /// The amount of time to take to perform the transition.
     #[serde(default = "default_transition_duration_millis")]
@@ -544,9 +563,9 @@ pub struct SlideTransitionConfig {
 }
 
 // The slide transition style configuration.
-#[derive(Clone, Debug, Deserialize, JsonSchema)]
-#[serde(deny_unknown_fields)]
-#[serde(tag = "style", rename_all = "snake_case")]
+#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
+#[serde(tag = "style", rename_all = "snake_case", deny_unknown_fields)]
 pub enum SlideTransitionStyleConfig {
     /// Slide horizontally.
     SlideHorizontal,

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,7 @@ mod third_party;
 mod tools;
 mod transitions;
 mod ui;
+mod utils;
 
 const DEFAULT_THEME: &str = "dark";
 const DEFAULT_EXPORT_PIXELS_PER_COLUMN: u16 = 20;

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,6 +80,7 @@ struct Cli {
 
     /// Generate a JSON schema for the configuration file.
     #[clap(long)]
+    #[cfg(feature = "json-schema")]
     generate_config_file_schema: bool,
 
     /// Use presentation mode.
@@ -348,11 +349,13 @@ fn overflow_validation_enabled(mode: &PresentMode, config: &ValidateOverflows) -
 }
 
 fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(feature = "json-schema")]
     if cli.generate_config_file_schema {
         let schema = schemars::schema_for!(Config);
         serde_json::to_writer_pretty(io::stdout(), &schema).map_err(|e| format!("failed to write schema: {e}"))?;
         return Ok(());
-    } else if cli.acknowledgements {
+    }
+    if cli.acknowledgements {
         let acknowledgements = include_bytes!("../bat/acknowledgements.txt");
         println!("{}", String::from_utf8_lossy(acknowledgements));
         return Ok(());

--- a/src/theme/raw.rs
+++ b/src/theme/raw.rs
@@ -2,7 +2,6 @@ use super::registry::LoadThemeError;
 use crate::markdown::text_style::{Color, Colors, UndefinedPaletteColorError};
 use hex::{FromHex, FromHexError};
 use serde::{Deserialize, Serialize, de::Visitor};
-use serde_with::{DeserializeFromStr, SerializeDisplay};
 use std::{
     collections::BTreeMap,
     fmt, fs,
@@ -508,8 +507,11 @@ impl<'de> Deserialize<'de> for FooterContent {
     }
 }
 
-#[derive(Clone, Debug, SerializeDisplay, DeserializeFromStr)]
+#[derive(Clone, Debug)]
 pub(crate) struct FooterTemplate(pub(crate) Vec<FooterTemplateChunk>);
+
+crate::utils::impl_deserialize_from_str!(FooterTemplate);
+crate::utils::impl_serialize_from_display!(FooterTemplate);
 
 impl FromStr for FooterTemplate {
     type Err = ParseFooterTemplateError;
@@ -801,13 +803,16 @@ pub(super) struct ColorPalette {
     pub(super) classes: BTreeMap<String, RawColors>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, SerializeDisplay, DeserializeFromStr)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum RawColor {
     Color(Color),
     Palette(String),
     ForegroundClass(String),
     BackgroundClass(String),
 }
+
+crate::utils::impl_deserialize_from_str!(RawColor);
+crate::utils::impl_serialize_from_display!(RawColor);
 
 impl RawColor {
     fn new_palette(name: &str) -> Result<Self, ParseColorError> {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,75 @@
+use serde::{Deserializer, Serializer};
+use std::{
+    fmt::{self, Display},
+    marker::PhantomData,
+    str::FromStr,
+};
+
+macro_rules! impl_deserialize_from_str {
+    ($ty:ty) => {
+        impl<'de> serde::de::Deserialize<'de> for $ty {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: serde::de::Deserializer<'de>,
+            {
+                $crate::utils::deserialize_from_str(deserializer)
+            }
+        }
+    };
+}
+
+macro_rules! impl_serialize_from_display {
+    ($ty:ty) => {
+        impl serde::Serialize for $ty {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                $crate::utils::serialize_display(self, serializer)
+            }
+        }
+    };
+}
+
+pub(crate) use impl_deserialize_from_str;
+pub(crate) use impl_serialize_from_display;
+
+// Same behavior as serde_with::DeserializeFromStr
+pub(crate) fn deserialize_from_str<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: FromStr,
+    T::Err: Display,
+{
+    struct Visitor<S>(PhantomData<S>);
+
+    impl<S> serde::de::Visitor<'_> for Visitor<S>
+    where
+        S: FromStr,
+        <S as FromStr>::Err: Display,
+    {
+        type Value = S;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            write!(formatter, "a string")
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            value.parse::<S>().map_err(serde::de::Error::custom)
+        }
+    }
+
+    deserializer.deserialize_str(Visitor(PhantomData))
+}
+
+// Same behavior as serde_with::SerializeDisplay
+pub(crate) fn serialize_display<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+where
+    T: Display,
+    S: Serializer,
+{
+    serializer.serialize_str(&value.to_string())
+}


### PR DESCRIPTION
This hides the JSON schema generation for the config file behind a new `json-schema` feature flag. This is not fundamental to the functioning of this tool and also there's already a schema generated [here](https://github.com/mfontanini/presenterm/blob/master/config-file-schema.json) so there's no need to have this available in the tool when released. If anyone does want the JSON schema for some specific version of the tool, they can always clone the repo and `cargo run --features json-schema`.

This also removes the `serde_with` dependency and instead hand rolls the `SerializeDisplay` and `DeserializeFromStr` macros manually. These are very few lines long and doesn't make importing that crate worth it.

Overall these 2 changes cause the number of crates to go down by something like 20 which is great.