### PR TITLE
feat: add padding to execution output

### DIFF
--- a/src/presentation/builder/snippet.rs
+++ b/src/presentation/builder/snippet.rs
@@ -335,6 +335,7 @@ impl<'a> SnippetProcessor<'a> {
             alignment,
             self.font_size,
             policy,
+            self.theme.execution_output.padding.clone(),
         );
         let operation = RenderOperation::RenderAsync(Rc::new(operation));
         self.operations.push(operation);

--- a/src/theme/clean.rs
+++ b/src/theme/clean.rs
@@ -574,14 +574,19 @@ pub(crate) struct PaddingRect {
 pub(crate) struct ExecutionOutputBlockStyle {
     pub(crate) style: TextStyle,
     pub(crate) status: ExecutionStatusBlockStyle,
+    pub(crate) padding: PaddingRect,
 }
 
 impl ExecutionOutputBlockStyle {
     fn new(raw: &raw::ExecutionOutputBlockStyle, palette: &ColorPalette) -> Result<Self, ProcessingThemeError> {
-        let raw::ExecutionOutputBlockStyle { colors, status } = raw;
+        let raw::ExecutionOutputBlockStyle { colors, status, padding } = raw;
         let colors = colors.resolve(palette)?;
         let style = TextStyle::colored(colors);
-        Ok(Self { style, status: ExecutionStatusBlockStyle::new(status, palette)? })
+        let padding = PaddingRect {
+            horizontal: padding.horizontal.unwrap_or_default(),
+            vertical: padding.vertical.unwrap_or_default(),
+        };
+        Ok(Self { style, status: ExecutionStatusBlockStyle::new(status, palette)?, padding })
     }
 }
 

--- a/src/theme/raw.rs
+++ b/src/theme/raw.rs
@@ -646,6 +646,10 @@ pub(super) struct ExecutionOutputBlockStyle {
     /// The colors to be used for the text that represents the status of the execution block.
     #[serde(default)]
     pub(super) status: ExecutionStatusBlockStyle,
+
+    /// The padding.
+    #[serde(default)]
+    pub(super) padding: PaddingRect,
 }
 
 /// The style for the status of a code execution block.

--- a/themes/catppuccin-frappe.yaml
+++ b/themes/catppuccin-frappe.yaml
@@ -38,6 +38,9 @@ execution_output:
       foreground: "e78284"
     not_started:
       foreground: "e5c890"
+  padding:
+    horizontal: 2
+    vertical: 1
 
 inline_code:
   colors:

--- a/themes/catppuccin-latte.yaml
+++ b/themes/catppuccin-latte.yaml
@@ -38,6 +38,9 @@ execution_output:
       foreground: "d20f39"
     not_started:
       foreground: "df8e1d"
+  padding:
+    horizontal: 2
+    vertical: 1
 
 inline_code:
   colors:

--- a/themes/catppuccin-macchiato.yaml
+++ b/themes/catppuccin-macchiato.yaml
@@ -38,6 +38,9 @@ execution_output:
       foreground: "ed8796"
     not_started:
       foreground: "eed49f"
+  padding:
+    horizontal: 2
+    vertical: 1
 
 inline_code:
   colors:

--- a/themes/catppuccin-mocha.yaml
+++ b/themes/catppuccin-mocha.yaml
@@ -38,6 +38,9 @@ execution_output:
       foreground: "f38ba8"
     not_started:
       foreground: "f9e2af"
+  padding:
+    horizontal: 2
+    vertical: 1
 
 inline_code:
   colors:

--- a/themes/dark.yaml
+++ b/themes/dark.yaml
@@ -38,6 +38,9 @@ execution_output:
       foreground: palette:red
     not_started:
       foreground: palette:orange
+  padding:
+    horizontal: 2
+    vertical: 1
 
 inline_code:
   colors:

--- a/themes/gruvbox-dark.yaml
+++ b/themes/gruvbox-dark.yaml
@@ -38,6 +38,9 @@ execution_output:
       foreground: "fb4934"
     not_started:
       foreground: "fabd2f"
+  padding:
+    horizontal: 2
+    vertical: 1
 
 inline_code:
   colors:

--- a/themes/light.yaml
+++ b/themes/light.yaml
@@ -38,6 +38,9 @@ execution_output:
       foreground: "f07167"
     not_started:
       foreground: "f77f00"
+  padding:
+    horizontal: 2
+    vertical: 1
 
 inline_code:
   colors:

--- a/themes/terminal-dark.yaml
+++ b/themes/terminal-dark.yaml
@@ -38,6 +38,9 @@ execution_output:
       foreground: red
     not_started:
       foreground: yellow
+  padding:
+    horizontal: 2
+    vertical: 1
 
 inline_code:
   colors:

--- a/themes/terminal-light.yaml
+++ b/themes/terminal-light.yaml
@@ -38,6 +38,9 @@ execution_output:
       foreground: dark_red
     not_started:
       foreground: dark_yellow
+  padding:
+    horizontal: 2
+    vertical: 1
 
 inline_code:
   colors:

--- a/themes/tokyonight-storm.yaml
+++ b/themes/tokyonight-storm.yaml
@@ -38,6 +38,9 @@ execution_output:
       foreground: "f7768e"
     not_started:
       foreground: "e0af68"
+  padding:
+    horizontal: 2
+    vertical: 1
 
 inline_code:
   colors:


### PR DESCRIPTION
This adds a new `execution_output.padding` option in the theme that behaves just like `code.padding`. Built in themes now all have this property set to be the same as the `code.padding` (2 horizontal, 1 vertical padding) because I think it looks better. Please chime in if anyone doesn't feel like this is the case though!

## Before

![image](https://github.com/user-attachments/assets/c2470572-74cc-463f-8cd3-e138f8bcf44d)

## After 
![image](https://github.com/user-attachments/assets/e3a2a3c3-1a96-4dae-a98d-847572f49a6a)


Closes #591