### PR TITLE
fix: execute snippets only once during export

### DIFF
--- a/src/export/exporter.rs
+++ b/src/export/exporter.rs
@@ -122,7 +122,7 @@ impl<'a> Exporter<'a> {
 
         let mut render = ExportRenderer::new(self.dimensions.clone(), output_directory, renderer);
         Self::log("waiting for images to be generated and code to be executed, if any...")?;
-        Self::render_async_images(&mut presentation);
+        Self::wait_render_asyncs(&mut presentation);
 
         for (index, slide) in presentation.into_slides().into_iter().enumerate() {
             let index = index + 1;
@@ -198,7 +198,7 @@ impl<'a> Exporter<'a> {
         Ok(())
     }
 
-    fn render_async_images(presentation: &mut Presentation) {
+    fn wait_render_asyncs(presentation: &mut Presentation) {
         let poller = Poller::launch();
         let mut pollables = Vec::new();
         for (index, slide) in presentation.iter_slides().enumerate() {

--- a/src/render/operation.rs
+++ b/src/render/operation.rs
@@ -194,7 +194,7 @@ pub(crate) trait Pollable: Send + 'static {
 }
 
 /// The state of a [Pollable].
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub(crate) enum PollableState {
     Unmodified,
     Modified,


### PR DESCRIPTION
A recent refactoring on snippet execution caused a disconnect between a snippet being executed and how it reflected its state on the shared types between the snippet and the component that polls it. This caused PDF exports that contained more than one executable snippet to only have its first snippet executed and the rest still shown as "running".

Addresses part of #582