### PR TITLE
feat: allow configuring sequential executable snippet processing

### DIFF
--- a/config-file-schema.json
+++ b/config-file-schema.json
@@ -141,6 +141,14 @@
               "$ref": "#/definitions/PauseExportPolicy"
             }
           ]
+        },
+        "snippets": {
+          "description": "The policy for executable snippets when exporting.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SnippetsExportPolicy"
+            }
+          ]
         }
       },
       "additionalProperties": false
@@ -766,6 +774,25 @@
         }
       },
       "additionalProperties": false
+    },
+    "SnippetsExportPolicy": {
+      "description": "The policy for executable snippets when exporting.",
+      "oneOf": [
+        {
+          "description": "Render all executable snippets in parallel.",
+          "type": "string",
+          "enum": [
+            "parallel"
+          ]
+        },
+        {
+          "description": "Render all executable snippets sequentially.",
+          "type": "string",
+          "enum": [
+            "sequential"
+          ]
+        }
+      ]
     },
     "SpeakerNotesConfig": {
       "type": "object",

--- a/src/config.rs
+++ b/src/config.rs
@@ -518,6 +518,10 @@ pub struct ExportConfig {
     /// Whether pauses should create new slides.
     #[serde(default)]
     pub pauses: PauseExportPolicy,
+
+    /// The policy for executable snippets when exporting.
+    #[serde(default)]
+    pub snippets: SnippetsExportPolicy,
 }
 
 /// The policy for pauses when exporting.
@@ -531,6 +535,19 @@ pub enum PauseExportPolicy {
 
     /// Create a new slide when a pause is found.
     NewSlide,
+}
+
+/// The policy for executable snippets when exporting.
+#[derive(Clone, Debug, Default, Deserialize)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub enum SnippetsExportPolicy {
+    /// Render all executable snippets in parallel.
+    #[default]
+    Parallel,
+
+    /// Render all executable snippets sequentially.
+    Sequential,
 }
 
 /// The dimensions to use for presentation exports.

--- a/src/main.rs
+++ b/src/main.rs
@@ -425,6 +425,7 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             builder_options,
             dimensions,
             config.export.pauses,
+            config.export.snippets,
         );
         let output_directory = match cli.export_temporary_path {
             Some(path) => OutputDirectory::external(path),


### PR DESCRIPTION
This adds a new attribute `export.snippets` in the config file that configured how executable snippets are handled when exporting PDFs/HTMLs. By default it uses `parallel` meaning all snippets are ran at the same time, whereas `sequential` means only one snippet will be ran at a time. This can help handle cases were snippets have to be ran sequentially because the output of snippet N depends on the output of snippet M < N.

Example config:

```yaml
export:
  snippets: sequential
```

Closes #582