### PR TITLE
Added uv as an executor for python code

### DIFF
--- a/executors.yaml
+++ b/executors.yaml
@@ -79,6 +79,11 @@ python:
   commands:
     - ["python", "-u", "$pwd/snippet.py"]
   hidden_line_prefix: "/// "
+  alternative:
+    uv:
+      filename: "snippet.py"
+      commands:
+        - ["uv", "run", "--script", "-q", "$pwd/snippet.py"]
 r:
   filename: snippet.R
   commands:
@@ -118,11 +123,6 @@ sh:
   filename: script.sh
   commands:
     - ["sh", "$pwd/script.sh"]
-  hidden_line_prefix: "/// "
-uv:
-  filename: snippet.py
-  commands:
-    - ["uv", "run","--script","-q", "$pwd/snippet.py"]
   hidden_line_prefix: "/// "
 zsh:
   filename: script.sh

--- a/executors.yaml
+++ b/executors.yaml
@@ -119,6 +119,11 @@ sh:
   commands:
     - ["sh", "$pwd/script.sh"]
   hidden_line_prefix: "/// "
+uv:
+  filename: snippet.py
+  commands:
+    - ["uv", "run","--script","-q", "$pwd/snippet.py"]
+  hidden_line_prefix: "/// "
 zsh:
   filename: script.sh
   commands:

--- a/src/code/snippet.rs
+++ b/src/code/snippet.rs
@@ -630,6 +630,7 @@ impl FromStr for SnippetLanguage {
             "toml" => Toml,
             "typescript" | "ts" => TypeScript,
             "typst" => Typst,
+            "uv" => Python,
             "xml" => Xml,
             "yaml" => Yaml,
             "verilog" => Verilog,

--- a/src/code/snippet.rs
+++ b/src/code/snippet.rs
@@ -630,7 +630,6 @@ impl FromStr for SnippetLanguage {
             "toml" => Toml,
             "typescript" | "ts" => TypeScript,
             "typst" => Typst,
-            "uv" => Python,
             "xml" => Xml,
             "yaml" => Yaml,
             "verilog" => Verilog,


### PR DESCRIPTION
With this you can use [uv](https://github.com/astral-sh/uvl) to execute python code by changing the language name to "uv". 
This calls `uv run --script -q (file)`. You can use the syntax for script dependencies:
```python
/// # /// script
/// # requires-python = ">=3.12"
/// # dependencies = [
/// #     "numpy",
/// # ]
/// # ///
import numpy as np
print("Hello from ts.py!")
```
and then use the triple slashes to hide it in the presentation. 

