### PR TITLE
feat: support iterm2 image protocol when running in tmux

### DIFF
--- a/config-file-schema.json
+++ b/config-file-schema.json
@@ -254,6 +254,13 @@
           ]
         },
         {
+          "description": "Use the iTerm2 image protocol in multipart mode.",
+          "type": "string",
+          "enum": [
+            "iterm2-multipart"
+          ]
+        },
+        {
           "description": "Use the kitty protocol in \"local\" mode, meaning both presenterm and the terminal run in the same host and can share the filesystem to communicate.",
           "type": "string",
           "enum": [

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,10 +1,7 @@
 use crate::{
     code::snippet::SnippetLanguage,
     commands::keyboard::KeyBinding,
-    terminal::{
-        GraphicsMode, capabilities::TerminalCapabilities, emulator::TerminalEmulator,
-        image::protocols::kitty::KittyMode,
-    },
+    terminal::{GraphicsMode, emulator::TerminalEmulator, image::protocols::kitty::KittyMode},
 };
 use clap::ValueEnum;
 use serde::Deserialize;
@@ -381,6 +378,9 @@ pub enum ImageProtocol {
     /// Use the iTerm2 image protocol.
     Iterm2,
 
+    /// Use the iTerm2 image protocol in multipart mode.
+    Iterm2Multipart,
+
     /// Use the kitty protocol in "local" mode, meaning both presenterm and the terminal run in the
     /// same host and can share the filesystem to communicate.
     KittyLocal,
@@ -409,12 +409,9 @@ impl TryFrom<&ImageProtocol> for GraphicsMode {
                 emulator.preferred_protocol()
             }
             ImageProtocol::Iterm2 => GraphicsMode::Iterm2,
-            ImageProtocol::KittyLocal => {
-                GraphicsMode::Kitty { mode: KittyMode::Local, inside_tmux: TerminalCapabilities::is_inside_tmux() }
-            }
-            ImageProtocol::KittyRemote => {
-                GraphicsMode::Kitty { mode: KittyMode::Remote, inside_tmux: TerminalCapabilities::is_inside_tmux() }
-            }
+            ImageProtocol::Iterm2Multipart => GraphicsMode::Iterm2Multipart,
+            ImageProtocol::KittyLocal => GraphicsMode::Kitty { mode: KittyMode::Local },
+            ImageProtocol::KittyRemote => GraphicsMode::Kitty { mode: KittyMode::Remote },
             ImageProtocol::AsciiBlocks => GraphicsMode::AsciiBlocks,
             #[cfg(feature = "sixel")]
             ImageProtocol::Sixel => GraphicsMode::Sixel,

--- a/src/markdown/text.rs
+++ b/src/markdown/text.rs
@@ -30,12 +30,6 @@ impl WeightedLine {
     pub(crate) fn font_size(&self) -> u8 {
         self.font_size
     }
-
-    /// Get an iterator to the underlying text chunks.
-    #[cfg(test)]
-    pub(crate) fn iter_texts(&self) -> impl Iterator<Item = &WeightedText> {
-        self.text.iter()
-    }
 }
 
 impl From<Line> for WeightedLine {

--- a/src/presentation/mod.rs
+++ b/src/presentation/mod.rs
@@ -273,11 +273,6 @@ impl Slide {
         self.chunks.iter()
     }
 
-    #[cfg(test)]
-    pub(crate) fn into_operations(self) -> Vec<RenderOperation> {
-        self.chunks.into_iter().flat_map(|chunk| chunk.operations.into_iter()).chain(self.footer).collect()
-    }
-
     fn jump_chunk(&mut self, chunk_index: usize) {
         self.visible_chunks = chunk_index.saturating_add(1).min(self.chunks.len());
         for chunk in self.chunks.iter().take(self.visible_chunks - 1) {

--- a/src/terminal/emulator.rs
+++ b/src/terminal/emulator.rs
@@ -42,10 +42,19 @@ impl TerminalEmulator {
 
     pub fn preferred_protocol(&self) -> GraphicsMode {
         let capabilities = Self::capabilities();
+        // Note: the order here is very important. In particular:
+        //
+        // * We prioritize checking for iterm2 support as the default for terminals that support
+        // it.
+        // * Kitty local is checked before remote since remote should also work when local is
+        // supported but local is more efficient.
+        // * Sixel is not great so we use it as a last resort.
+        // * ASCII blocks is supported by all terminals so it must come last.
         let modes = [
             GraphicsMode::Iterm2,
-            GraphicsMode::Kitty { mode: KittyMode::Local, inside_tmux: capabilities.tmux },
-            GraphicsMode::Kitty { mode: KittyMode::Remote, inside_tmux: capabilities.tmux },
+            GraphicsMode::Iterm2Multipart,
+            GraphicsMode::Kitty { mode: KittyMode::Local },
+            GraphicsMode::Kitty { mode: KittyMode::Remote },
             #[cfg(feature = "sixel")]
             GraphicsMode::Sixel,
             GraphicsMode::AsciiBlocks,
@@ -60,8 +69,10 @@ impl TerminalEmulator {
 
     fn is_detected(&self, term: &str, term_program: &str) -> bool {
         match self {
-            TerminalEmulator::Iterm2 => term_program.contains("iTerm"),
-            TerminalEmulator::WezTerm => term_program.contains("WezTerm"),
+            TerminalEmulator::Iterm2 => {
+                term_program.contains("iTerm") || env::var("LC_TERMINAL").is_ok_and(|c| c.contains("iTerm"))
+            }
+            TerminalEmulator::WezTerm => term_program.contains("WezTerm") || env::var("WEZTERM_EXECUTABLE").is_ok(),
             TerminalEmulator::Mintty => term_program.contains("mintty"),
             TerminalEmulator::Ghostty => term_program.contains("ghostty"),
             TerminalEmulator::Kitty => term.contains("kitty"),
@@ -77,27 +88,20 @@ impl TerminalEmulator {
 
     fn supports_graphics_mode(&self, mode: &GraphicsMode, capabilities: &TerminalCapabilities) -> bool {
         match (mode, self) {
-            (GraphicsMode::Kitty { mode, .. }, Self::Kitty | Self::WezTerm | Self::Ghostty) => match mode {
+            // Use the kitty protocol in any terminal that supports the kitty graphics protocol.
+            //
+            // Note that this could potentially break for terminals that don't support the unicode
+            // placeholder part of the spec which is required for this to work under tmux, but it's
+            // not our fault terminals half implement the protocol.
+            (GraphicsMode::Kitty { mode, .. }, _) => match mode {
                 KittyMode::Local => capabilities.kitty_local,
-                KittyMode::Remote => true,
+                KittyMode::Remote => capabilities.kitty_remote,
             },
-            (GraphicsMode::Kitty { mode: KittyMode::Local, .. }, Self::Unknown) => {
-                // If we don't know the emulator but we detected that we support kitty use it,
-                // **unless** we are inside tmux and we "guess" that we're using wezterm. This is
-                // because wezterm's support for unicode placeholders (needed to display images in
-                // kitty when inside tmux) is not implemented (see
-                // https://github.com/wez/wezterm/issues/986).
-                //
-                // We can only really guess it's wezterm by checking environment variables and will
-                // not work if you started tmux on a different emulator and are running presenterm
-                // in wezterm.
-                capabilities.kitty_local && (!capabilities.tmux || !Self::guess_wezterm())
-            }
-            (GraphicsMode::Kitty { mode: KittyMode::Remote, .. }, Self::Unknown) => {
-                // Same as the above
-                capabilities.kitty_remote && (!capabilities.tmux || !Self::guess_wezterm())
-            }
+            // All of these support the iterm2 protocol
             (GraphicsMode::Iterm2, Self::Iterm2 | Self::WezTerm | Self::Mintty | Self::Konsole) => true,
+            // Only iterm2 supports the iterm2 protocol in multipart form.
+            (GraphicsMode::Iterm2Multipart, Self::Iterm2) => true,
+            // All terminals support ascii protocol
             (GraphicsMode::AsciiBlocks, _) => true,
             #[cfg(feature = "sixel")]
             (GraphicsMode::Sixel, Self::Foot | Self::Yaft | Self::Mlterm) => true,
@@ -105,9 +109,5 @@ impl TerminalEmulator {
             (GraphicsMode::Sixel, Self::St | Self::Xterm | Self::Unknown) => capabilities.sixel,
             _ => false,
         }
-    }
-
-    fn guess_wezterm() -> bool {
-        env::var("WEZTERM_EXECUTABLE").is_ok()
     }
 }

--- a/src/terminal/image/protocols/iterm.rs
+++ b/src/terminal/image/protocols/iterm.rs
@@ -4,7 +4,9 @@ use crate::terminal::{
 };
 use base64::{Engine, engine::general_purpose::STANDARD};
 use image::{GenericImageView, ImageEncoder, RgbaImage, codecs::png::PngEncoder};
-use std::fs;
+use std::{fs, str};
+
+const CHUNK_SIZE: usize = 32 * 1024;
 
 pub(crate) struct ItermImage {
     dimensions: (u32, u32),
@@ -13,12 +15,6 @@ pub(crate) struct ItermImage {
 }
 
 impl ItermImage {
-    fn new(contents: Vec<u8>, dimensions: (u32, u32)) -> Self {
-        let raw_length = contents.len();
-        let base64_contents = STANDARD.encode(&contents);
-        Self { dimensions, raw_length, base64_contents }
-    }
-
     pub(crate) fn as_rgba8(&self) -> RgbaImage {
         let contents = STANDARD.decode(&self.base64_contents).expect("base64 must be valid");
         let image = image::load_from_memory(&contents).expect("image must have been originally valid");
@@ -32,27 +28,43 @@ impl ImageProperties for ItermImage {
     }
 }
 
-#[derive(Default)]
-pub struct ItermPrinter;
+pub enum ItermMode {
+    Single,
+    Multipart,
+}
+
+pub struct ItermPrinter {
+    mode: ItermMode,
+    tmux: bool,
+}
+
+impl ItermPrinter {
+    pub(crate) fn new(mode: ItermMode, tmux: bool) -> Self {
+        Self { mode, tmux }
+    }
+}
 
 impl PrintImage for ItermPrinter {
     type Image = ItermImage;
 
     fn register(&self, spec: ImageSpec) -> Result<Self::Image, RegisterImageError> {
-        match spec {
+        let (contents, dimensions) = match spec {
             ImageSpec::Generated(image) => {
                 let dimensions = image.dimensions();
                 let mut contents = Vec::new();
                 let encoder = PngEncoder::new(&mut contents);
                 encoder.write_image(image.as_bytes(), dimensions.0, dimensions.1, image.color().into())?;
-                Ok(ItermImage::new(contents, dimensions))
+                (contents, dimensions)
             }
             ImageSpec::Filesystem(path) => {
                 let contents = fs::read(path)?;
                 let image = image::load_from_memory(&contents)?;
-                Ok(ItermImage::new(contents, image.dimensions()))
+                (contents, image.dimensions())
             }
-        }
+        };
+        let raw_length = contents.len();
+        let contents = STANDARD.encode(&contents);
+        Ok(ItermImage { dimensions, raw_length, base64_contents: contents })
     }
 
     fn print<T>(&self, image: &Self::Image, options: &PrintOptions, terminal: &mut T) -> Result<(), PrintImageError>
@@ -62,11 +74,35 @@ impl PrintImage for ItermPrinter {
         let size = image.raw_length;
         let columns = options.columns;
         let rows = options.rows;
-        let contents = &image.base64_contents;
-        let content = format!(
-            "\x1b]1337;File=size={size};width={columns};height={rows};inline=1;preserveAspectRatio=1:{contents}\x07"
-        );
-        terminal.execute(&TerminalCommand::PrintText { content: &content, style: Default::default() })?;
+        let (start, end) = match self.tmux {
+            true => ("\x1bPtmux;\x1b\x1b]1337;", "\x07\x1b\\"),
+            false => ("\x1b]1337;", "\x07"),
+        };
+        let base64 = &image.base64_contents;
+        match &self.mode {
+            ItermMode::Single => {
+                let content = &format!(
+                    "{start}File=size={size};width={columns};height={rows};inline=1;preserveAspectRatio=1:{base64}{end}"
+                );
+                terminal.execute(&TerminalCommand::PrintText { content, style: Default::default() })?;
+            }
+            ItermMode::Multipart => {
+                let content = &format!(
+                    "{start}MultipartFile=size={size};width={columns};height={rows};inline=1;preserveAspectRatio=1{end}"
+                );
+                terminal.execute(&TerminalCommand::PrintText { content, style: Default::default() })?;
+                for chunk in base64.as_bytes().chunks(CHUNK_SIZE) {
+                    // SAFETY: this is base64 so it must be utf8
+                    let chunk = str::from_utf8(chunk).expect("not utf8");
+                    let content = &format!("{start}FilePart={chunk}{end}");
+                    terminal.execute(&TerminalCommand::PrintText { content, style: Default::default() })?;
+                }
+                terminal.execute(&TerminalCommand::PrintText {
+                    content: &format!("{start}FileEnd{end}"),
+                    style: Default::default(),
+                })?;
+            }
+        };
         Ok(())
     }
 }

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -10,9 +10,9 @@ pub(crate) use printer::{Terminal, TerminalWrite, should_hide_cursor};
 #[derive(Clone, Debug)]
 pub enum GraphicsMode {
     Iterm2,
+    Iterm2Multipart,
     Kitty {
         mode: image::protocols::kitty::KittyMode,
-        inside_tmux: bool,
     },
     AsciiBlocks,
     Raw,


### PR DESCRIPTION
This allows the iterm2 image protocol to work inside tmux. For this to work, the passthrough sequence needs to be enabled in tmux via `set-option -g allow-passthrough on`.

This also adds preliminary support for the newer multipart iterm2 image protocol, although somehow it works outside of tmux but not inside. I'll look at this later, at least for small-ish images (I think < 1mb after base64 encoding) this works. For now iterm and wezterm will keep using the normal iterm2 mode.