### PR TITLE
feat: add `rust-script-pedantic` executor for rust

### DIFF
--- a/executors.yaml
+++ b/executors.yaml
@@ -103,6 +103,12 @@ rust:
       filename: snippet.rs
       commands:
         - ["rust-script", "--debug", "$pwd/snippet.rs"]
+    rust-script-pedantic:
+      filename: snippet.rs
+      environment:
+        RUSTFLAGS: "--deny warnings"
+      commands:
+        - ["rust-script", "--debug", "$pwd/snippet.rs"]
 sh:
   filename: script.sh
   commands:


### PR DESCRIPTION
This adds a new `rust-script-pedantic` alternative executor for rust. This is the same as `rust-script` but it passes `--deny warnings` to `rust-script` so any warnings are considered errors. This is useful when using `--validate-snippets` so you know there's no warnings nor errors in the snippets.

Relates to #639