### PR TITLE
Update Catppuccin themes to use palettes

### DIFF
--- a/themes/catppuccin-frappe.yaml
+++ b/themes/catppuccin-frappe.yaml
@@ -3,15 +3,15 @@ default:
   margin:
     percent: 8
   colors:
-    foreground: "c6d0f5"
-    background: "303446"
+    foreground: palette:text
+    background: palette:base
 
 slide_title:
   alignment: center
   padding_bottom: 1
   padding_top: 1
   colors:
-    foreground: "e5c890"
+    foreground: palette:yellow
   bold: true
   font_size: 2
 
@@ -27,51 +27,51 @@ code:
 
 execution_output:
   colors:
-    foreground: "c6d0f5"
-    background: "414559"
+    foreground: palette:text
+    background: palette:surface0
   status:
     running:
-      foreground: "8caaee"
+      foreground: palette:blue
     success:
-      foreground: "a6d189"
+      foreground: palette:green
     failure:
-      foreground: "e78284"
+      foreground: palette:red
     not_started:
-      foreground: "e5c890"
+      foreground: palette:yellow
   padding:
     horizontal: 2
     vertical: 1
 
 inline_code:
   colors:
-    foreground: "a6d189"
+    foreground: palette:green
 
 intro_slide:
   title:
     alignment: center
     colors:
-      foreground: "a6d189"
+      foreground: palette:green
     font_size: 2
   subtitle:
     alignment: center
     colors:
-      foreground: "85c1dc"
+      foreground: palette:sapphire
   event:
     alignment: center
     colors:
-      foreground: "a6d189"
+      foreground: palette:green
   location:
     alignment: center
     colors:
-      foreground: "85c1dc"
+      foreground: palette:sapphire
   date:
     alignment: center
     colors:
-      foreground: "e5c890"
+      foreground: palette:yellow
   author:
     alignment: center
     colors:
-      foreground: "b5bfe2"
+      foreground: palette:subtext1
     positioning: page_bottom
   footer: false
 
@@ -79,56 +79,56 @@ headings:
   h1:
     prefix: "██"
     colors:
-      foreground: "81c8be"
+      foreground: palette:teal
   h2:
     prefix: "▓▓▓"
     colors:
-      foreground: "ca9ee6"
+      foreground: palette:mauve
   h3:
     prefix: "▒▒▒▒"
     colors:
-      foreground: "8caaee"
+      foreground: palette:blue
   h4:
     prefix: "░░░░░"
     colors:
-      foreground: "e78284"
+      foreground: palette:red
   h5:
     prefix: "░░░░░░"
     colors:
-      foreground: "a6d189"
+      foreground: palette:green
   h6:
     prefix: "░░░░░░░"
     colors:
-      foreground: "ef9f76"
+      foreground: palette:peach
 
 block_quote:
   prefix: "▍ "
   colors:
-    foreground: "c6d0f5"
-    background: "414559"
-    prefix: "e5c890"
+    foreground: palette:text
+    background: palette:surface0
+    prefix: palette:yellow
 
 alert:
   prefix: "▍ "
   base_colors:
-    foreground: "c6d0f5"
-    background: "414559"
+    foreground: palette:text
+    background: palette:surface0
   styles:
     note:
-      color: "8caaee"
+      color: palette:blue
     tip:
-      color: "a6d189"
+      color: palette:green
     important:
-      color: "ca9ee6"
+      color: palette:mauve
     warning:
-      color: "e5c890"
+      color: palette:yellow
     caution:
-      color: "e78284"
+      color: palette:red
 
 typst:
   colors:
-    foreground: "c6d0f5"
-    background: "414559"
+    foreground: palette:text
+    background: palette:surface0
 
 footer:
   style: template
@@ -136,7 +136,7 @@ footer:
 
 modals:
   selection_colors:
-    foreground: "85c1dc"
+    foreground: palette:sapphire
 
 mermaid:
   background: transparent
@@ -144,3 +144,32 @@ mermaid:
 
 d2:
   theme: 4
