### PR TITLE
feat: add support for multiline slide titles

### DIFF
--- a/src/demo.rs
+++ b/src/demo.rs
@@ -124,7 +124,7 @@ impl ThemesDemo {
             &parser,
             options,
         )?;
-        let mut elements = vec![MarkdownElement::SetexHeading { text: format!("theme: {theme_name}").into() }];
+        let mut elements = vec![MarkdownElement::SetexHeading { text: vec![format!("theme: {theme_name}").into()] }];
         elements.extend(base_elements.iter().cloned());
         builder.build_from_parsed(elements)
     }

--- a/src/markdown/elements.rs
+++ b/src/markdown/elements.rs
@@ -14,7 +14,7 @@ pub(crate) enum MarkdownElement {
     FrontMatter(String),
 
     /// A setex heading.
-    SetexHeading { text: Line<RawColor> },
+    SetexHeading { text: Vec<Line<RawColor>> },
 
     /// A normal heading.
     Heading { level: u8, text: Line<RawColor> },


### PR DESCRIPTION
`SetexHeading` is now a vector of lines, with an implicit line break between them, inserted by `push_slide_title`.  
I decided to only put the contents of the first exHeading line as the slide name(for the slides modal), as there is no solution that will fit all formatting(without any additional insertions, the words will be squished together, with any added characters, it will look weird if the writer already added one)