### PR TITLE
feat: allow validating snippets

### DIFF
--- a/config-file-schema.json
+++ b/config-file-schema.json
@@ -716,6 +716,11 @@
               "$ref": "#/definitions/SnippetRenderConfig"
             }
           ]
+        },
+        "validate": {
+          "description": "Whether to validate snippets.",
+          "default": false,
+          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/src/config.rs
+++ b/src/config.rs
@@ -239,6 +239,10 @@ pub struct SnippetConfig {
     /// The properties for snippet auto rendering.
     #[serde(default)]
     pub render: SnippetRenderConfig,
+
+    /// Whether to validate snippets.
+    #[serde(default)]
+    pub validate: bool,
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,6 +135,10 @@ struct Cli {
     /// Whether to listen for speaker notes.
     #[clap(short, long, group = "speaker-notes")]
     listen_speaker_notes: bool,
+
+    /// Whether to validate snippets.
+    #[clap(long)]
+    validate_snippets: bool,
 }
 
 fn create_splash() -> String {
@@ -290,6 +294,7 @@ impl CoreComponents {
             pause_after_incremental_lists: config.defaults.incremental_lists.pause_after.unwrap_or(true),
             pause_create_new_slide: false,
             list_item_newlines: config.options.list_item_newlines.map(Into::into).unwrap_or(1),
+            validate_snippets: config.snippet.validate,
         }
     }
 
@@ -406,6 +411,9 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
     let parser = MarkdownParser::new(&arena);
     let validate_overflows =
         overflow_validation_enabled(&present_mode, &config.defaults.validate_overflows) || cli.validate_overflows;
+    if cli.validate_snippets {
+        builder_options.validate_snippets = cli.validate_snippets;
+    }
     if cli.export_pdf || cli.export_html {
         let dimensions = match config.export.dimensions {
             Some(dimensions) => WindowSize {

--- a/src/presentation/builder/mod.rs
+++ b/src/presentation/builder/mod.rs
@@ -75,6 +75,7 @@ pub struct PresentationBuilderOptions {
     pub pause_after_incremental_lists: bool,
     pub pause_create_new_slide: bool,
     pub list_item_newlines: u8,
+    pub validate_snippets: bool,
 }
 
 impl PresentationBuilderOptions {
@@ -120,6 +121,7 @@ impl Default for PresentationBuilderOptions {
             pause_after_incremental_lists: true,
             pause_create_new_slide: false,
             list_item_newlines: 1,
+            validate_snippets: false,
         }
     }
 }

--- a/src/ui/execution/mod.rs
+++ b/src/ui/execution/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod acquire_terminal;
 pub(crate) mod disabled;
 pub(crate) mod image;
 pub(crate) mod snippet;
+pub(crate) mod validator;
 
 pub(crate) use acquire_terminal::RunAcquireTerminalSnippet;
 pub(crate) use disabled::SnippetExecutionDisabledOperation;

--- a/src/ui/execution/validator.rs
+++ b/src/ui/execution/validator.rs
@@ -1,0 +1,171 @@
+use crate::{
+    code::{
+        execute::{ExecutionHandle, LanguageSnippetExecutor, ProcessStatus},
+        snippet::{ExpectedSnippetExecutionResult, Snippet},
+    },
+    render::operation::{
+        AsRenderOperations, Pollable, PollableState, RenderAsync, RenderAsyncStartPolicy, RenderOperation,
+    },
+};
+use std::{
+    mem,
+    ops::DerefMut,
+    sync::{Arc, Mutex},
+};
+
+#[derive(Debug)]
+pub(crate) struct ValidateSnippetOperation {
+    snippet: Snippet,
+    executor: LanguageSnippetExecutor,
+    state: Arc<Mutex<State>>,
+}
+
+impl ValidateSnippetOperation {
+    pub(crate) fn new(snippet: Snippet, executor: LanguageSnippetExecutor) -> Self {
+        Self { snippet, executor, state: Default::default() }
+    }
+}
+
+impl AsRenderOperations for ValidateSnippetOperation {
+    fn as_render_operations(&self, _dimensions: &crate::WindowSize) -> Vec<RenderOperation> {
+        vec![]
+    }
+}
+
+impl RenderAsync for ValidateSnippetOperation {
+    fn pollable(&self) -> Box<dyn Pollable> {
+        Box::new(OperationPollable {
+            snippet: self.snippet.clone(),
+            executor: self.executor.clone(),
+            state: self.state.clone(),
+        })
+    }
+
+    fn start_policy(&self) -> RenderAsyncStartPolicy {
+        RenderAsyncStartPolicy::Automatic
+    }
+}
+
+#[derive(Debug, Default)]
+enum State {
+    #[default]
+    Initial,
+    Running(ExecutionHandle),
+    Done(PollableState),
+}
+
+struct OperationPollable {
+    snippet: Snippet,
+    executor: LanguageSnippetExecutor,
+    state: Arc<Mutex<State>>,
+}
+
+impl OperationPollable {
+    fn success_to_pollable_state(&self) -> PollableState {
+        match self.snippet.attributes.expected_execution_result {
+            ExpectedSnippetExecutionResult::Success => PollableState::Done,
+            ExpectedSnippetExecutionResult::Failure => {
+                PollableState::Failed { error: "expected snippet to fail but it succeeded".into() }
+            }
+        }
+    }
+
+    fn error_to_pollable_state<S: Into<String>>(&self, error: S) -> PollableState {
+        match self.snippet.attributes.expected_execution_result {
+            ExpectedSnippetExecutionResult::Success => PollableState::Failed { error: error.into() },
+            ExpectedSnippetExecutionResult::Failure => PollableState::Done,
+        }
+    }
+}
+
+impl Pollable for OperationPollable {
+    fn poll(&mut self) -> PollableState {
+        let mut state = self.state.lock().expect("lock poisoned");
+        let next_state = match mem::take(state.deref_mut()) {
+            State::Initial => match self.executor.execute_async(&self.snippet) {
+                Ok(handle) => State::Running(handle),
+                Err(e) => State::Done(self.error_to_pollable_state(e.to_string())),
+            },
+            State::Running(handle) => {
+                let state = handle.state.lock().expect("lock poisoned");
+                match state.status {
+                    ProcessStatus::Running => {
+                        drop(state);
+                        State::Running(handle)
+                    }
+                    ProcessStatus::Success => State::Done(self.success_to_pollable_state()),
+                    ProcessStatus::Failure => {
+                        State::Done(self.error_to_pollable_state(String::from_utf8_lossy(&state.output)))
+                    }
+                }
+            }
+            State::Done(output) => State::Done(output),
+        };
+        *state = next_state;
+        match &*state {
+            State::Initial | State::Running(_) => PollableState::Unmodified,
+            State::Done(output) => output.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::code::{
+        execute::SnippetExecutor,
+        snippet::{SnippetAttributes, SnippetLanguage},
+    };
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::success("fn main() { println!(\"hi\"); }", ExpectedSnippetExecutionResult::Success)]
+    #[case::failure("fn main() ", ExpectedSnippetExecutionResult::Failure)]
+    fn expectation_matches(#[case] contents: &str, #[case] expected_execution_result: ExpectedSnippetExecutionResult) {
+        let snippet = Snippet {
+            contents: contents.into(),
+            language: SnippetLanguage::Rust,
+            attributes: SnippetAttributes { expected_execution_result, ..Default::default() },
+        };
+        let executor = SnippetExecutor::default().language_executor(&snippet.language, &Default::default()).unwrap();
+        let state = Arc::new(Mutex::new(State::default()));
+        let mut pollable =
+            OperationPollable { snippet: snippet.clone(), executor: executor.clone(), state: state.clone() };
+        loop {
+            match pollable.poll() {
+                PollableState::Unmodified | PollableState::Modified => continue,
+                PollableState::Done => break,
+                PollableState::Failed { error } => panic!("finished with error: {error}"),
+            }
+        }
+        let mut pollable = OperationPollable { snippet, executor, state: state.clone() };
+        assert!(matches!(pollable.poll(), PollableState::Done), "different pollable returned different");
+    }
+
+    #[rstest]
+    #[case::success("fn main() { println!(\"hi\"); }", ExpectedSnippetExecutionResult::Failure)]
+    #[case::failure("fn main() ", ExpectedSnippetExecutionResult::Success)]
+    fn expect_does_not_match(
+        #[case] contents: &str,
+        #[case] expected_execution_result: ExpectedSnippetExecutionResult,
+    ) {
+        let snippet = Snippet {
+            contents: contents.into(),
+            language: SnippetLanguage::Rust,
+            attributes: SnippetAttributes { expected_execution_result, ..Default::default() },
+        };
+        let executor = SnippetExecutor::default().language_executor(&snippet.language, &Default::default()).unwrap();
+        let state = Arc::new(Mutex::new(State::default()));
+        let mut pollable =
+            OperationPollable { snippet: snippet.clone(), executor: executor.clone(), state: state.clone() };
+        loop {
+            match pollable.poll() {
+                PollableState::Unmodified | PollableState::Modified => continue,
+                PollableState::Done => panic!("finished successfully"),
+                PollableState::Failed { .. } => break,
+            }
+        }
+        let mut pollable = OperationPollable { snippet, executor, state: state.clone() };
+        assert!(matches!(pollable.poll(), PollableState::Failed { .. }), "different pollable returned different");
+    }
+}


### PR DESCRIPTION
This adds a `--validate-snippets` cli arg and a config option `snippets.validate` that allow configuring whether snippets should be validated. This causes presenterm to execute snippets on load and every time the presentation is modified, and ensure the snippet execution returns a 0 status code. The snippets can also now contain a `+validate:fail` or `+validate:failure` that indicate the expected validation output should be an error. e.g. if you expect a snippet to fail because it contains a syntax error, you can use this to annotate it accordingly and ensure it fails.

Note that this isn't done for `+acquire_terminal` snippets because they'd otherwise take over the terminal.

[![asciicast](https://asciinema.org/a/URm4c8QhLAnnoxKc218fN6FyY.svg)](https://asciinema.org/a/URm4c8QhLAnnoxKc218fN6FyY)

Closes #634