### PR TITLE
chore: allow presentation builder to take markdown as input

### DIFF
--- a/src/demo.rs
+++ b/src/demo.rs
@@ -111,6 +111,8 @@ impl ThemesDemo {
         };
         let executer = Arc::new(SnippetExecutor::default());
         let bindings_config = Default::default();
+        let arena = Default::default();
+        let parser = MarkdownParser::new(&arena);
         let builder = PresentationBuilder::new(
             theme,
             resources,
@@ -119,11 +121,12 @@ impl ThemesDemo {
             &self.themes,
             image_registry,
             bindings_config,
+            &parser,
             options,
         )?;
         let mut elements = vec![MarkdownElement::SetexHeading { text: format!("theme: {theme_name}").into() }];
         elements.extend(base_elements.iter().cloned());
-        builder.build(elements)
+        builder.build_from_parsed(elements)
     }
 }
 

--- a/src/export/exporter.rs
+++ b/src/export/exporter.rs
@@ -117,7 +117,6 @@ impl<'a> Exporter<'a> {
         renderer: OutputFormat,
     ) -> Result<ExportRenderer, ExportError> {
         let content = fs::read_to_string(presentation_path).map_err(ExportError::ReadPresentation)?;
-        let elements = self.parser.parse(&content)?;
 
         let mut presentation = PresentationBuilder::new(
             self.default_theme,
@@ -127,9 +126,10 @@ impl<'a> Exporter<'a> {
             &self.themes,
             Default::default(),
             KeyBindingsConfig::default(),
+            &self.parser,
             self.options.clone(),
         )?
-        .build(elements)?;
+        .build(&content)?;
         Self::validate_theme_colors(&presentation)?;
 
         let mut render = ExportRenderer::new(self.dimensions.clone(), output_directory, renderer);

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -414,7 +414,6 @@ impl<'a> Presenter<'a> {
 
     fn load_presentation(&mut self, path: &Path) -> Result<Presentation, LoadPresentationError> {
         let content = fs::read_to_string(path).map_err(LoadPresentationError::Reading)?;
-        let elements = self.parser.parse(&content)?;
         let presentation = PresentationBuilder::new(
             self.default_theme,
             self.resources.clone(),
@@ -423,9 +422,10 @@ impl<'a> Presenter<'a> {
             &self.themes,
             ImageRegistry::new(self.image_printer.clone()),
             self.options.bindings.clone(),
+            &self.parser,
             self.options.builder_options.clone(),
         )?
-        .build(elements)?;
+        .build(&content)?;
         Ok(presentation)
     }
 


### PR DESCRIPTION
This paves the way for #552 to be implemented. Essentially the presentation builder now takes markdown, which allows it to parse it and in the future parse other markdown chunks loaded from other files without having a weird mixed API. 

As part of this all builder tests were changed to take markdown as input, which makes them much more concise.