### PR TITLE
feat: allow using an ENV var to point to the config file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 anyhow = "1"
 base64 = "0.22"
 bincode = "1.3"
-clap = { version = "4.4", features = ["derive", "string"] }
+clap = { version = "4.4", features = ["derive", "string", "env"] }
 comrak = { version = "0.39", default-features = false }
 crossterm = { version = "0.29", default-features = false, features = ["events", "windows"] }
 directories = "6.0"

--- a/docs/src/configuration/introduction.md
+++ b/docs/src/configuration/introduction.md
@@ -10,7 +10,7 @@ custom themes, in the following directories:
 
 The configuration file will be looked up automatically in the directories above under the name `config.yaml`. e.g. on 
 Linux you should create it under `~/.config/presenterm/config.yaml`. You can also specify a custom path to this file 
-when running _presenterm_ via the `--config-file` parameter.
+when running _presenterm_ via the `--config-file` parameter or via the ``PRESENTERM_CONFIG_FILE`` environment variable.
 
 A [sample configuration file](https://github.com/mfontanini/presenterm/blob/master/config.sample.yaml) is provided in 
 the repository that you can use as a base.

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,7 +125,7 @@ struct Cli {
     enable_snippet_execution_replace: bool,
 
     /// The path to the configuration file.
-    #[clap(short, long)]
+    #[clap(short, long, env = "PRESENTERM_CONFIG_FILE")]
     config_file: Option<String>,
 
     /// Whether to publish speaker notes to local listeners.


### PR DESCRIPTION
I am kinda lazy and pretty forgetful so having to use ``--config-file`` to point to a local config file irks me.  
So this patch introduces a new env var: ``PRESENTERM_CONFIG_FILE``.    
``--config-file`` still has priority over the env var.

I use nix flakes a lot for working on projects (and I know others use ``direnv``) so this would allow for using a per project config file far easier.

I have tested it out locally and works pretty well