### PR TITLE
feat: allow specifying start/end lines in file snippet type

### DIFF
--- a/src/code/snippet.rs
+++ b/src/code/snippet.rs
@@ -659,6 +659,8 @@ pub(crate) enum Highlight {
 pub(crate) struct ExternalFile {
     pub(crate) path: PathBuf,
     pub(crate) language: SnippetLanguage,
+    pub(crate) start_line: Option<usize>,
+    pub(crate) end_line: Option<usize>,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This adds new optional `start_line` and `end_line` properties when using a `file` type snippet, which allow specifying the line range to be used.

Caveats:

* The line selection is applied before highlighting so if you truncate the file in a place that should be highlighted in some way because of something that came before (e.g. multi line comments) it won't be highlighted appropriately. This can be fixed but requires changing a few things and I think this should not be hit very often.
* Using `+line_numbers` will always start at 1. In the future I may add a property like `preserve_line_numbers` but again this would require changing a few things (the same ones as the point above) so I kept it this way for now.

Example:

~~~markdown
```file +line_numbers
language: rust
path: scripts/foo.rs
start_line: 3
end_line: 20
```
~~~

Closes #562