### PR TITLE
chore: bump rust version to 1.82

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -63,7 +63,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install nix
-        uses: DeterminateSystems/nix-installer-action@v13
+        uses: DeterminateSystems/nix-installer-action@v17
       - name: Build
         run: nix build .#dev.presenterm
 

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install rust toolchain
-        uses: dtolnay/rust-toolchain@1.78.0
+        uses: dtolnay/rust-toolchain@1.82.0
         with:
           components: clippy
 

--- a/flake.lock
+++ b/flake.lock
@@ -3,52 +3,45 @@
     "android-nixpkgs": {
       "inputs": {
         "devshell": "devshell",
-        "flake-utils": "flake-utils_3",
+        "flake-utils": "flake-utils_2",
         "nixpkgs": [
           "flakebox",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1719001124,
-        "narHash": "sha256-JXrMwYlQarZPyjN5UkD4fS9mrHSE1PUa7P//1Z5Sqr0=",
+        "lastModified": 1732566114,
+        "narHash": "sha256-rgFf/qq7vR4KKRfZ55jnWN+d7WjE8Qhz6BYywsbD79w=",
         "owner": "tadfisher",
         "repo": "android-nixpkgs",
-        "rev": "7fa1348249564e43185d3053f579f9fa923d46cc",
+        "rev": "4ecd9e0da0a955a180a429196f59a8716d1dd138",
         "type": "github"
       },
       "original": {
         "owner": "tadfisher",
         "repo": "android-nixpkgs",
-        "rev": "7fa1348249564e43185d3053f579f9fa923d46cc",
+        "rev": "4ecd9e0da0a955a180a429196f59a8716d1dd138",
         "type": "github"
       }
     },
     "crane": {
-      "inputs": {
-        "nixpkgs": [
-          "flakebox",
-          "nixpkgs"
-        ]
-      },
       "locked": {
-        "lastModified": 1717383740,
-        "narHash": "sha256-559HbY4uhNeoYvK3H6AMZAtVfmR3y8plXZ1x6ON/cWU=",
+        "lastModified": 1739936662,
+        "narHash": "sha256-x4syUjNUuRblR07nDPeLDP7DpphaBVbUaSoeZkFbGSk=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "b65673fce97d277934488a451724be94cc62499a",
+        "rev": "19de14aaeb869287647d9461cbd389187d8ecdb7",
         "type": "github"
       },
       "original": {
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "b65673fce97d277934488a451724be94cc62499a",
+        "rev": "19de14aaeb869287647d9461cbd389187d8ecdb7",
         "type": "github"
       }
     },
     "devshell": {
       "inputs": {
-        "flake-utils": "flake-utils_2",
         "nixpkgs": [
           "flakebox",
           "android-nixpkgs",
@@ -56,11 +49,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717408969,
-        "narHash": "sha256-Q0OEFqe35fZbbRPPRdrjTUUChKVhhWXz3T9ZSKmaoVY=",
+        "lastModified": 1728330715,
+        "narHash": "sha256-xRJ2nPOXb//u1jaBnDP56M7v5ldavjbtR6lfGqSvcKg=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "1ebbe68d57457c8cae98145410b164b5477761f4",
+        "rev": "dd6b80932022cea34a019e2bb32f6fa9e494dfef",
         "type": "github"
       },
       "original": {
@@ -78,11 +71,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1717827974,
-        "narHash": "sha256-ixopuTeTouxqTxfMuzs6IaRttbT8JqRW5C9Q/57WxQw=",
+        "lastModified": 1744958318,
+        "narHash": "sha256-L0a9BKIgHAD9mqum0VoXjBUDwnCV16/Q1AQg3a8cEnw=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "ab655c627777ab5f9964652fe23bbb1dfbd687a8",
+        "rev": "4cc256372df88f061c5156b8ca4ed6d5b01fb1a7",
         "type": "github"
       },
       "original": {
@@ -96,11 +89,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -114,11 +107,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -129,35 +122,17 @@
     },
     "flake-utils_3": {
       "inputs": {
-        "systems": "systems_3"
-      },
-      "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_4": {
-      "inputs": {
         "systems": [
           "flakebox",
           "systems"
         ]
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -171,37 +146,37 @@
         "android-nixpkgs": "android-nixpkgs",
         "crane": "crane",
         "fenix": "fenix",
-        "flake-utils": "flake-utils_4",
+        "flake-utils": "flake-utils_3",
         "nixpkgs": "nixpkgs",
-        "systems": "systems_4"
+        "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1720463890,
-        "narHash": "sha256-C5bQ8jHIHm2fwh3U/uEANmHYL7vRAHq6S7SNqyakYMI=",
+        "lastModified": 1747060781,
+        "narHash": "sha256-O1JJkZihr6cQ1E4k9HzDG3Dc3eIBrhnKvkYfvhAogPg=",
         "owner": "rustshop",
         "repo": "flakebox",
-        "rev": "ead24017440df8c5fd75cdb04c16d13c7d6fa50d",
+        "rev": "47f7fe6aa0951ee984800f3e339c0c54f4a4e862",
         "type": "github"
       },
       "original": {
         "owner": "rustshop",
         "repo": "flakebox",
-        "rev": "ead24017440df8c5fd75cdb04c16d13c7d6fa50d",
+        "rev": "47f7fe6aa0951ee984800f3e339c0c54f4a4e862",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1718835956,
-        "narHash": "sha256-wM9v2yIxClRYsGHut5vHICZTK7xdrUGfrLkXvSuv6s4=",
+        "lastModified": 1744440957,
+        "narHash": "sha256-FHlSkNqFmPxPJvy+6fNLaNeWnF1lZSgqVCl/eWaJRc4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "dd457de7e08c6d06789b1f5b88fc9327f4d96309",
+        "rev": "26d499fc9f1d567283d5d56fcf367edd815dba1d",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-24.05",
+        "ref": "nixos-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -215,11 +190,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1717583671,
-        "narHash": "sha256-+lRAmz92CNUxorqWusgJbL9VE1eKCnQQojglRemzwkw=",
+        "lastModified": 1744878314,
+        "narHash": "sha256-iPHZkar3ebiF0rT6VLorSXIQCG7kAOmAsfuTahCzgS8=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "48bbdd6a74f3176987d5c809894ac33957000d19",
+        "rev": "ed737b545e8db5d9c78fcaba73baed0f34e5b3f8",
         "type": "github"
       },
       "original": {
@@ -260,21 +235,6 @@
       }
     },
     "systems_3": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_4": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     flakebox = {
-      url = "github:rustshop/flakebox?rev=ead24017440df8c5fd75cdb04c16d13c7d6fa50d";
+      url = "github:rustshop/flakebox?rev=47f7fe6aa0951ee984800f3e339c0c54f4a4e862";
     };
 
     flake-utils.url = "github:numtide/flake-utils";

--- a/src/code/padding.rs
+++ b/src/code/padding.rs
@@ -15,7 +15,7 @@ impl NumberPadder {
         let number_padding = self.width - line_number_width;
 
         let mut output = String::with_capacity(self.width);
-        output.extend(iter::repeat(' ').take(number_padding));
+        output.extend(iter::repeat_n(' ', number_padding));
         output.push_str(&number.to_string());
         output
     }

--- a/src/export/html.rs
+++ b/src/export/html.rs
@@ -110,7 +110,7 @@ mod test {
         let html_text = HtmlText::new("", &style, FontSize::Pixels(2));
         let style = match &html_text {
             HtmlText::Plain(_) => "",
-            HtmlText::Styled { style, .. } => &style,
+            HtmlText::Styled { style, .. } => style,
         };
         assert_eq!(style, expected_style);
     }

--- a/src/markdown/parse.rs
+++ b/src/markdown/parse.rs
@@ -1062,7 +1062,7 @@ mom
 > hi mom
 > bye **mom**
 ";
-        let MarkdownElement::Alert { lines, .. } = parse_single(&input) else {
+        let MarkdownElement::Alert { lines, .. } = parse_single(input) else {
             panic!("not an alert");
         };
         assert_eq!(lines.len(), 2);

--- a/src/presentation/builder/mod.rs
+++ b/src/presentation/builder/mod.rs
@@ -938,7 +938,7 @@ impl<'a> PresentationBuilder<'a> {
     }
 
     fn push_line_breaks(&mut self, count: usize) {
-        self.chunk_operations.extend(iter::repeat(RenderOperation::RenderLineBreak).take(count));
+        self.chunk_operations.extend(iter::repeat_n(RenderOperation::RenderLineBreak, count));
     }
 
     fn push_code(&mut self, info: String, code: String, source_position: SourcePosition) -> BuildResult {
@@ -1025,7 +1025,7 @@ impl<'a> PresentationBuilder<'a> {
                     margin += 1;
                 }
             }
-            contents.extend(iter::repeat("─").take(*width + margin));
+            contents.extend(iter::repeat_n("─", *width + margin));
             separator.0.push(Text::from(contents));
         }
 
@@ -1439,7 +1439,7 @@ mod test {
             | JumpToBottomRow { .. }
             | InitColumnLayout { .. }
             | EnterColumn { .. }
-            | ExitLayout { .. }
+            | ExitLayout
             | ApplyMargin(_)
             | PopMargin => false,
             RenderText { .. }

--- a/src/terminal/ansi.rs
+++ b/src/terminal/ansi.rs
@@ -225,7 +225,7 @@ mod tests {
     )]
     fn parse_single(#[case] input: &str, #[case] expected: Line) {
         let splitter = AnsiSplitter::new(Default::default());
-        let (lines, _) = splitter.split_lines(&[input]);
+        let (lines, _) = splitter.split_lines([input]);
         assert_eq!(lines, vec![expected.into()]);
     }
 
@@ -268,7 +268,7 @@ mod tests {
             .fg_color(Color::Red)
             .bg_color(Color::Black);
         let splitter = AnsiSplitter::new(style);
-        let (lines, _) = splitter.split_lines(&[input]);
+        let (lines, _) = splitter.split_lines([input]);
         assert_eq!(lines, vec![expected.into()]);
     }
 }

--- a/src/terminal/image/protocols/ascii.rs
+++ b/src/terminal/image/protocols/ascii.rs
@@ -107,7 +107,7 @@ impl PrintImage for AsciiPrinter {
         let cached_sizes = image.inner.cached_sizes.lock().unwrap();
         let image = cached_sizes.get(&cache_key).expect("scaled image no longer there");
 
-        let default_background = options.background_color.map(Color::from);
+        let default_background = options.background_color;
 
         // Iterate pixel rows in pairs to be able to merge both pixels in a single iteration.
         // Note that may not have a second row if there's an odd number of them.

--- a/src/ui/execution/snippet.rs
+++ b/src/ui/execution/snippet.rs
@@ -145,7 +145,7 @@ impl AsRenderOperations for RunSnippetOperation {
             };
             let block_length =
                 if has_margin { self.block_length.max(inner.max_line_length) } else { inner.max_line_length };
-            let vertical_padding = iter::repeat(" ").take(self.padding.vertical as usize).map(WeightedLine::from);
+            let vertical_padding = iter::repeat_n(" ", self.padding.vertical as usize).map(WeightedLine::from);
             let lines = vertical_padding.clone().chain(inner.output_lines.iter().cloned()).chain(vertical_padding);
             for line in lines {
                 operations.push(RenderOperation::RenderBlockLine(BlockLine {

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -189,7 +189,7 @@ impl ModalBuilder {
         let padding = missing / 2;
         let mut output = " ".repeat(padding);
         output.push_str(&text);
-        output.extend(iter::repeat(' ').take(padding));
+        output.extend(iter::repeat_n(' ', padding));
         output
     }
 


### PR DESCRIPTION
Rust 1.82 came out 7 months ago, it's about time to upgrade. This fixes clippy lints that required that version to be used.