### PR TITLE
Add a note to export pdf using `uv`

### DIFF
--- a/docs/src/features/exports.md
+++ b/docs/src/features/exports.md
@@ -26,6 +26,12 @@ want the output file to be written to.
 > If you're using a separate virtual env to install _weasyprint_ just make sure you activate it before running 
 > _presenterm_ with the `--export-pdf` parameter.
 
+> [!note]
+> If you have [uv](https://github.com/astral-sh/uv) installed you can simply run: 
+> ```bash
+> uv run --with weasyprint presenterm --export-pdf examples/demo.md
+> ```
+
 ## HTML
 
 Similarly, using the `--export-html` parameter allows generating a single self contained HTML file that contains all 


### PR DESCRIPTION
[uv](https://github.com/astral-sh/uv) is a cool project also made in rust where you can run command with a python dependency without the need of a `pyproject.toml` (see https://docs.astral.sh/uv/guides/scripts/#running-a-script-with-dependencies)

Add a note for exporting pdf using it