### PR TITLE
feat: add markdown context to errors

### DIFF
--- a/src/presentation/builder/comment.rs
+++ b/src/presentation/builder/comment.rs
@@ -236,9 +236,7 @@ mod tests {
     use std::{fs, io::BufWriter};
 
     use super::*;
-    use crate::presentation::builder::{
-        PresentationBuilderOptions, error::BuildError, sources::MarkdownSourceError, utils::Test,
-    };
+    use crate::presentation::builder::{PresentationBuilderOptions, utils::Test};
     use image::{DynamicImage, ImageEncoder, codecs::png::PngEncoder};
     use rstest::rstest;
     use tempfile::tempdir;
@@ -654,16 +652,7 @@ hi
         let input = "<!-- include: main.md -->";
 
         let err = Test::new(input).resources_path(path).expect_invalid();
-        assert!(
-            matches!(
-                err,
-                BuildError::InvalidPresentation {
-                    error: InvalidPresentation::Import { error: MarkdownSourceError::IncludeCycle(..), .. },
-                    ..
-                }
-            ),
-            "{err:?}"
-        );
+        assert!(err.to_string().contains("was already imported"), "{err:?}");
     }
 
     #[test]
@@ -676,15 +665,6 @@ hi
         let input = "<!-- include: main.md -->";
 
         let err = Test::new(input).resources_path(path).expect_invalid();
-        assert!(
-            matches!(
-                err,
-                BuildError::InvalidPresentation {
-                    error: InvalidPresentation::Import { error: MarkdownSourceError::IncludeCycle(..), .. },
-                    ..
-                }
-            ),
-            "{err:?}"
-        );
+        assert!(err.to_string().contains("was already imported"), "{err:?}");
     }
 }

--- a/src/presentation/builder/error.rs
+++ b/src/presentation/builder/error.rs
@@ -7,7 +7,11 @@ use crate::{
     third_party::ThirdPartyRenderError,
     ui::footer::InvalidFooterTemplateError,
 };
-use std::{fmt, io, path::PathBuf};
+use std::{
+    fmt,
+    io::{self},
+    path::PathBuf,
+};
 
 /// An error when building a presentation.
 #[derive(thiserror::Error, Debug)]
@@ -45,14 +49,24 @@ pub(crate) enum BuildError {
     #[error("invalid footer: {0}")]
     InvalidFooter(#[from] InvalidFooterTemplateError),
 
-    #[error("invalid markdown in {path:?}: {error}")]
-    Parse { path: PathBuf, error: ParseError },
+    #[error(
+        "invalid markdown at {display_path}:{line}:{column}:\n\n{context}",
+        display_path = .path.display(),
+        line = .error.sourcepos.start.line,
+        column = .error.sourcepos.start.column,
+    )]
+    Parse { path: PathBuf, error: ParseError, context: String },
 
     #[error("cannot process presentation file: {0}")]
     EnterRoot(MarkdownSourceError),
 
-    #[error("error at '{source_position}': {error}")]
-    InvalidPresentation { source_position: FileSourcePosition, error: InvalidPresentation },
+    #[error(
+        "error at {display_path}:{line}:{column}:\n\n{context}",
+        display_path = .path.display(),
+        line = .source_position.start.line,
+        column = .source_position.start.column,
+    )]
+    InvalidPresentation { path: PathBuf, source_position: SourcePosition, context: String },
 
     #[error("need to enter layout column explicitly using `column` command")]
     NotInsideColumn,


### PR DESCRIPTION
This adds prettier errors by adding a context that displays the markdown file where the error was found. There's still a couple of error types that don't have this (and will soon) but for now any parse error or "general" presentation error will use this new format.

![image](https://github.com/user-attachments/assets/dcc156f1-171a-423a-9fbe-89beaa8dd031)
