### PR TITLE
feat!: add show pauses keyboard binding

### DIFF
--- a/config-file-schema.json
+++ b/config-file-schema.json
@@ -369,7 +369,7 @@
           }
         },
         "next_fast": {
-          "description": "The keys that cause the presentation to jump to the next slide \"fast\".\n\n\"fast\" means for slides that contain pauses, we will only jump between the first and last pause rather than going through each individual one.",
+          "description": "The keys that cause the presentation to jump to the next slide \"fast\".\n\n\"fast\" means for slides that contain pauses, we will skip all pauses and jump straight to the next slide.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/KeyBinding"
@@ -383,7 +383,7 @@
           }
         },
         "previous_fast": {
-          "description": "The keys that cause the presentation to move backwards \"fast\".\n\n\"fast\" means for slides that contain pauses, we will only jump between the first and last pause rather than going through each individual one.",
+          "description": "The keys that cause the presentation to move backwards \"fast\".\n\n\"fast\" means for slides that contain pauses, we will skip all pauses and jump straight to the previous slide.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/KeyBinding"
@@ -391,6 +391,13 @@
         },
         "reload": {
           "description": "The key binding to reload the presentation.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/KeyBinding"
+          }
+        },
+        "skip_pauses": {
+          "description": "The key binding to show the entire slide, after skipping any pauses in it.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/KeyBinding"

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -101,3 +101,6 @@ bindings:
 
   # the key binding to suspend the application.
   suspend: ["<c-z>"]
+
+  # the key binding to show all pauses in the current slide.
+  show_pauses: ["s"]

--- a/src/commands/keyboard.rs
+++ b/src/commands/keyboard.rs
@@ -94,6 +94,7 @@ impl CommandKeyBindings {
             ToggleSlideIndex => Command::ToggleSlideIndex,
             ToggleKeyBindingsConfig => Command::ToggleKeyBindingsConfig,
             CloseModal => Command::CloseModal,
+            SkipPauses => Command::SkipPauses,
         };
         InputAction::Emit(command)
     }