+
+palette:
+  colors:
+    rosewater: "f2d5cf"
+    flamingo: "eebebe"
+    pink: "f4b8e4"
+    mauve: "ca9ee6"
+    red: "e78284"
+    maroon: "ea999c"
+    peach: "ef9f76"
+    yellow: "e5c890"
+    green: "a6d189"
+    teal: "81c8be"
+    sky: "99d1db"
+    sapphire: "85c1dc"
+    blue: "8caaee"
+    lavender: "babbf1"
+    text: "c6d0f5"
+    subtext1: "b5bfe2"
+    subtext0: "a5adce"
+    overlay2: "949cbb"
+    overlay1: "838ba7"
+    overlay0: "737994"
+    surface2: "626880"
+    surface1: "51576d"
+    surface0: "414559"
+    base: "303446"
+    mantle: "292c3c"
+    crust: "232634"

--- a/themes/catppuccin-latte.yaml
+++ b/themes/catppuccin-latte.yaml
@@ -3,15 +3,15 @@ default:
   margin:
     percent: 8
   colors:
-    foreground: "4c4f69"
-    background: "eff1f5"
+    foreground: palette:text
+    background: palette:base
 
 slide_title:
   alignment: center
   padding_bottom: 1
   padding_top: 1
   colors:
-    foreground: "df8e1d"
+    foreground: palette:yellow
   bold: true
   font_size: 2
 
@@ -27,51 +27,51 @@ code:
 
 execution_output:
   colors:
-    foreground: "4c4f69"
-    background: "ccd0da"
+    foreground: palette:text
+    background: palette:surface0
   status:
     running:
-      foreground: "04a5e5"
+      foreground: palette:sky
     success:
-      foreground: "40a02b"
+      foreground: palette:green
     failure:
-      foreground: "d20f39"
+      foreground: palette:red
     not_started:
-      foreground: "df8e1d"
+      foreground: palette:yellow
   padding:
     horizontal: 2
     vertical: 1
 
 inline_code:
   colors:
-    foreground: "40a02b"
+    foreground: palette:green
 
 intro_slide:
   title:
     alignment: center
     colors:
-      foreground: "40a02b"
+      foreground: palette:green
     font_size: 2
   subtitle:
     alignment: center
     colors:
-      foreground: "209fb5"
+      foreground: palette:sapphire
   event:
     alignment: center
     colors:
-      foreground: "40a02b"
+      foreground: palette:green
   location:
     alignment: center
     colors:
-      foreground: "209fb5"
+      foreground: palette:sapphire
   date:
     alignment: center
     colors:
-      foreground: "df8e1d"
+      foreground: palette:yellow
   author:
     alignment: center
     colors:
-      foreground: "5c5f77"
+      foreground: palette:subtext1
     positioning: page_bottom
   footer: false
 
@@ -79,56 +79,56 @@ headings:
   h1:
     prefix: "██"
     colors:
-      foreground: "179299"
+      foreground: palette:teal
   h2:
     prefix: "▓▓▓"
     colors:
-      foreground: "8839ef"
+      foreground: palette:mauve
   h3:
     prefix: "▒▒▒▒"
     colors:
-      foreground: "1e66f5"
+      foreground: palette:blue
   h4:
     prefix: "░░░░░"
     colors:
-      foreground: "d20f39"
+      foreground: palette:red
   h5:
     prefix: "░░░░░░"
     colors:
-      foreground: "40a02b"
+      foreground: palette:green
   h6:
     prefix: "░░░░░░░"
     colors:
-      foreground: "fe640b"
+      foreground: palette:peach
 
 block_quote:
   prefix: "▍ "
   colors:
-    foreground: "4c4f69"
-    background: "ccd0da"
-    prefix: "df8e1d"
+    foreground: palette:text
+    background: palette:surface0
+    prefix: palette:yellow
 
 alert:
   prefix: "▍ "
   base_colors:
