### PR TITLE
feat: allow specifying where snippet output will go

### DIFF
--- a/src/code/snippet.rs
+++ b/src/code/snippet.rs
@@ -246,6 +246,9 @@ impl SnippetParser {
                     attributes.representation = SnippetRepr::ExecReplace;
                     attributes.execution = SnippetExec::Exec(spec);
                 }
+                Id(id) => {
+                    attributes.id = Some(id);
+                }
                 Validate(spec) => {
                     if matches!(attributes.execution, SnippetExec::None) {
                         attributes.execution = SnippetExec::Validate(spec);
@@ -294,6 +297,7 @@ impl SnippetParser {
                             "exec_replace" => {
                                 SnippetAttribute::ExecReplace(SnippetExecutorSpec::Alternative(parameter.to_string()))
                             }
+                            "id" => SnippetAttribute::Id(parameter.to_string()),
                             "validate" => {
                                 SnippetAttribute::Validate(SnippetExecutorSpec::Alternative(parameter.to_string()))
                             }
@@ -430,6 +434,7 @@ enum SnippetAttribute {
     NoBackground,
     AcquireTerminal(SnippetExecutorSpec),
     ExpectedExecutionResult(ExpectedSnippetExecutionResult),
+    Id(String),
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -662,6 +667,9 @@ pub(crate) struct SnippetAttributes {
 
     /// The expected execution result for a snippet.
     pub(crate) expected_execution_result: ExpectedSnippetExecutionResult,
+
+    /// The identifier for a snippet.
+    pub(crate) id: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]

--- a/src/presentation/builder/comment.rs
+++ b/src/presentation/builder/comment.rs
@@ -103,6 +103,13 @@ impl PresentationBuilder<'_, '_> {
                 self.process_include(path, source_position)?;
                 return Ok(());
             }
+            CommentCommand::SnippetOutput(id) => {
+                let handle = self.executable_snippets.get(&id).cloned().ok_or_else(|| {
+                    self.invalid_presentation(source_position, InvalidPresentation::UndefinedSnippetId(id))
+                })?;
+                self.push_detached_code_execution(handle)?;
+                return Ok(());
+            }
         };
         // Don't push line breaks for any comments.
         self.slide_state.ignore_element_line_break = true;
@@ -189,6 +196,7 @@ enum CommentCommand {
     ResetLayout,
     SkipSlide,
     SpeakerNote(String),
+    SnippetOutput(String),
 }
 
 impl FromStr for CommentCommand {

--- a/src/presentation/builder/error.rs
+++ b/src/presentation/builder/error.rs
@@ -98,6 +98,15 @@ pub(crate) enum InvalidPresentation {
 
     #[error("font sizes must be >= 1 and <= 7")]
     InvalidFontSize,
+
+    #[error("snippet id '{0}' not defined")]
+    UndefinedSnippetId(String),
+
+    #[error("snippet identifiers can only be used in +exec blocks")]
+    SnippetIdNonExec,
+
+    #[error("snippet id '{0}' already exists")]
+    SnippetAlreadyExists(String),
 }
 
 #[derive(Debug)]

--- a/src/presentation/builder/mod.rs
+++ b/src/presentation/builder/mod.rs
@@ -31,6 +31,7 @@ use crate::{
     },
     third_party::ThirdPartyRender,
     ui::{
+        execution::snippet::SnippetHandle,
         footer::{FooterGenerator, FooterVariables},
         modals::{IndexBuilder, KeyBindingsModalBuilder},
         separator::RenderSeparator,
@@ -38,7 +39,13 @@ use crate::{
 };
 use comrak::Arena;
 use image::DynamicImage;
-use std::{collections::HashSet, fs, io, iter, mem, path::Path, rc::Rc, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    fs, io, iter, mem,
+    path::Path,
+    rc::Rc,
+    sync::Arc,
+};
 
 pub(crate) mod error;
 
@@ -158,6 +165,7 @@ pub(crate) struct PresentationBuilder<'a, 'b> {
     bindings_config: KeyBindingsConfig,
     slides_without_footer: HashSet<usize>,
     markdown_parser: &'a MarkdownParser<'b>,
+    executable_snippets: HashMap<String, SnippetHandle>,
     sources: MarkdownSources,
     options: PresentationBuilderOptions,
 }
@@ -198,6 +206,7 @@ impl<'a, 'b> PresentationBuilder<'a, 'b> {
             slides_without_footer: HashSet::new(),
             markdown_parser,
             sources: Default::default(),
+            executable_snippets: Default::default(),
             options,
         })
     }

--- a/src/presentation/builder/tests.rs
+++ b/src/presentation/builder/tests.rs
@@ -667,7 +667,7 @@ hi
     for operation in slide.iter_visible_operations() {
         if let RenderOperation::RenderAsync(operation) = operation {
             let operation = format!("{operation:?}");
-            if operation.contains("RunSnippetOperation") {
+            if operation.contains("RunSnippetTrigger") {
                 assert!(enabled);
                 found_render_block = true;
             } else if operation.contains("SnippetExecutionDisabledOperation") {

--- a/src/render/engine.rs
+++ b/src/render/engine.rs
@@ -5,7 +5,6 @@ use crate::{
     config::{MaxColumnsAlignment, MaxRowsAlignment},
     markdown::{text::WeightedLine, text_style::Colors},
     render::{
-        layout::Positioning,
         operation::{
             AsRenderOperations, BlockLine, ImageRenderProperties, ImageSize, MarginProperties, RenderAsync,
             RenderOperation,
@@ -327,14 +326,12 @@ where
         let layout = self.build_layout(*alignment).with_font_size(text.font_size());
 
         let dimensions = self.current_dimensions();
-        let Positioning { max_line_length, start_column } = layout.compute(dimensions, *block_length);
-        if self.options.validate_overflows && text.width() as u16 > max_line_length {
+        let positioning = layout.compute(dimensions, *block_length);
+        if self.options.validate_overflows && text.width() as u16 > positioning.max_line_length {
             return Err(RenderError::HorizontalOverflow);
         }
 
-        self.terminal.execute(&TerminalCommand::MoveToColumn(start_column))?;
-
-        let positioning = Positioning { max_line_length, start_column };
+        self.terminal.execute(&TerminalCommand::MoveToColumn(positioning.start_column))?;
         let text_drawer =
             TextDrawer::new(prefix, *right_padding_length, text, positioning, &self.colors, MINIMUM_LINE_LENGTH)?
                 .with_surrounding_block(*block_color)

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -68,6 +68,7 @@ impl TerminalDrawer {
 
     pub(crate) fn render_error(&mut self, message: &str, source: &ErrorSource) -> RenderResult {
         let (lines, _) = AnsiParser::new(Default::default()).parse_lines(message.lines());
+        let lines = lines.into_iter().map(Into::into).collect();
         let operation = RenderErrorOperation { lines, source: source.clone() };
         let operation = RenderOperation::RenderDynamic(Rc::new(operation));
         let dimensions = WindowSize::current(self.options.font_size_fallback)?;

--- a/src/render/text.rs
+++ b/src/render/text.rs
@@ -36,29 +36,28 @@ impl<'a> TextDrawer<'a> {
         let text_length = (line.width() + prefix.width() + right_padding_length as usize) as u16;
         // If our line doesn't fit and it's just too small then abort
         if text_length > positioning.max_line_length && positioning.max_line_length <= minimum_line_length {
-            Err(RenderError::TerminalTooSmall)
-        } else {
-            let prefix_width = prefix.width() as u16;
-            let positioning = Positioning {
-                max_line_length: positioning
-                    .max_line_length
-                    .saturating_sub(prefix_width)
-                    .saturating_sub(right_padding_length),
-                start_column: positioning.start_column,
-            };
-            Ok(Self {
-                prefix,
-                right_padding_length,
-                line,
-                positioning,
-                prefix_width,
-                default_colors,
-                draw_block: false,
-                block_color: None,
-                repeat_prefix: false,
-                center_newlines: false,
-            })
+            return Err(RenderError::TerminalTooSmall);
         }
+        let prefix_width = prefix.width() as u16;
+        let positioning = Positioning {
+            max_line_length: positioning
+                .max_line_length
+                .saturating_sub(prefix_width)
+                .saturating_sub(right_padding_length),
+            start_column: positioning.start_column,
+        };
+        Ok(Self {
+            prefix,
+            right_padding_length,
+            line,
+            positioning,
+            prefix_width,
+            default_colors,
+            draw_block: false,
+            block_color: None,
+            repeat_prefix: false,
+            center_newlines: false,
+        })
     }
 
     pub(crate) fn with_surrounding_block(mut self, block_color: Option<Color>) -> Self {

--- a/src/terminal/ansi.rs
+++ b/src/terminal/ansi.rs
@@ -1,6 +1,5 @@
 use crate::markdown::{
     elements::{Line, Text},
-    text::WeightedLine,
     text_style::{Color, TextStyle},
 };
 use std::mem;
@@ -15,7 +14,7 @@ impl AnsiParser {
         Self { starting_style: current_style }
     }
 
-    pub(crate) fn parse_lines<I, S>(self, lines: I) -> (Vec<WeightedLine>, TextStyle)
+    pub(crate) fn parse_lines<I, S>(self, lines: I) -> (Vec<Line>, TextStyle)
     where
         I: IntoIterator<Item = S>,
         S: AsRef<str>,
@@ -28,7 +27,7 @@ impl AnsiParser {
             parser.advance(&mut handler, line.as_ref().as_bytes());
 
             let (line, ending_style) = handler.into_parts();
-            output_lines.push(line.into());
+            output_lines.push(line);
             style = ending_style;
         }
         (output_lines, style)

--- a/src/theme/clean.rs
+++ b/src/theme/clean.rs
@@ -565,7 +565,7 @@ impl CodeBlockStyle {
 }
 
 /// Vertical/horizontal padding.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default)]
 pub(crate) struct PaddingRect {
     /// The number of columns to use as horizontal padding.
     pub(crate) horizontal: u8,
@@ -594,7 +594,7 @@ impl ExecutionOutputBlockStyle {
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Copy, Clone, Debug, Default)]
 pub(crate) struct ExecutionStatusBlockStyle {
     pub(crate) running_style: TextStyle,
     pub(crate) success_style: TextStyle,

--- a/src/ui/execution/snippet.rs
+++ b/src/ui/execution/snippet.rs
@@ -5,7 +5,6 @@ use crate::{
     },
     markdown::{
         elements::{Line, Text},
-        text::WeightedLine,
         text_style::{Colors, TextStyle},
     },
     render::{
@@ -16,7 +15,7 @@ use crate::{
         properties::WindowSize,
     },
     terminal::ansi::AnsiParser,
-    theme::{Alignment, ExecutionOutputBlockStyle, ExecutionStatusBlockStyle, PaddingRect},
+    theme::{Alignment, ExecutionOutputBlockStyle, ExecutionStatusBlockStyle},
     ui::separator::{RenderSeparator, SeparatorWidth},
 };
 use std::{
@@ -36,105 +35,53 @@ enum State {
     Done,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 struct Inner {
-    output_lines: Vec<WeightedLine>,
+    snippet: Snippet,
+    executor: LanguageSnippetExecutor,
+    output_lines: Vec<Line>,
     max_line_length: u16,
     process_status: Option<ProcessStatus>,
     state: State,
+    policy: RenderAsyncStartPolicy,
 }
 
 #[derive(Debug)]
 pub(crate) struct RunSnippetOperation {
-    code: Snippet,
-    executor: LanguageSnippetExecutor,
     default_colors: Colors,
-    block_colors: Colors,
-    style: ExecutionStatusBlockStyle,
+    style: ExecutionOutputBlockStyle,
     block_length: u16,
     alignment: Alignment,
-    inner: Arc<Mutex<Inner>>,
-    separator: DisplaySeparator,
+    handle: SnippetHandle,
     font_size: u8,
-    policy: RenderAsyncStartPolicy,
-    padding: PaddingRect,
 }
 
 impl RunSnippetOperation {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
-        code: Snippet,
-        executor: LanguageSnippetExecutor,
+        handle: SnippetHandle,
         default_colors: Colors,
         style: ExecutionOutputBlockStyle,
         block_length: u16,
-        separator: DisplaySeparator,
         alignment: Alignment,
         font_size: u8,
-        policy: RenderAsyncStartPolicy,
-        padding: PaddingRect,
     ) -> Self {
-        let block_colors = style.style.colors;
-        let status_colors = style.status.clone();
         let block_length = alignment.adjust_size(block_length);
-        let inner = Inner::default();
-        Self {
-            code,
-            executor,
-            default_colors,
-            block_colors,
-            style: status_colors,
-            block_length,
-            alignment,
-            inner: Arc::new(Mutex::new(inner)),
-            separator,
-            font_size,
-            policy,
-            padding,
-        }
+        Self { default_colors, style, block_length, alignment, handle, font_size }
     }
-}
-
-#[derive(Debug)]
-pub(crate) enum DisplaySeparator {
-    On,
-    Off,
 }
 
 impl AsRenderOperations for RunSnippetOperation {
     fn as_render_operations(&self, _dimensions: &WindowSize) -> Vec<RenderOperation> {
-        let inner = self.inner.lock().unwrap();
-        let description = match &inner.process_status {
-            Some(ProcessStatus::Running) => Text::new("running", self.style.running_style),
-            Some(ProcessStatus::Success) => Text::new("finished", self.style.success_style),
-            Some(ProcessStatus::Failure) => Text::new("finished with error", self.style.failure_style),
-            None => Text::new("not started", self.style.not_started_style),
-        };
-        let mut operations = match self.separator {
-            DisplaySeparator::On => {
-                let heading = Line(vec![" [".into(), description.clone(), "] ".into()]);
-                let separator_width = match &self.alignment {
-                    Alignment::Left { .. } | Alignment::Right { .. } => SeparatorWidth::FitToWindow,
-                    // We need a minimum here otherwise if the code/block length is too narrow, the separator is
-                    // word-wrapped and looks bad.
-                    Alignment::Center { .. } => SeparatorWidth::Fixed(self.block_length.max(MINIMUM_SEPARATOR_WIDTH)),
-                };
-                let separator = RenderSeparator::new(heading, separator_width, self.font_size);
-                vec![
-                    RenderOperation::RenderLineBreak,
-                    RenderOperation::RenderDynamic(Rc::new(separator)),
-                    RenderOperation::RenderLineBreak,
-                ]
-            }
-            DisplaySeparator::Off => vec![],
-        };
+        let inner = self.handle.0.lock().unwrap();
         if let State::Initial = inner.state {
-            return operations;
+            return Vec::new();
         }
-        operations.push(RenderOperation::RenderLineBreak);
 
-        if self.block_colors.background.is_some() {
-            operations.push(RenderOperation::SetColors(self.block_colors));
+        let mut operations = vec![];
+        let block_colors = self.style.style.colors;
+        if block_colors.background.is_some() {
+            operations.push(RenderOperation::SetColors(block_colors));
         }
 
         if !inner.output_lines.is_empty() {
@@ -143,50 +90,33 @@ impl AsRenderOperations for RunSnippetOperation {
                 Alignment::Right { margin } => !margin.is_empty(),
                 Alignment::Center { minimum_margin, minimum_size } => !minimum_margin.is_empty() || minimum_size != &0,
             };
+            let padding = self.style.padding;
             let block_length =
                 if has_margin { self.block_length.max(inner.max_line_length) } else { inner.max_line_length };
-            let vertical_padding = iter::repeat_n(" ", self.padding.vertical as usize).map(WeightedLine::from);
+            let vertical_padding = iter::repeat_n(" ", padding.vertical as usize).map(Line::from);
             let lines = vertical_padding.clone().chain(inner.output_lines.iter().cloned()).chain(vertical_padding);
-            for line in lines {
+            for mut line in lines {
+                line.apply_style(&TextStyle::default().size(self.font_size));
                 operations.push(RenderOperation::RenderBlockLine(BlockLine {
-                    prefix: " ".repeat(self.padding.horizontal as usize).into(),
-                    right_padding_length: self.padding.horizontal as u16,
+                    prefix: " ".repeat(padding.horizontal as usize).into(),
+                    right_padding_length: padding.horizontal as u16,
                     repeat_prefix_on_wrap: false,
-                    text: line,
+                    text: line.into(),
                     block_length,
                     alignment: self.alignment,
-                    block_color: self.block_colors.background,
+                    block_color: block_colors.background,
                 }));
                 operations.push(RenderOperation::RenderLineBreak);
             }
         }
-        operations.push(RenderOperation::SetColors(self.default_colors));
+        operations.extend([RenderOperation::SetColors(self.default_colors)]);
         operations
-    }
-}
-
-impl RenderAsync for RunSnippetOperation {
-    fn pollable(&self) -> Box<dyn Pollable> {
-        Box::new(OperationPollable {
-            inner: self.inner.clone(),
-            executor: self.executor.clone(),
-            code: self.code.clone(),
-            last_length: 0,
-            style: TextStyle::default().size(self.font_size),
-        })
-    }
-
-    fn start_policy(&self) -> RenderAsyncStartPolicy {
-        self.policy
     }
 }
 
 struct OperationPollable {
     inner: Arc<Mutex<Inner>>,
-    executor: LanguageSnippetExecutor,
-    code: Snippet,
     last_length: usize,
-    style: TextStyle,
 }
 
 impl OperationPollable {
@@ -195,10 +125,10 @@ impl OperationPollable {
         if !matches!(inner.state, State::Initial) {
             return;
         }
-        inner.state = match self.executor.execute_async(&self.code) {
+        inner.state = match inner.executor.execute_async(&inner.snippet) {
             Ok(handle) => State::Running(handle),
             Err(e) => {
-                inner.output_lines = vec![WeightedLine::from(e.to_string())];
+                inner.output_lines = vec![e.to_string().into()];
                 State::Done
             }
         }
@@ -232,7 +162,7 @@ impl Pollable for OperationPollable {
         drop(state);
 
         let mut max_line_length = 0;
-        let (lines, _) = AnsiParser::new(self.style).parse_lines(&lines);
+        let (lines, _) = AnsiParser::new(Default::default()).parse_lines(&lines);
         for line in &lines {
             let width = u16::try_from(line.width()).unwrap_or(u16::MAX);
             max_line_length = max_line_length.max(width);
@@ -254,6 +184,108 @@ impl Pollable for OperationPollable {
     }
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct SnippetHandle(Arc<Mutex<Inner>>);
+
+impl SnippetHandle {
+    pub(crate) fn new(code: Snippet, executor: LanguageSnippetExecutor, policy: RenderAsyncStartPolicy) -> Self {
+        let inner = Inner {
+            snippet: code,
+            executor,
+            process_status: Default::default(),
+            output_lines: Default::default(),
+            max_line_length: Default::default(),
+            state: Default::default(),
+            policy,
+        };
+        Self(Arc::new(Mutex::new(inner)))
+    }
+
+    pub(crate) fn executor(&self) -> LanguageSnippetExecutor {
+        self.0.lock().unwrap().executor.clone()
+    }
+
+    pub(crate) fn snippet(&self) -> Snippet {
+        self.0.lock().unwrap().snippet.clone()
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct RunSnippetTrigger(Arc<Mutex<Inner>>);
+
+impl RunSnippetTrigger {
+    pub(crate) fn new(handle: SnippetHandle) -> Self {
+        Self(handle.0)
+    }
+}
+
+impl AsRenderOperations for RunSnippetTrigger {
+    fn as_render_operations(&self, _dimensions: &WindowSize) -> Vec<RenderOperation> {
+        vec![]
+    }
+}
+
+impl RenderAsync for RunSnippetTrigger {
+    fn pollable(&self) -> Box<dyn Pollable> {
+        Box::new(OperationPollable { inner: self.0.clone(), last_length: 0 })
+    }
+
+    fn start_policy(&self) -> RenderAsyncStartPolicy {
+        self.0.lock().unwrap().policy
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct ExecIndicatorStyle {
+    pub(crate) theme: ExecutionStatusBlockStyle,
+    pub(crate) block_length: u16,
+    pub(crate) font_size: u8,
+    pub(crate) alignment: Alignment,
+}
+
+#[derive(Debug)]
+pub(crate) struct ExecIndicator {
+    handle: SnippetHandle,
+    separator_width: SeparatorWidth,
+    theme: ExecutionStatusBlockStyle,
+    font_size: u8,
+}
+
+impl ExecIndicator {
+    pub(crate) fn new(handle: SnippetHandle, style: ExecIndicatorStyle) -> Self {
+        let ExecIndicatorStyle { theme, block_length, font_size, alignment } = style;
+        let block_length = alignment.adjust_size(block_length);
+        let separator_width = match &alignment {
+            Alignment::Left { .. } | Alignment::Right { .. } => SeparatorWidth::FitToWindow,
+            // We need a minimum here otherwise if the code/block length is too narrow, the separator is
+            // word-wrapped and looks bad.
+            Alignment::Center { .. } => SeparatorWidth::Fixed(block_length.max(MINIMUM_SEPARATOR_WIDTH)),
+        };
+        Self { handle, separator_width, theme, font_size }
+    }
+}
+
+impl AsRenderOperations for ExecIndicator {
+    fn as_render_operations(&self, _dimensions: &WindowSize) -> Vec<RenderOperation> {
+        let inner = self.handle.0.lock().unwrap();
+        let status = &inner.process_status;
+        let description = match status {
+            Some(ProcessStatus::Running) => Text::new("running", self.theme.running_style),
+            Some(ProcessStatus::Success) => Text::new("finished", self.theme.success_style),
+            Some(ProcessStatus::Failure) => Text::new("finished with error", self.theme.failure_style),
+            None => Text::new("not started", self.theme.not_started_style),
+        };
+
+        let heading = Line(vec![" [".into(), description.clone(), "] ".into()]);
+        let separator = RenderSeparator::new(heading, self.separator_width.clone(), self.font_size);
+        vec![
+            RenderOperation::RenderLineBreak,
+            RenderOperation::RenderDynamic(Rc::new(separator)),
+            RenderOperation::RenderLineBreak,
+        ]
+    }
+}
+
 #[cfg(all(target_os = "linux", test))]
 mod tests {
     use super::*;
@@ -262,55 +294,42 @@ mod tests {
             execute::SnippetExecutor,
             snippet::{SnippetAttributes, SnippetExec, SnippetLanguage},
         },
-        markdown::text_style::Color,
+        markdown::{
+            elements::{Line, Text},
+            text_style::Color,
+        },
     };
 
-    fn make_run_shell(code: &str) -> RunSnippetOperation {
+    fn make_run_shell(code: &str) -> RunSnippetTrigger {
         let snippet = Snippet {
             contents: code.into(),
             language: SnippetLanguage::Bash,
             attributes: SnippetAttributes { execution: SnippetExec::Exec(Default::default()), ..Default::default() },
         };
         let executor = SnippetExecutor::default().language_executor(&snippet.language, &Default::default()).unwrap();
-        let default_colors = Default::default();
-        let style = ExecutionOutputBlockStyle::default();
-        let block_length = 0;
-        let separator = DisplaySeparator::On;
-        let alignment = Default::default();
-        let font_size = 1;
         let policy = RenderAsyncStartPolicy::OnDemand;
-        RunSnippetOperation::new(
-            snippet,
-            executor,
-            default_colors,
-            style,
-            block_length,
-            separator,
-            alignment,
-            font_size,
-            policy,
-            Default::default(),
-        )
+        let handle = SnippetHandle::new(snippet, executor, policy);
+        RunSnippetTrigger::new(handle)
     }
 
     #[test]
     fn run_command() {
-        let operation = make_run_shell("echo -e '\\033[1;31mhi mom'");
-        let mut pollable = operation.pollable();
+        let handle = make_run_shell("echo -e '\\033[1;31mhi mom'");
+        let mut pollable = handle.pollable();
         // Run until done
         while let PollableState::Modified | PollableState::Unmodified = pollable.poll() {}
 
         // Expect to see the output lines
-        let inner = operation.inner.lock().unwrap();
+        let inner = handle.0.lock().unwrap();
         let line = Line::from(Text::new("hi mom", TextStyle::default().fg_color(Color::Red).bold()));
         assert_eq!(inner.output_lines, vec![line.into()]);
     }
 
     #[test]
     fn multiple_pollables() {
-        let operation = make_run_shell("echo -e '\\033[1;31mhi mom'");
-        let mut main_pollable = operation.pollable();
-        let mut pollable2 = operation.pollable();
+        let handle = make_run_shell("echo -e '\\033[1;31mhi mom'");
+        let mut main_pollable = handle.pollable();
+        let mut pollable2 = handle.pollable();
         // Run until done
         while let PollableState::Modified | PollableState::Unmodified = main_pollable.poll() {}
 
@@ -318,7 +337,7 @@ mod tests {
         assert_eq!(pollable2.poll(), PollableState::Done);
 
         // A new pollable should claim `Done` immediately
-        let mut pollable3 = operation.pollable();
+        let mut pollable3 = handle.pollable();
         assert_eq!(pollable3.poll(), PollableState::Done);
     }
 }


### PR DESCRIPTION
This adds a way of specifying where the output of an executable snippet will go, so it's not always shown right below the snippet. This can be useful in particular to place code in another column when the code itself is already long enough. To do this you need to:

* Create a `+exec` snippet and add a `+id:<name>` attribute.
* Add a comment command `snippet_output: <name>`. The output of the snippet will be placed here.

For example:

~~~markdown
<!-- column_layout: [1, 1] -->

<!-- column: 0 -->
```bash +exec +id:foo
echo "hello world"
echo "the time is $(date)"
```

<!-- column: 1 -->

<!-- snippet_output: foo -->
~~~

Looks like:

![image](https://github.com/user-attachments/assets/8360b180-29fe-46fd-bd8f-6a6af012682a)

The `+id` property may have more uses in the future but for now this is all it can be used for.

Closes #540

PS: this needs more testing and some better error reporting but I'm fried already.