### PR TITLE
feat: add keymap to toggle layout grid

### DIFF
--- a/config-file-schema.json
+++ b/config-file-schema.json
@@ -417,6 +417,13 @@
             "$ref": "#/definitions/KeyBinding"
           }
         },
+        "toggle_layout_grid": {
+          "description": "The key binding to toggle the layout grid.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/KeyBinding"
+          }
+        },
         "toggle_slide_index": {
           "description": "The key binding to toggle the slide index modal.",
           "type": "array",

--- a/src/commands/keyboard.rs
+++ b/src/commands/keyboard.rs
@@ -93,6 +93,7 @@ impl CommandKeyBindings {
             HardReload => Command::HardReload,
             ToggleSlideIndex => Command::ToggleSlideIndex,
             ToggleKeyBindingsConfig => Command::ToggleKeyBindingsConfig,
+            ToggleLayoutGrid => Command::ToggleLayoutGrid,
             CloseModal => Command::CloseModal,
             SkipPauses => Command::SkipPauses,
         };
@@ -124,22 +125,41 @@ impl TryFrom<KeyBindingsConfig> for CommandKeyBindings {
         if !config.go_to_slide.iter().all(|k| k.expects_number()) {
             return Err(KeyBindingsValidationError::Invalid("go_to_slide", "<number> matcher required"));
         }
+        let KeyBindingsConfig {
+            next,
+            next_fast,
+            previous,
+            previous_fast,
+            first_slide,
+            last_slide,
+            go_to_slide,
+            execute_code,
+            reload,
+            toggle_slide_index,
+            toggle_bindings,
+            toggle_layout_grid,
+            close_modal,
+            exit,
+            suspend,
+            skip_pauses,
+        } = config;
         let bindings: Vec<_> = iter::empty()
-            .chain(zip(CommandDiscriminants::Next, config.next))
-            .chain(zip(CommandDiscriminants::NextFast, config.next_fast))
-            .chain(zip(CommandDiscriminants::Previous, config.previous))
-            .chain(zip(CommandDiscriminants::PreviousFast, config.previous_fast))
-            .chain(zip(CommandDiscriminants::FirstSlide, config.first_slide))
-            .chain(zip(CommandDiscriminants::LastSlide, config.last_slide))
-            .chain(zip(CommandDiscriminants::GoToSlide, config.go_to_slide))
-            .chain(zip(CommandDiscriminants::Exit, config.exit))
-            .chain(zip(CommandDiscriminants::Suspend, config.suspend))
-            .chain(zip(CommandDiscriminants::HardReload, config.reload))
-            .chain(zip(CommandDiscriminants::ToggleSlideIndex, config.toggle_slide_index))
-            .chain(zip(CommandDiscriminants::ToggleKeyBindingsConfig, config.toggle_bindings))
-            .chain(zip(CommandDiscriminants::RenderAsyncOperations, config.execute_code))
-            .chain(zip(CommandDiscriminants::CloseModal, config.close_modal))
-            .chain(zip(CommandDiscriminants::SkipPauses, config.skip_pauses))
+            .chain(zip(CommandDiscriminants::Next, next))
+            .chain(zip(CommandDiscriminants::NextFast, next_fast))
+            .chain(zip(CommandDiscriminants::Previous, previous))
+            .chain(zip(CommandDiscriminants::PreviousFast, previous_fast))
+            .chain(zip(CommandDiscriminants::FirstSlide, first_slide))
+            .chain(zip(CommandDiscriminants::LastSlide, last_slide))
+            .chain(zip(CommandDiscriminants::GoToSlide, go_to_slide))
+            .chain(zip(CommandDiscriminants::Exit, exit))
+            .chain(zip(CommandDiscriminants::Suspend, suspend))
+            .chain(zip(CommandDiscriminants::HardReload, reload))
+            .chain(zip(CommandDiscriminants::ToggleSlideIndex, toggle_slide_index))
+            .chain(zip(CommandDiscriminants::ToggleKeyBindingsConfig, toggle_bindings))
+            .chain(zip(CommandDiscriminants::ToggleLayoutGrid, toggle_layout_grid))
+            .chain(zip(CommandDiscriminants::RenderAsyncOperations, execute_code))
+            .chain(zip(CommandDiscriminants::CloseModal, close_modal))
+            .chain(zip(CommandDiscriminants::SkipPauses, skip_pauses))
             .collect();
         Self::validate_conflicts(bindings.iter().map(|binding| &binding.0))?;
         Ok(Self { bindings })

--- a/src/commands/listener.rs
+++ b/src/commands/listener.rs
@@ -96,6 +96,9 @@ pub(crate) enum Command {
     /// Toggle the key bindings config view.
     ToggleKeyBindingsConfig,
 
+    /// Toggle layout grid.
+    ToggleLayoutGrid,
+
     /// Hide the currently open modal, if any.
     CloseModal,
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -476,6 +476,10 @@ pub struct KeyBindingsConfig {
     #[serde(default = "default_toggle_bindings_modal_bindings")]
     pub(crate) toggle_bindings: Vec<KeyBinding>,
 
+    /// The key binding to toggle the layout grid.
+    #[serde(default = "default_toggle_layout_grid")]
+    pub(crate) toggle_layout_grid: Vec<KeyBinding>,
+
     /// The key binding to close the currently open modal.
     #[serde(default = "default_close_modal_bindings")]
     pub(crate) close_modal: Vec<KeyBinding>,
@@ -507,6 +511,7 @@ impl Default for KeyBindingsConfig {
             reload: default_reload_bindings(),
             toggle_slide_index: default_toggle_index_bindings(),
             toggle_bindings: default_toggle_bindings_modal_bindings(),
+            toggle_layout_grid: default_toggle_layout_grid(),
             close_modal: default_close_modal_bindings(),
             exit: default_exit_bindings(),
             suspend: default_suspend_bindings(),
@@ -710,6 +715,10 @@ fn default_toggle_index_bindings() -> Vec<KeyBinding> {
 
 fn default_toggle_bindings_modal_bindings() -> Vec<KeyBinding> {
     make_keybindings(["?"])
+}
+
+fn default_toggle_layout_grid() -> Vec<KeyBinding> {
+    make_keybindings(["T"])
 }
 
 fn default_close_modal_bindings() -> Vec<KeyBinding> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -296,6 +296,7 @@ impl CoreComponents {
             pause_create_new_slide: false,
             list_item_newlines: config.options.list_item_newlines.map(Into::into).unwrap_or(1),
             validate_snippets: config.snippet.validate,
+            layout_grid: false,
         }
     }
 

--- a/src/presentation/builder/mod.rs
+++ b/src/presentation/builder/mod.rs
@@ -90,6 +90,7 @@ pub struct PresentationBuilderOptions {
     pub pause_create_new_slide: bool,
     pub list_item_newlines: u8,
     pub validate_snippets: bool,
+    pub layout_grid: bool,
 }
 
 impl PresentationBuilderOptions {
@@ -136,6 +137,7 @@ impl Default for PresentationBuilderOptions {
             pause_create_new_slide: false,
             list_item_newlines: 1,
             validate_snippets: false,
+            layout_grid: false,
         }
     }
 }

--- a/src/presentation/diff.rs
+++ b/src/presentation/diff.rs
@@ -77,7 +77,9 @@ impl ContentDiff for RenderOperation {
                 true
             }
             (RenderBlockLine(original), RenderBlockLine(updated)) if original != updated => true,
-            (InitColumnLayout { columns: original }, InitColumnLayout { columns: updated }) if original != updated => {
+            (InitColumnLayout { columns: original, .. }, InitColumnLayout { columns: updated, .. })
+                if original != updated =>
+            {
                 true
             }
             (EnterColumn { column: original }, EnterColumn { column: updated }) if original != updated => true,
@@ -120,7 +122,7 @@ mod test {
         },
         presentation::{Slide, SlideBuilder},
         render::{
-            operation::{AsRenderOperations, BlockLine, Pollable, RenderAsync, ToggleState},
+            operation::{AsRenderOperations, BlockLine, LayoutGrid, Pollable, RenderAsync, ToggleState},
             properties::WindowSize,
         },
         theme::{Alignment, Margin},
@@ -164,7 +166,7 @@ mod test {
     ))]
     #[case(RenderOperation::RenderDynamic(Rc::new(Dynamic)))]
     #[case(RenderOperation::RenderAsync(Rc::new(Dynamic)))]
-    #[case(RenderOperation::InitColumnLayout{ columns: vec![1, 2] })]
+    #[case(RenderOperation::InitColumnLayout{ columns: vec![1, 2], grid: LayoutGrid::None })]
     #[case(RenderOperation::EnterColumn{ column: 1 })]
     #[case(RenderOperation::ExitLayout)]
     fn same_not_modified(#[case] operation: RenderOperation) {
@@ -201,8 +203,8 @@ mod test {
 
     #[test]
     fn different_column_layout() {
-        let lhs = RenderOperation::InitColumnLayout { columns: vec![1, 2] };
-        let rhs = RenderOperation::InitColumnLayout { columns: vec![1, 3] };
+        let lhs = RenderOperation::InitColumnLayout { columns: vec![1, 2], grid: LayoutGrid::None };
+        let rhs = RenderOperation::InitColumnLayout { columns: vec![1, 3], grid: LayoutGrid::None };
         assert!(lhs.is_content_different(&rhs));
     }
 

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -259,6 +259,10 @@ impl<'a> Presenter<'a> {
                 }
                 return CommandSideEffect::Reload;
             }
+            Command::ToggleLayoutGrid => {
+                self.options.builder_options.layout_grid = !self.options.builder_options.layout_grid;
+                return CommandSideEffect::Reload;
+            }
             Command::Exit => return CommandSideEffect::Exit,
             Command::Suspend => return CommandSideEffect::Suspend,
             _ => (),
@@ -335,7 +339,12 @@ impl<'a> Presenter<'a> {
                 true
             }
             // These are handled above as they don't require the presentation
-            Command::Reload | Command::HardReload | Command::Exit | Command::Suspend | Command::Redraw => {
+            Command::Reload
+            | Command::HardReload
+            | Command::Exit
+            | Command::Suspend
+            | Command::Redraw
+            | Command::ToggleLayoutGrid => {
                 panic!("unreachable commands")
             }
         };

--- a/src/render/operation.rs
+++ b/src/render/operation.rs
@@ -2,7 +2,7 @@ use super::properties::WindowSize;
 use crate::{
     markdown::{
         text::{WeightedLine, WeightedText},
-        text_style::{Color, Colors},
+        text_style::{Color, Colors, TextStyle},
     },
     terminal::image::Image,
     theme::{Alignment, Margin},
@@ -81,7 +81,7 @@ pub(crate) enum RenderOperation {
     ///
     /// The value for each column is the width of the column in column-unit units, where the entire
     /// screen contains `columns.sum()` column-units.
-    InitColumnLayout { columns: Vec<u8> },
+    InitColumnLayout { columns: Vec<u8>, grid: LayoutGrid },
 
     /// Enter a column in a column layout.
     ///
@@ -96,6 +96,13 @@ pub(crate) enum RenderOperation {
 
     /// Pop an `ApplyMargin` operation.
     PopMargin,
+}
+
+/// Grid options for a layout.
+#[derive(Copy, Clone, Debug)]
+pub(crate) enum LayoutGrid {
+    None,
+    Draw(TextStyle),
 }
 
 /// The properties of an image being rendered.

--- a/src/render/properties.rs
+++ b/src/render/properties.rs
@@ -63,6 +63,15 @@ impl WindowSize {
         }
     }
 
+    /// Set the column count.
+    ///
+    /// This preserves the relationship between columns and pixels.
+    pub(crate) fn set_columns(&self, amount: u16) -> WindowSize {
+        let pixels_per_column = self.pixels_per_column();
+        let width = (pixels_per_column * amount as f64) as u16;
+        WindowSize { rows: self.rows, columns: amount, height: self.height, width }
+    }
+
     /// The number of pixels per column.
     pub(crate) fn pixels_per_column(&self) -> f64 {
         self.width as f64 / self.columns as f64

--- a/src/theme/clean.rs
+++ b/src/theme/clean.rs
@@ -47,6 +47,7 @@ pub(crate) struct PresentationTheme {
     pub(crate) mermaid: MermaidStyle,
     pub(crate) d2: D2Style,
     pub(crate) modals: ModalStyle,
+    pub(crate) layout_grid: LayoutGridStyle,
     pub(crate) palette: ColorPalette,
 }
 
@@ -72,6 +73,7 @@ impl PresentationTheme {
             mermaid,
             d2,
             modals,
+            layout_grid,
             palette,
             extends: _,
         } = raw;
@@ -94,6 +96,7 @@ impl PresentationTheme {
             mermaid: MermaidStyle::new(mermaid),
             d2: D2Style::new(d2),
             modals: ModalStyle::new(modals, &default_style, &palette)?,
+            layout_grid: LayoutGridStyle::new(layout_grid, &default_style, &palette)?,
             palette,
         })
     }
@@ -709,6 +712,26 @@ impl ModalStyle {
         let mut selection_style = style.bold();
         selection_style.merge(&TextStyle::colored(selection_colors.resolve(palette)?));
         Ok(Self { style, selection_style })
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct LayoutGridStyle {
+    pub(crate) style: TextStyle,
+}
+
+impl LayoutGridStyle {
+    fn new(
+        raw: &raw::LayoutGridStyle,
+        default_style: &DefaultStyle,
+        palette: &ColorPalette,
+    ) -> Result<Self, ProcessingThemeError> {
+        let raw::LayoutGridStyle { color } = raw;
+        let mut style = default_style.style;
+        if let Some(color) = color {
+            style.colors.foreground = color.resolve(palette)?;
+        }
+        Ok(Self { style })
     }
 }
 

--- a/src/theme/raw.rs
+++ b/src/theme/raw.rs
@@ -79,6 +79,10 @@ pub struct PresentationTheme {
     #[serde(default)]
     pub(crate) modals: ModalStyle,
 
+    /// The style for layouts.
+    #[serde(default)]
+    pub(crate) layout_grid: LayoutGridStyle,
+
     /// The color palette.
     #[serde(default)]
     pub(crate) palette: ColorPalette,
@@ -806,6 +810,14 @@ pub(crate) struct ModalStyle {
     /// The colors to use for selected lines.
     #[serde(default)]
     pub(crate) selection_colors: RawColors,
+}
+
+/// Layout grid style.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub(crate) struct LayoutGridStyle {
+    /// The color for layout grids.
+    #[serde(default)]
+    pub(crate) color: Option<RawColor>,
 }
 
 /// The color palette.

--- a/themes/catppuccin-frappe.yaml
+++ b/themes/catppuccin-frappe.yaml
@@ -145,6 +145,9 @@ mermaid:
 d2:
   theme: 4
 
+layout_grid:
+  color: palette:blue
+
 palette:
   colors:
     rosewater: "f2d5cf"

--- a/themes/catppuccin-latte.yaml
+++ b/themes/catppuccin-latte.yaml
@@ -145,6 +145,9 @@ mermaid:
 d2:
   theme: 100
 
+layout_grid:
+  color: palette:blue
+
 palette:
   colors:
     rosewater: "dc8a78"

--- a/themes/catppuccin-macchiato.yaml
+++ b/themes/catppuccin-macchiato.yaml
@@ -145,6 +145,9 @@ mermaid:
 d2:
   theme: 200
 
+layout_grid:
+  color: palette:blue
+
 palette:
   colors:
     rosewater: "f4dbd6"

--- a/themes/catppuccin-mocha.yaml
+++ b/themes/catppuccin-mocha.yaml
@@ -145,6 +145,9 @@ mermaid:
 d2:
   theme: 200
 
+layout_grid:
+  color: palette:blue
+
 palette:
   colors:
     rosewater: "f5e0dc"

--- a/themes/dark.yaml
+++ b/themes/dark.yaml
@@ -146,6 +146,9 @@ mermaid:
 d2:
   theme: 200
 
+layout_grid:
+  color: palette:blue
+
 palette:
   colors:
     blue: "3085c3"

--- a/themes/gruvbox-dark.yaml
+++ b/themes/gruvbox-dark.yaml
@@ -144,3 +144,6 @@ mermaid:
 
 d2:
   theme: 103
+
+layout_grid:
+  color: "83a598" 

--- a/themes/light.yaml
+++ b/themes/light.yaml
@@ -145,3 +145,6 @@ mermaid:
 
 d2:
   theme: 4
+
+layout_grid:
+  color: "457b9d"

--- a/themes/terminal-dark.yaml
+++ b/themes/terminal-dark.yaml
@@ -143,3 +143,7 @@ mermaid:
 
 d2:
   theme: 200
+
+layout_grid:
+  color: blue
+

--- a/themes/terminal-light.yaml
+++ b/themes/terminal-light.yaml
@@ -143,3 +143,6 @@ mermaid:
 
 d2:
   theme: 4
+
+layout_grid:
+  color: blue

--- a/themes/tokyonight-storm.yaml
+++ b/themes/tokyonight-storm.yaml
@@ -145,3 +145,6 @@ mermaid:
 
 d2:
   theme: 200
+
+layout_grid:
+  color: "7aa2f7"


### PR DESCRIPTION
This adds a new keymap (uppercase `T`) that toggles a layout grid for column layouts. This causes a vertical line to show up  in between every column in a column layout, which can ease debugging the layout.

https://github.com/user-attachments/assets/c80fd9af-8917-418f-8c4f-a9cd96197120

Closes #707
Also closes #717 since this touched the same code.

