### PR TITLE
feat: center runtime errors

### DIFF
--- a/src/markdown/text.rs
+++ b/src/markdown/text.rs
@@ -2,7 +2,7 @@ use super::{
     elements::{Line, Text},
     text_style::TextStyle,
 };
-use std::mem;
+use std::{fmt, mem};
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 /// A weighted line of text.
@@ -90,7 +90,7 @@ struct CharAccumulator {
 }
 
 /// A piece of weighted text.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub(crate) struct WeightedText {
     text: Text,
     accumulators: Vec<CharAccumulator>,
@@ -128,6 +128,12 @@ impl From<Text> for WeightedText {
         }
         accumulators.push(CharAccumulator { width, bytes });
         Self { text, accumulators }
+    }
+}
+
+impl fmt::Debug for WeightedText {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WeightedText").field("text", &self.text).finish()
     }
 }
 

--- a/src/terminal/ansi.rs
+++ b/src/terminal/ansi.rs
@@ -6,16 +6,16 @@ use crate::markdown::{
 use std::mem;
 use vte::{ParamsIter, Parser, Perform};
 
-pub(crate) struct AnsiSplitter {
+pub(crate) struct AnsiParser {
     starting_style: TextStyle,
 }
 
-impl AnsiSplitter {
+impl AnsiParser {
     pub(crate) fn new(current_style: TextStyle) -> Self {
         Self { starting_style: current_style }
     }
 
-    pub(crate) fn split_lines<I, S>(self, lines: I) -> (Vec<WeightedLine>, TextStyle)
+    pub(crate) fn parse_lines<I, S>(self, lines: I) -> (Vec<WeightedLine>, TextStyle)
     where
         I: IntoIterator<Item = S>,
         S: AsRef<str>,
@@ -224,8 +224,8 @@ mod tests {
         Line::from(Text::new("hi", TextStyle::default().bold()))
     )]
     fn parse_single(#[case] input: &str, #[case] expected: Line) {
-        let splitter = AnsiSplitter::new(Default::default());
-        let (lines, _) = splitter.split_lines([input]);
+        let splitter = AnsiParser::new(Default::default());
+        let (lines, _) = splitter.parse_lines([input]);
         assert_eq!(lines, vec![expected.into()]);
     }
 
@@ -267,8 +267,8 @@ mod tests {
             .strikethrough()
             .fg_color(Color::Red)
             .bg_color(Color::Black);
-        let splitter = AnsiSplitter::new(style);
-        let (lines, _) = splitter.split_lines([input]);
+        let splitter = AnsiParser::new(style);
+        let (lines, _) = splitter.parse_lines([input]);
         assert_eq!(lines, vec![expected.into()]);
     }
 }

--- a/src/ui/execution/snippet.rs
+++ b/src/ui/execution/snippet.rs
@@ -15,7 +15,7 @@ use crate::{
         },
         properties::WindowSize,
     },
-    terminal::ansi::AnsiSplitter,
+    terminal::ansi::AnsiParser,
     theme::{Alignment, ExecutionOutputBlockStyle, ExecutionStatusBlockStyle, PaddingRect},
     ui::separator::{RenderSeparator, SeparatorWidth},
 };
@@ -232,7 +232,7 @@ impl Pollable for OperationPollable {
         drop(state);
 
         let mut max_line_length = 0;
-        let (lines, _) = AnsiSplitter::new(self.style).split_lines(&lines);
+        let (lines, _) = AnsiParser::new(self.style).parse_lines(&lines);
         for line in &lines {
             let width = u16::try_from(line.width()).unwrap_or(u16::MAX);
             max_line_length = max_line_length.max(width);


### PR DESCRIPTION
Before this change we were applying a 25% horizontal margin to all runtime errors (e.g. image doesn't exist), which caused errors to look bad, especially if the terminal size was small. This instead centers them which makes them look a lot better.