### PR TITLE
fix: use charset in output HTML

### DIFF
--- a/src/export/output.rs
+++ b/src/export/output.rs
@@ -216,6 +216,7 @@ let originalHeight = {height};
             OutputFormat::Html => format!(
                 "
 <head>
+<meta charset=\"UTF-8\">
 <style>
 {css}
 </style>


### PR DESCRIPTION
Without this safari shows crap on non ascii characters