### PR TITLE
feat: allow alternative snippet executors for supported langs

### DIFF
--- a/config-file-schema.json
+++ b/config-file-schema.json
@@ -403,8 +403,15 @@
         "filename"
       ],
       "properties": {
+        "alternative": {
+          "description": "Alternative executors for this language.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/SnippetExecutorConfig"
+          }
+        },
         "commands": {
-          "description": "The commands to be run when executing snippets for this programming language.",
+          "description": "The commands to be ran when executing snippets for this programming language.",
           "type": "array",
           "items": {
             "type": "array",
@@ -706,9 +713,6 @@
     },
     "SnippetExecConfig": {
       "type": "object",
-      "required": [
-        "enable"
-      ],
       "properties": {
         "custom": {
           "description": "Custom snippet executors.",
@@ -719,6 +723,7 @@
         },
         "enable": {
           "description": "Whether to enable snippet execution.",
+          "default": false,
           "type": "boolean"
         }
       },
@@ -736,6 +741,38 @@
         }
       },
       "additionalProperties": false
+    },
+    "SnippetExecutorConfig": {
+      "description": "A snippet executor configuration.",
+      "type": "object",
+      "required": [
+        "commands",
+        "filename"
+      ],
+      "properties": {
+        "commands": {
+          "description": "The commands to be ran when executing snippets for this programming language.",
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "environment": {
+          "description": "The environment variables to set before invoking every command.",
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "filename": {
+          "description": "The filename to use for the snippet input file.",
+          "type": "string"
+        }
+      }
     },
     "SnippetLanguage": {
       "description": "The language of a code snippet.",

--- a/executors.yaml
+++ b/executors.yaml
@@ -98,6 +98,11 @@ rust:
     - ["rustc", "--crate-name", "presenterm_snippet", "$pwd/snippet.rs", "-o", "$pwd/snippet", "--color", "always"]
     - ["$pwd/snippet"]
   hidden_line_prefix: "# "
+  alternative:
+    rust-script:
+      filename: snippet.rs
+      commands:
+        - ["rust-script", "--debug", "$pwd/snippet.rs"]
 sh:
   filename: script.sh
   commands:

--- a/src/config.rs
+++ b/src/config.rs
@@ -242,6 +242,7 @@ pub struct SnippetConfig {
 #[serde(deny_unknown_fields)]
 pub struct SnippetExecConfig {
     /// Whether to enable snippet execution.
+    #[serde(default)]
     pub enable: bool,
 
     /// Custom snippet executors.
@@ -323,6 +324,21 @@ pub(crate) fn default_u16_max() -> u16 {
 #[derive(Clone, Debug, Deserialize)]
 #[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct LanguageSnippetExecutionConfig {
+    #[serde(flatten)]
+    pub executor: SnippetExecutorConfig,
+
+    /// The prefix to use to hide lines visually but still execute them.
+    pub hidden_line_prefix: Option<String>,
+
+    /// Alternative executors for this language.
+    #[serde(default)]
+    pub alternative: HashMap<String, SnippetExecutorConfig>,
+}
+
+/// A snippet executor configuration.
+#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
+pub struct SnippetExecutorConfig {
     /// The filename to use for the snippet input file.
     pub filename: String,
 
@@ -330,11 +346,8 @@ pub struct LanguageSnippetExecutionConfig {
     #[serde(default)]
     pub environment: HashMap<String, String>,
 
-    /// The commands to be run when executing snippets for this programming language.
+    /// The commands to be ran when executing snippets for this programming language.
     pub commands: Vec<Vec<String>>,
-
-    /// The prefix to use to hide lines visually but still execute them.
-    pub hidden_line_prefix: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, ValueEnum)]

--- a/src/presentation/builder/mod.rs
+++ b/src/presentation/builder/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     code::{
-        execute::SnippetExecutor,
+        execute::{SnippetExecutor, UnsupportedExecution},
         highlighting::{HighlightThemeSet, SnippetHighlighter},
         snippet::SnippetLanguage,
     },
@@ -1179,8 +1179,8 @@ pub enum BuildError {
     #[error("third party render failed: {0}")]
     ThirdPartyRender(#[from] ThirdPartyRenderError),
 
-    #[error("language {0:?} does not support execution")]
-    UnsupportedExecution(SnippetLanguage),
+    #[error(transparent)]
+    UnsupportedExecution(#[from] UnsupportedExecution),
 
     #[error(transparent)]
     UndefinedPaletteColor(#[from] UndefinedPaletteColorError),

--- a/src/ui/execution/acquire_terminal.rs
+++ b/src/ui/execution/acquire_terminal.rs
@@ -1,5 +1,5 @@
 use crate::{
-    code::{execute::SnippetExecutor, snippet::Snippet},
+    code::{execute::LanguageSnippetExecutor, snippet::Snippet},
     markdown::elements::{Line, Text},
     render::{
         operation::{AsRenderOperations, Pollable, PollableState, RenderAsync, RenderOperation},
@@ -26,7 +26,7 @@ const MINIMUM_SEPARATOR_WIDTH: u16 = 32;
 pub(crate) struct RunAcquireTerminalSnippet {
     snippet: Snippet,
     block_length: u16,
-    executor: Arc<SnippetExecutor>,
+    executor: LanguageSnippetExecutor,
     colors: ExecutionStatusBlockStyle,
     state: Arc<Mutex<State>>,
     font_size: u8,
@@ -35,7 +35,7 @@ pub(crate) struct RunAcquireTerminalSnippet {
 impl RunAcquireTerminalSnippet {
     pub(crate) fn new(
         snippet: Snippet,
-        executor: Arc<SnippetExecutor>,
+        executor: LanguageSnippetExecutor,
         colors: ExecutionStatusBlockStyle,
         block_length: u16,
         font_size: u8,


### PR DESCRIPTION
This adds support for alternative snippet executors for an already executable language. This allows, for example, executing a rust snippet using something other than the default way of execution (e.g. via `rust-script`).

See executors.yaml changes for config but essentially, a new `alternative` map can be defined under each language that contains the same parameters as the normal executor attribute.

To use alternative executors use the syntax `+exec:<name>` for normal execution, `+exec_replace:<name>` for exec replace and `+acquire_terminal:<name>` for acquire terminal execution type. For example, the following uses rust-script:

~~~markdown
```rust +exec:rust-script
fn foo() { .... }
// ....
```
~~~

Closes #603