### PR TITLE
feat: allow multiline slide titles

### DIFF
--- a/src/presentation/builder/mod.rs
+++ b/src/presentation/builder/mod.rs
@@ -40,7 +40,6 @@ use crate::{
         separator::RenderSeparator,
     },
 };
-use comrak::Arena;
 use image::DynamicImage;
 use std::{
     collections::{HashMap, HashSet},
@@ -396,15 +395,6 @@ impl<'a, 'b> PresentationBuilder<'a, 'b> {
             self.themes.highlight.load_by_name(theme).ok_or_else(|| BuildError::InvalidCodeTheme(theme.clone()))?;
         self.highlighter = highlighter;
         Ok(())
-    }
-
-    fn format_presentation_title(&self, title: String) -> Result<Line, BuildError> {
-        let arena = Arena::default();
-        let parser = MarkdownParser::new(&arena);
-        let line = parser.parse_inlines(&title).map_err(|e| BuildError::PresentationTitle(e.to_string()))?;
-        let mut line = line.resolve(&self.theme.palette)?;
-        line.apply_style(&self.theme.intro_slide.title.style);
-        Ok(line)
     }
 
     fn invalid_presentation<E>(&self, source_position: SourcePosition, error: E) -> BuildError


### PR DESCRIPTION
This allows multiline slide titles by using markdown multiline syntax.

Example:

```markdown
---
title: |
    My journey:
    from `foo` to `bar`
---
```


<img width="1024" height="884" alt="image" src="https://github.com/user-attachments/assets/90994230-4556-4788-a71f-a4d53e82274c" />

Closes #670