### PR TITLE
feat: allow configuring number of newlines in between list items

### DIFF
--- a/config-file-schema.json
+++ b/config-file-schema.json
@@ -551,6 +551,15 @@
             "null"
           ]
         },
+        "list_item_newlines": {
+          "description": "The number of newlines in between list items.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint8",
+          "minimum": 1.0
+        },
         "strict_front_matter_parsing": {
           "description": "Whether to be strict about parsing the presentation's front matter.",
           "type": [

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,7 @@ use std::{
     collections::{BTreeMap, HashMap},
     fs, io,
     net::{IpAddr, Ipv4Addr, SocketAddr},
+    num::NonZeroU8,
     path::{Path, PathBuf},
 };
 
@@ -208,6 +209,9 @@ pub struct OptionsConfig {
 
     /// Show all lists incrementally, by implicitly adding pauses in between elements.
     pub incremental_lists: Option<bool>,
+
+    /// The number of newlines in between list items.
+    pub list_item_newlines: Option<NonZeroU8>,
 
     /// Whether to treat a thematic break as a slide end.
     pub end_slide_shorthand: Option<bool>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -289,6 +289,7 @@ impl CoreComponents {
             pause_before_incremental_lists: config.defaults.incremental_lists.pause_before.unwrap_or(true),
             pause_after_incremental_lists: config.defaults.incremental_lists.pause_after.unwrap_or(true),
             pause_create_new_slide: false,
+            list_item_newlines: config.options.list_item_newlines.map(Into::into).unwrap_or(1),
         }
     }
 


### PR DESCRIPTION
This adds a new comment command `list_item_newlines` which is also configurable via `options.list_item_newlines` in the config file/presentation front matter. This option allows configuring the number of newlines in between list items (defaults to 1):

```markdown
* hi
    * inner
* bye

---

<!-- list_item_newlines: 2 -->

* hi
    * inner
* bye
```

![image](https://github.com/user-attachments/assets/fed1e5ef-dcb9-4a1b-b897-e85dc6577675)

Closes #626