@@ -138,6 +139,7 @@ impl TryFrom<KeyBindingsConfig> for CommandKeyBindings {
             .chain(zip(CommandDiscriminants::ToggleKeyBindingsConfig, config.toggle_bindings))
             .chain(zip(CommandDiscriminants::RenderAsyncOperations, config.execute_code))
             .chain(zip(CommandDiscriminants::CloseModal, config.close_modal))
+            .chain(zip(CommandDiscriminants::SkipPauses, config.skip_pauses))
             .collect();
         Self::validate_conflicts(bindings.iter().map(|binding| &binding.0))?;
         Ok(Self { bindings })

--- a/src/commands/listener.rs
+++ b/src/commands/listener.rs
@@ -98,4 +98,7 @@ pub(crate) enum Command {
 
     /// Hide the currently open modal, if any.
     CloseModal,
+
+    /// Skip pauses in the current slide.
+    SkipPauses,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -432,8 +432,8 @@ pub struct KeyBindingsConfig {
 
     /// The keys that cause the presentation to jump to the next slide "fast".
     ///
-    /// "fast" means for slides that contain pauses, we will only jump between the first and last
-    /// pause rather than going through each individual one.
+    /// "fast" means for slides that contain pauses, we will skip all pauses and jump straight to
+    /// the next slide.
     #[serde(default = "default_next_fast_bindings")]
     pub(crate) next_fast: Vec<KeyBinding>,
 
@@ -443,8 +443,8 @@ pub struct KeyBindingsConfig {
 
     /// The keys that cause the presentation to move backwards "fast".
     ///
-    /// "fast" means for slides that contain pauses, we will only jump between the first and last
-    /// pause rather than going through each individual one.
+    /// "fast" means for slides that contain pauses, we will skip all pauses and jump straight to
+    /// the previous slide.
     #[serde(default = "default_previous_fast_bindings")]
     pub(crate) previous_fast: Vec<KeyBinding>,
 
@@ -487,6 +487,10 @@ pub struct KeyBindingsConfig {
     /// The key binding to suspend the application.
     #[serde(default = "default_suspend_bindings")]
     pub(crate) suspend: Vec<KeyBinding>,
+
+    /// The key binding to show the entire slide, after skipping any pauses in it.
+    #[serde(default = "default_skip_pauses")]
+    pub(crate) skip_pauses: Vec<KeyBinding>,
 }
 
 impl Default for KeyBindingsConfig {
@@ -506,6 +510,7 @@ impl Default for KeyBindingsConfig {
             close_modal: default_close_modal_bindings(),
             exit: default_exit_bindings(),
             suspend: default_suspend_bindings(),
+            skip_pauses: default_skip_pauses(),
         }
     }
 }
@@ -717,6 +722,10 @@ fn default_exit_bindings() -> Vec<KeyBinding> {
 
 fn default_suspend_bindings() -> Vec<KeyBinding> {
     make_keybindings(["<c-z>"])
+}
+
+fn default_skip_pauses() -> Vec<KeyBinding> {
+    make_keybindings(["s"])
 }
 
 fn default_transition_duration_millis() -> u16 {

--- a/src/presentation/mod.rs
+++ b/src/presentation/mod.rs
@@ -76,15 +76,9 @@ impl Presentation {
         self.jump_next_slide()
     }
 
-    /// Show all chunks in this slide, or jump to the next if already applied.
+    /// Jump to the next slide, ignoring any chunks and modifiers.
     pub(crate) fn jump_next_fast(&mut self) -> bool {
-        let current_slide = self.current_slide_mut();
-        if current_slide.visible_chunks == current_slide.chunks.len() {
-            self.jump_next_slide()
-        } else {
-            current_slide.show_all_chunks();
-            true
-        }
+        self.jump_next_slide()
     }
 
     /// Jump backwards.
@@ -96,15 +90,11 @@ impl Presentation {
         self.jump_previous_slide()
     }
 
-    /// Show only the first chunk in this slide or jump to the previous slide if already there.
+    /// Jump to the previous slide ignoring any chunks and modifiers.
     pub(crate) fn jump_previous_fast(&mut self) -> bool {
-        let current_slide = self.current_slide_mut();
-        if current_slide.visible_chunks == current_slide.chunks.len() && current_slide.chunks.len() > 1 {
-            current_slide.show_first_chunk();
-            true
-        } else {
-            self.jump_previous_slide()
-        }
+        let output = self.jump_previous_slide();
+        self.current_slide_mut().show_first_chunk();
+        output
     }
 
     /// Jump to the first slide.
@@ -143,6 +133,11 @@ impl Presentation {
     pub(crate) fn current_slide_mut(&mut self) -> &mut Slide {
         let index = self.current_slide_index();
         &mut self.slides[index]
+    }
+
+    /// Show all chunks in the current slide.
+    pub(crate) fn show_all_slide_chunks(&mut self) {
+        self.current_slide_mut().show_all_chunks();
     }
 
     fn jump_next_slide(&mut self) -> bool {
@@ -548,11 +543,11 @@ mod test {
     #[case::next_from_first(0, &[Jump::Next], 0, 1)]
     #[case::next_next_from_first(0, &[Jump::Next, Jump::Next], 0, 2)]
     #[case::next_next_next_from_first(0, &[Jump::Next, Jump::Next, Jump::Next], 1, 0)]
-    #[case::next_fast_from_first(0, &[Jump::NextFast], 0, 2)]
-    #[case::next_fast_twice_from_first(0, &[Jump::NextFast, Jump::NextFast], 1, 0)]
+    #[case::next_fast_from_first(0, &[Jump::NextFast], 1, 0)]
+    #[case::next_fast_twice_from_first(0, &[Jump::NextFast, Jump::NextFast], 2, 0)]
     #[case::last_from_first(0, &[Jump::Last], 2, 0)]
     #[case::previous_from_second(1, &[Jump::Previous], 0, 2)]
-    #[case::previous_fast_from_second(1, &[Jump::PreviousFast], 0, 2)]
+    #[case::previous_fast_from_second(1, &[Jump::PreviousFast], 0, 0)]
     #[case::previous_fast_twice_from_second(1, &[Jump::PreviousFast, Jump::PreviousFast], 0, 0)]
     #[case::next_from_second(1, &[Jump::Next], 1, 1)]
     #[case::specific_first_from_second(1, &[Jump::Specific(0)], 0, 0)]

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -330,6 +330,10 @@ impl<'a> Presenter<'a> {
                 self.state = PresenterState::Presenting(presentation);
                 true
             }
+            Command::SkipPauses => {
+                presentation.show_all_slide_chunks();
+                true
+            }
             // These are handled above as they don't require the presentation
             Command::Reload | Command::HardReload | Command::Exit | Command::Suspend | Command::Redraw => {
                 panic!("unreachable commands")


### PR DESCRIPTION
This does two things:

* A breaking change for the jump next and jump previous keyboard bindings: now they jump to the next slide ignoring all pauses. Before this they jumped from the current slide to the current slide with all pauses displayed. This makes little sense and it makes more sense that this binding allows jumping to the next slide skipping all pauses; this also aligns better with "jump fast".
* Because someone may want the old "fast" behavior, this adds a new `show_pauses` keybinding (defaults to `s`) which shows all pauses in the current slide. e.g. if the slide you're currently in has N pauses and you can currently only see any number < N, then pressing `s` will display all of them.

Closes #677