### PR TITLE
feat: add support for footnotes

### DIFF
--- a/src/markdown/elements.rs
+++ b/src/markdown/elements.rs
@@ -65,6 +65,9 @@ pub(crate) enum MarkdownElement {
         /// The content lines in this alert.
         lines: Vec<Line<RawColor>>,
     },
+
+    /// A footnote definition.
+    Footnote(Line<RawColor>),
 }
 
 #[derive(Clone, Copy, Debug, Default)]

--- a/src/presentation/builder/mod.rs
+++ b/src/presentation/builder/mod.rs
@@ -311,6 +311,10 @@ impl<'a> PresentationBuilder<'a> {
                 self.push_image_from_path(path, title, source_position)?
             }
             MarkdownElement::Alert { alert_type, title, lines } => self.push_alert(alert_type, title, lines)?,
+            MarkdownElement::Footnote(line) => {
+                let line = line.resolve(&self.theme.palette)?;
+                self.push_text(line, ElementType::Paragraph);
+            }
         };
         if should_clear_last {
             self.slide_state.last_element = LastElement::Other;
@@ -2045,5 +2049,13 @@ language: rust"
             source_position: Default::default(),
         }];
         build_presentation(elements);
+    }
+
+    #[test]
+    fn footnote() {
+        let elements = vec![MarkdownElement::Footnote(Line::from("hi")), MarkdownElement::Footnote(Line::from("bye"))];
+        let slides = build_presentation(elements).into_slides();
+        let text = extract_slide_text_lines(slides.into_iter().next().unwrap());
+        assert_eq!(text, &["hi", "bye"]);
     }
 }


### PR DESCRIPTION
This adds support for markdown footnotes. Footnotes are written where they show up, as is. Example:

```
foo![^1] and bar[^2]

[^1]: hi
[^2]: bye
```

![image](https://github.com/user-attachments/assets/587d3d5f-4831-42bc-823f-39c4f831b928)

Closes #604 

PS: this requires the kitty font size protocol. In another PR I'll add something to use unicode half characters as fallback where possible.
