### PR TITLE
feat: add `include` comment command to import markdown files

### DIFF
--- a/src/presentation/builder/snippet.rs
+++ b/src/presentation/builder/snippet.rs
@@ -16,7 +16,7 @@ use crate::{
         operation::{AsRenderOperations, RenderAsyncStartPolicy, RenderOperation},
         properties::WindowSize,
     },
-    resource::Resources,
+    resource::{ResourceBasePath, Resources},
     theme::{Alignment, CodeBlockStyle, PresentationTheme},
     third_party::{ThirdPartyRender, ThirdPartyRenderRequest},
     ui::execution::{
@@ -36,6 +36,7 @@ pub(crate) struct SnippetProcessorState<'a> {
     pub(crate) highlighter: &'a SnippetHighlighter,
     pub(crate) options: &'a PresentationBuilderOptions,
     pub(crate) font_size: u8,
+    pub(crate) resource_base_path: ResourceBasePath,
 }
 
 pub(crate) struct SnippetProcessor<'a> {
@@ -49,6 +50,7 @@ pub(crate) struct SnippetProcessor<'a> {
     highlighter: &'a SnippetHighlighter,
     options: &'a PresentationBuilderOptions,
     font_size: u8,
+    resource_base_path: ResourceBasePath,
 }
 
 impl<'a> SnippetProcessor<'a> {
@@ -62,6 +64,7 @@ impl<'a> SnippetProcessor<'a> {
             highlighter,
             options,
             font_size,
+            resource_base_path,
         } = state;
         Self {
             operations: Vec::new(),
@@ -74,6 +77,7 @@ impl<'a> SnippetProcessor<'a> {
             highlighter,
             options,
             font_size,
+            resource_base_path,
         }
     }
 
@@ -179,9 +183,8 @@ impl<'a> SnippetProcessor<'a> {
             .map_err(|e| BuildError::InvalidSnippet { source_position, error: e.to_string() })?;
         let path = file.path;
         let path_display = path.display();
-        let contents = self.resources.external_snippet(&path).map_err(|e| BuildError::InvalidSnippet {
-            source_position,
-            error: format!("failed to load {path_display}: {e}"),
+        let contents = self.resources.external_text_file(&path, &self.resource_base_path).map_err(|e| {
+            BuildError::InvalidSnippet { source_position, error: format!("failed to load {path_display}: {e}") }
         })?;
         code.language = file.language;
         code.contents = Self::filter_lines(contents, file.start_line, file.end_line);


### PR DESCRIPTION
This adds a new `include` comment command that allows including an external markdown file. The file is included as-is and mostly parsed as if it were part of the original markdown.

Example:

~~~markdown
hi

<!-- include: other.md -->
~~~

other.md:

~~~markdown
bye
~~~

The result will be a single slide that contains "hi" and "bye" each in a new line.

Notes:

* The file is parsed separately so no parsing state is shared between them. e.g. if you have an import like the following, where `other.md` contains the closing backticks, it won't work:

  ~~~markdown
  ```
  <!-- include: other.md -->
  ~~~
* Errors are still not adapted to this multi markdown mode. That is, now if you have an error on some markdown file you'll see "error at 5:1" but you won't know the filename. This will be fixed separately in another PR that will come in soon (no energy left today sorry).
* Reloading in certain cases can be a bit strange when using external files. e.g. if your main markdown imports a.md successfully, but then you go and delete a.md, this will error (as expected), but if you add it back it won't automatically reload. You will need to modify the main markdown or any other watched resource for the presentation to reload. This may be addressed in another PR.

Closes #552. Better errors will come in another PR but this is usable as it is.