-    foreground: "4c4f69"
-    background: "ccd0da"
+    foreground: palette:text
+    background: palette:surface0
   styles:
     note:
-      color: "1e66f5"
+      color: palette:blue
     tip:
-      color: "40a02b"
+      color: palette:green
     important:
-      color: "8839ef"
+      color: palette:mauve
     warning:
-      color: "df8e1d"
+      color: palette:yellow
     caution:
-      color: "d20f39"
+      color: palette:red
 
 typst:
   colors:
-    foreground: "4c4f69"
-    background: "ccd0da"
+    foreground: palette:text
+    background: palette:surface0
 
 footer:
   style: template
@@ -136,7 +136,7 @@ footer:
 
 modals:
   selection_colors:
-    foreground: "209fb5"
+    foreground: palette:sapphire
 
 mermaid:
   background: transparent
@@ -144,3 +144,32 @@ mermaid:
 
 d2:
   theme: 100
+
+palette:
+  colors:
+    rosewater: "dc8a78"
+    flamingo: "dd7878"
+    pink: "ea76cb"
+    mauve: "8839ef"
+    red: "d20f39"
+    maroon: "e64553"
+    peach: "fe640b"
+    yellow: "df8e1d"
+    green: "40a02b"
+    teal: "179299"
+    sky: "04a5e5"
+    sapphire: "209fb5"
+    blue: "1e66f5"
+    lavender: "7287fd"
+    text: "4c4f69"
+    subtext1: "5c5f77"
+    subtext0: "6c6f85"
+    overlay2: "7c7f93"
+    overlay1: "8c8fa1"
+    overlay0: "9ca0b0"
+    surface2: "acb0be"
+    surface1: "bcc0cc"
+    surface0: "ccd0da"
+    base: "eff1f5"
+    mantle: "e6e9ef"
+    crust: "dce0e8"

--- a/themes/catppuccin-macchiato.yaml
+++ b/themes/catppuccin-macchiato.yaml
@@ -3,15 +3,15 @@ default:
   margin:
     percent: 8
   colors:
-    foreground: "cad3f5"
-    background: "24273a"
+    foreground: palette:text
+    background: palette:base
 
 slide_title:
   alignment: center
   padding_bottom: 1
   padding_top: 1
   colors:
-    foreground: "eed49f"
+    foreground: palette:yellow
   bold: true
   font_size: 2
 
@@ -27,51 +27,51 @@ code:
 
 execution_output:
   colors:
-    foreground: "cad3f5"
-    background: "363a4f"
+    foreground: palette:text
+    background: palette:surface0
   status:
     running:
-      foreground: "91d7e3"
+      foreground: palette:sky
     success:
-      foreground: "a6da95"
+      foreground: palette:green
     failure:
-      foreground: "ed8796"
+      foreground: palette:red
     not_started:
-      foreground: "eed49f"
+      foreground: palette:yellow
   padding:
     horizontal: 2
     vertical: 1
 
 inline_code:
   colors:
-    foreground: "a6da95"
+    foreground: palette:green
 
 intro_slide:
   title:
     alignment: center
     colors:
-      foreground: "a6da95"
+      foreground: palette:green
     font_size: 2
   subtitle:
     alignment: center
     colors:
-      foreground: "7dc4e4"
+      foreground: palette:sapphire
   event:
     alignment: center
     colors:
-      foreground: "a6da95"
+      foreground: palette:green
   location:
     alignment: center
     colors:
-      foreground: "7dc4e4"
+      foreground: palette:sapphire
   date:
     alignment: center
     colors:
-      foreground: "eed49f"
+      foreground: palette:yellow
   author:
     alignment: center
     colors:
-      foreground: "b8c0e0"
+      foreground: palette:subtext1
     positioning: page_bottom
   footer: false
 
@@ -79,56 +79,56 @@ headings:
   h1:
     prefix: "██"
     colors:
-      foreground: "8bd5ca"
+      foreground: palette:teal
   h2:
     prefix: "▓▓▓"
     colors:
