### PR TITLE
feat: allow validating snippets without executing them in presentation

### DIFF
--- a/src/presentation/builder/snippet.rs
+++ b/src/presentation/builder/snippet.rs
@@ -138,6 +138,11 @@ impl<'a> SnippetProcessor<'a> {
                 self.push_code_execution(snippet, block_length, ExecutionMode::AlongSnippet, &spec)
             }
             SnippetExec::AcquireTerminal(spec) => self.push_acquire_terminal_execution(snippet, block_length, &spec),
+            SnippetExec::Validate(spec) => {
+                let executor = self.snippet_executor.language_executor(&snippet.language, &spec)?;
+                self.push_validator(&snippet, &executor);
+                Ok(())
+            }
         }
     }
 


### PR DESCRIPTION
This adds a `+validate` (also `+validate:<executor>`) that allows indicating that the snippet should be validated. This causes `--validate-snippets` to validate any snippet that's either `+exec` or `+exec_replace` or `+validate`.

This renames the `+validate` created in #637 that allows specifying whether the snippet should succeed or fail into `+expect`. e.g. `+expect:failure` means "this snippet should fail when being validated".

Closes #643