### PR TITLE
feat: make HTML export self contained

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -45,7 +45,7 @@ jobs:
           source ./.venv/bin/activate
           uv pip install weasyprint
 
-      - name: Export demo presentation as PDF
+      - name: Export demo presentation as PDF and HTML
         run: |
           cat >/tmp/config.yaml <<EOL
           export:
@@ -54,7 +54,8 @@ jobs:
               columns: 135
           EOL
           source ./.venv/bin/activate
-          cargo run -- -e -c /tmp/config.yaml examples/demo.md
+          cargo run -- --export-pdf -c /tmp/config.yaml examples/demo.md
+          cargo run -- --export-html -c /tmp/config.yaml examples/demo.md
 
   nix-flake:
     name: Validate nix flake

--- a/src/main.rs
+++ b/src/main.rs
@@ -293,8 +293,8 @@ impl CoreComponents {
     }
 
     fn select_graphics_mode(cli: &Cli, config: &Config) -> GraphicsMode {
-        if cli.export_pdf {
-            GraphicsMode::AsciiBlocks
+        if cli.export_pdf | cli.export_html {
+            GraphicsMode::Raw
         } else {
             let protocol = cli.image_protocol.as_ref().unwrap_or(&config.defaults.image_protocol);
             match GraphicsMode::try_from(protocol) {

--- a/src/terminal/image/mod.rs
+++ b/src/terminal/image/mod.rs
@@ -1,7 +1,6 @@
+use self::printer::{ImageProperties, TerminalImage};
 use image::DynamicImage;
 use protocols::ascii::AsciiImage;
-
-use self::printer::{ImageProperties, TerminalImage};
 use std::{
     fmt::Debug,
     ops::Deref,
@@ -43,6 +42,7 @@ impl Image {
                     TerminalImage::Ascii(image) => image.clone(),
                     TerminalImage::Kitty(image) => DynamicImage::from(image.as_rgba8()).into(),
                     TerminalImage::Iterm(image) => DynamicImage::from(image.as_rgba8()).into(),
+                    TerminalImage::Raw(_) => unreachable!("raw is only used for exports"),
                     #[cfg(feature = "sixel")]
                     TerminalImage::Sixel(image) => DynamicImage::from(image.as_rgba8()).into(),
                 };

--- a/src/terminal/image/protocols/ascii.rs
+++ b/src/terminal/image/protocols/ascii.rs
@@ -36,10 +36,6 @@ impl AsciiImage {
             cached_sizes.insert(cache_key, image.into_rgba8());
         }
     }
-
-    pub(crate) fn image(&self) -> &DynamicImage {
-        &self.inner.image
-    }
 }
 
 impl ImageProperties for AsciiImage {

--- a/src/terminal/image/protocols/mod.rs
+++ b/src/terminal/image/protocols/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod ascii;
 pub(crate) mod iterm;
 pub(crate) mod kitty;
+pub(crate) mod raw;
 #[cfg(feature = "sixel")]
 pub(crate) mod sixel;

--- a/src/terminal/image/protocols/raw.rs
+++ b/src/terminal/image/protocols/raw.rs
@@ -1,0 +1,61 @@
+use crate::terminal::{
+    image::printer::{ImageProperties, ImageSpec, PrintImage, PrintImageError, PrintOptions, RegisterImageError},
+    printer::TerminalIo,
+};
+use base64::{Engine, engine::general_purpose::STANDARD};
+use image::{GenericImageView, ImageEncoder, ImageFormat, codecs::png::PngEncoder};
+use std::fs;
+
+pub(crate) struct RawImage {
+    contents: Vec<u8>,
+    format: ImageFormat,
+    width: u32,
+    height: u32,
+}
+
+impl RawImage {
+    pub(crate) fn to_inline_html(&self) -> String {
+        let mime_type = self.format.to_mime_type();
+        let data = STANDARD.encode(&self.contents);
+        format!("data:{mime_type};base64,{data}")
+    }
+}
+
+impl ImageProperties for RawImage {
+    fn dimensions(&self) -> (u32, u32) {
+        (self.width, self.height)
+    }
+}
+
+pub(crate) struct RawPrinter;
+
+impl PrintImage for RawPrinter {
+    type Image = RawImage;
+
+    fn register(&self, spec: ImageSpec) -> Result<Self::Image, RegisterImageError> {
+        let image = match spec {
+            ImageSpec::Generated(image) => {
+                let mut contents = Vec::new();
+                let encoder = PngEncoder::new(&mut contents);
+                let (width, height) = image.dimensions();
+                encoder.write_image(image.as_bytes(), width, height, image.color().into())?;
+                RawImage { contents, format: ImageFormat::Png, width, height }
+            }
+            ImageSpec::Filesystem(path) => {
+                let contents = fs::read(path)?;
+                let format = image::guess_format(&contents)?;
+                let image = image::load_from_memory_with_format(&contents, format)?;
+                let (width, height) = image.dimensions();
+                RawImage { contents, format, width, height }
+            }
+        };
+        Ok(image)
+    }
+
+    fn print<T>(&self, _image: &Self::Image, _options: &PrintOptions, _terminal: &mut T) -> Result<(), PrintImageError>
+    where
+        T: TerminalIo,
+    {
+        Err(PrintImageError::Other("raw images can't be printed".into()))
+    }
+}

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -15,6 +15,7 @@ pub enum GraphicsMode {
         inside_tmux: bool,
     },
     AsciiBlocks,
+    Raw,
     #[cfg(feature = "sixel")]
     Sixel,
 }


### PR DESCRIPTION
#566 did the heavy work to allow HTML exports but the one thing missing is that images were still referenced on their external paths, which caused 2 issues:

* Files were not redistributable unless you included images and fixed their paths.
* Generated images (e.g. mermaid diagrams) were likely pointing to a temporary directory so they'd be lost.

This changes that so HTML exports are now fully self contained, using `data:...` notation to inline images within the HTML.