-      foreground: "c6a0f6"
+      foreground: palette:mauve
   h3:
     prefix: "▒▒▒▒"
     colors:
-      foreground: "8aadf4"
+      foreground: palette:blue
   h4:
     prefix: "░░░░░"
     colors:
-      foreground: "ed8796"
+      foreground: palette:red
   h5:
     prefix: "░░░░░░"
     colors:
-      foreground: "a6da95"
+      foreground: palette:green
   h6:
     prefix: "░░░░░░░"
     colors:
-      foreground: "f5a97f"
+      foreground: palette:peach
 
 block_quote:
   prefix: "▍ "
   colors:
-    foreground: "cad3f5"
-    background: "363a4f"
-    prefix: "eed49f"
+    foreground: palette:text
+    background: palette:surface0
+    prefix: palette:yellow
 
 alert:
   prefix: "▍ "
   base_colors:
-    foreground: "cad3f5"
-    background: "363a4f"
+    foreground: palette:text
+    background: palette:surface0
   styles:
     note:
-      color: "8aadf4"
+      color: palette:blue
     tip:
-      color: "a6da95"
+      color: palette:green
     important:
-      color: "c6a0f6"
+      color: palette:mauve
     warning:
-      color: "f5a97f"
+      color: palette:peach
     caution:
-      color: "ed8796"
+      color: palette:red
 
 typst:
   colors:
-    foreground: "cad3f5"
-    background: "363a4f"
+    foreground: palette:text
+    background: palette:surface0
 
 footer:
   style: template
@@ -136,7 +136,7 @@ footer:
 
 modals:
   selection_colors:
-    foreground: "7dc4e4"
+    foreground: palette:sapphire
 
 mermaid:
   background: transparent
@@ -144,3 +144,32 @@ mermaid:
 
 d2:
   theme: 200
+
+palette:
+  colors:
+    rosewater: "f4dbd6"
+    flamingo: "f0c6c6"
+    pink: "f5bde6"
+    mauve: "c6a0f6"
+    red: "ed8796"
+    maroon: "ee99a0"
+    peach: "f5a97f"
+    yellow: "eed49f"
+    green: "a6da95"
+    teal: "8bd5ca"
+    sky: "91d7e3"
+    sapphire: "7dc4e4"
+    blue: "8aadf4"
+    lavender: "b7bdf8"
+    text: "cad3f5"
+    subtext1: "b8c0e0"
+    subtext0: "a5adcb"
+    overlay2: "939ab7"
+    overlay1: "8087a2"
+    overlay0: "6e738d"
+    surface2: "5b6078"
+    surface1: "494d64"
+    surface0: "363a4f"
+    base: "24273a"
+    mantle: "1e2030"
+    crust: "181926"

--- a/themes/catppuccin-mocha.yaml
+++ b/themes/catppuccin-mocha.yaml
@@ -3,15 +3,15 @@ default:
   margin:
     percent: 8
   colors:
-    foreground: "cdd6f4"
-    background: "1e1e2e"
+    foreground: palette:text
+    background: palette:base
 
 slide_title:
   alignment: center
   padding_bottom: 1
   padding_top: 1
   colors:
-    foreground: "f9e2af"
+    foreground: palette:yellow
   bold: true
   font_size: 2
 
@@ -27,51 +27,51 @@ code:
 
 execution_output:
   colors:
-    foreground: "cdd6f4"
-    background: "313244"
+    foreground: palette:text
+    background: palette:surface0
   status:
     running:
-      foreground: "89dceb"
+      foreground: palette:sky
     success:
-      foreground: "a6e3a1"
+      foreground: palette:green
     failure:
-      foreground: "f38ba8"
+      foreground: palette:red
     not_started:
-      foreground: "f9e2af"
+      foreground: palette:yellow
   padding:
     horizontal: 2
     vertical: 1
 
 inline_code:
   colors:
-    foreground: "a6e3a1"
+    foreground: palette:green
 
 intro_slide:
   title:
     alignment: center
     colors:
