### PR TITLE
feat: support superscript via kitty font size protocol

### DIFF
--- a/src/export/html.rs
+++ b/src/export/html.rs
@@ -8,8 +8,9 @@ pub(crate) enum HtmlText {
 
 impl HtmlText {
     pub(crate) fn new(text: &str, style: &TextStyle, font_size: FontSize) -> Self {
+        let mut text = text.to_string();
         if style == &TextStyle::default() {
-            return Self::Plain(text.to_string());
+            return Self::Plain(text);
         }
         let mut css_styles = Vec::new();
         let mut text_decorations = Vec::new();
@@ -19,6 +20,7 @@ impl HtmlText {
                 TextAttribute::Italics => css_styles.push(Cow::Borrowed("font-style: italic")),
                 TextAttribute::Strikethrough => text_decorations.push(Cow::Borrowed("line-through")),
                 TextAttribute::Underlined => text_decorations.push(Cow::Borrowed("underline")),
+                TextAttribute::Superscript => text = format!("<sup>{text}</sup>"),
                 TextAttribute::ForegroundColor(color) => {
                     let color = color_to_html(&color);
                     css_styles.push(format!("color: {color}").into());
@@ -38,7 +40,7 @@ impl HtmlText {
             css_styles.push(format!("font-size: {font_size}").into());
         }
         let css_style = css_styles.join("; ");
-        Self::Styled { text: text.to_string(), style: css_style }
+        Self::Styled { text, style: css_style }
     }
 }
 

--- a/src/markdown/parse.rs
+++ b/src/markdown/parse.rs
@@ -34,6 +34,7 @@ impl Default for ParserOptions {
         options.extension.multiline_block_quotes = true;
         options.extension.alerts = true;
         options.extension.wikilinks_title_before_pipe = true;
+        options.extension.superscript = true;
         Self(options)
     }
 }
@@ -362,6 +363,7 @@ impl<'a> InlinesParser<'a> {
             NodeValue::Strong => self.process_children(node, style.bold())?,
             NodeValue::Emph => self.process_children(node, style.italics())?,
             NodeValue::Strikethrough => self.process_children(node, style.strikethrough())?,
+            NodeValue::Superscript => self.process_children(node, style.superscript())?,
             NodeValue::SoftBreak => {
                 match self.soft_break {
                     SoftBreak::Newline => {
@@ -653,7 +655,8 @@ boop
 
     #[test]
     fn paragraph() {
-        let parsed = parse_single("some **bold text**, _italics_, *italics*, **nested _italics_**, ~strikethrough~");
+        let parsed =
+            parse_single("some **bold text**, _italics_, *italics*, **nested _italics_**, ~strikethrough~, ^super^");
         let MarkdownElement::Paragraph(elements) = parsed else { panic!("not a paragraph: {parsed:?}") };
         let expected_chunks = vec![
             Text::from("some "),
@@ -667,6 +670,8 @@ boop
             Text::new("italics", TextStyle::default().italics().bold()),
             Text::from(", "),
             Text::new("strikethrough", TextStyle::default().strikethrough()),
+            Text::from(", "),
+            Text::new("super", TextStyle::default().superscript()),
         ];
 
         let expected_elements = &[Line(expected_chunks)];

--- a/src/terminal/printer.rs
+++ b/src/terminal/printer.rs
@@ -1,3 +1,4 @@
+use super::emulator::TerminalEmulator;
 use crate::{
     markdown::text_style::{Color, Colors, TextStyle},
     terminal::image::{
@@ -119,7 +120,8 @@ impl<I: TerminalWrite> Terminal<I> {
         if self.cursor_row.saturating_add(style.size as u16) > self.rows {
             return Ok(());
         }
-        let content = style.apply(content);
+        let capabilities = TerminalEmulator::capabilities();
+        let content = style.apply(content, &capabilities);
         self.writer.queue(style::PrintStyledContent(content))?;
         self.current_row_height = self.current_row_height.max(style.size as u16);
         Ok(())


### PR DESCRIPTION
This adds support for superscripts via `x^42^` syntax. This requires the terminal to support half sizes (`n=X:d=Y`) via the kitty font size protocol. This works _okay_ in PDF/HTML exports, except when using superscripts in block quotes. In that case it looks a bit messed up. It's possible there's other places where it also looks bad (now typing this, alerts are also affected).

This is using half blocks but also still making them take up an entire cell. There's a way around this but requires changing a few things so I'd rather have something functional for now that can be iterated on.

Relates to #604