### PR TITLE
fix: display right source line when using import + column layout

### DIFF
--- a/src/presentation/builder/comment.rs
+++ b/src/presentation/builder/comment.rs
@@ -27,8 +27,6 @@ impl PresentationBuilder<'_, '_> {
         } else {
             self.process_comment_command_presentation_mode(command, source_position)?;
         }
-        let source_position = self.sources.resolve_source_position(source_position);
-        self.slide_state.last_comment_position = Some(source_position);
         Ok(())
     }
 
@@ -47,6 +45,8 @@ impl PresentationBuilder<'_, '_> {
             CommentCommand::JumpToMiddle => self.chunk_operations.push(RenderOperation::JumpToVerticalCenter),
             CommentCommand::InitColumnLayout(columns) => {
                 self.validate_column_layout(&columns, source_position)?;
+                let resolved_position = self.sources.resolve_source_position(source_position);
+                self.slide_state.last_layout_comment = Some(resolved_position);
                 self.slide_state.layout = LayoutState::InLayout { columns_count: columns.len() };
                 self.chunk_operations.push(RenderOperation::InitColumnLayout { columns });
                 self.slide_state.needs_enter_column = true;

--- a/src/presentation/builder/mod.rs
+++ b/src/presentation/builder/mod.rs
@@ -318,7 +318,7 @@ impl<'a, 'b> PresentationBuilder<'a, 'b> {
         if last_valid {
             Ok(())
         } else {
-            let position = self.slide_state.last_comment_position.as_ref().expect("no last position");
+            let position = self.slide_state.last_layout_comment.as_ref().expect("no last position");
             let context = fs::read_to_string(&position.file)
                 .ok()
                 .map(|s| {
@@ -580,7 +580,7 @@ struct SlideState {
     font_size: Option<u8>,
     alignment: Option<Alignment>,
     skip_slide: bool,
-    last_comment_position: Option<FileSourcePosition>,
+    last_layout_comment: Option<FileSourcePosition>,
 }
 
 #[derive(Debug, Default)]


### PR DESCRIPTION
Improve #684 when using include + a layout without a `coumn`