-      foreground: "a6e3a1"
+      foreground: palette:green
     font_size: 2
   subtitle:
     alignment: center
     colors:
-      foreground: "74c7ec"
+      foreground: palette:sapphire
   event:
     alignment: center
     colors:
-      foreground: "a6e3a1"
+      foreground: palette:green
   location:
     alignment: center
     colors:
-      foreground: "74c7ec"
+      foreground: palette:sapphire
   date:
     alignment: center
     colors:
-      foreground: "f9e2af"
+      foreground: palette:yellow
   author:
     alignment: center
     colors:
-      foreground: "bac2de"
+      foreground: palette:subtext1
     positioning: page_bottom
   footer: false
 
@@ -79,56 +79,56 @@ headings:
   h1:
     prefix: "██"
     colors:
-      foreground: "94e2d5"
+      foreground: palette:teal
   h2:
     prefix: "▓▓▓"
     colors:
-      foreground: "cba6f7"
+      foreground: palette:mauve
   h3:
     prefix: "▒▒▒▒"
     colors:
-      foreground: "89b4fa"
+      foreground: palette:blue
   h4:
     prefix: "░░░░░"
     colors:
-      foreground: "f38ba8"
+      foreground: palette:red
   h5:
     prefix: "░░░░░░"
     colors:
-      foreground: "a6e3a1"
+      foreground: palette:green
   h6:
     prefix: "░░░░░░░"
     colors:
-      foreground: "fab387"
+      foreground: palette:peach
 
 block_quote:
   prefix: "▍ "
   colors:
-    foreground: "cdd6f4"
-    background: "313244"
-    prefix: "f9e2af"
+    foreground: palette:text
+    background: palette:surface0
+    prefix: palette:yellow
 
 alert:
   prefix: "▍ "
   base_colors:
-    foreground: "cdd6f4"
-    background: "313244"
+    foreground: palette:text
+    background: palette:surface0
   styles:
     note:
-      color: "89b4fa"
+      color: palette:blue
     tip:
-      color: "a6e3a1"
+      color: palette:green
     important:
-      color: "cba6f7"
+      color: palette:mauve
     warning:
-      color: "fab387"
+      color: palette:peach
     caution:
-      color: "f38ba8"
+      color: palette:red
 
 typst:
   colors:
-    foreground: "cdd6f4"
-    background: "313244"
+    foreground: palette:text
+    background: palette:surface0
 
 footer:
   style: template
@@ -136,7 +136,7 @@ footer:
 
 modals:
   selection_colors:
-    foreground: "74c7ec"
+    foreground: palette:sapphire
 
 mermaid:
   background: transparent
@@ -144,3 +144,32 @@ mermaid:
 
 d2:
   theme: 200
+
+palette:
+  colors:
+    rosewater: "f5e0dc"
+    flamingo: "f2cdcd"
+    pink: "f5c2e7"
+    mauve: "cba6f7"
+    red: "f38ba8"
+    maroon: "eba0ac"
+    peach: "fab387"
+    yellow: "f9e2af"
+    green: "a6e3a1"
+    teal: "94e2d5"
+    sky: "89dceb"
+    sapphire: "74c7ec"
+    blue: "89b4fa"
+    lavender: "b4befe"
+    text: "cdd6f4"
+    subtext1: "bac2de"
+    subtext0: "a6adc8"
+    overlay2: "9399b2"
+    overlay1: "7f849c"
+    overlay0: "6c7086"
+    surface2: "585b70"
+    surface1: "45475a"
+    surface0: "313244"
+    base: "1e1e2e"
+    mantle: "181825"
+    crust: "11111b"


### PR DESCRIPTION
Previously the colours were hard coded. This PR updates the themes to make use of palettes, which has the nice advantage of allowing these colours to be referred to by name in slides - and makes switching between the catppuccin themes more pleasant for the user.

Palettes have been built by referencing the [Catppuccin documentation](https://github.com/catppuccin/catppuccin).

Closes #673