### PR TITLE
fix: don't add extra heading lines depending on font size

### DIFF
--- a/src/presentation/builder/heading.rs
+++ b/src/presentation/builder/heading.rs
@@ -58,7 +58,7 @@ impl PresentationBuilder<'_, '_> {
         text.apply_style(&style.style);
 
         self.push_text(text, element_type);
-        self.push_line_breaks(self.slide_font_size() as usize);
+        self.push_line_break();
         Ok(())
     }
 }
@@ -158,6 +158,27 @@ bar
         let lines = Test::new(input).theme(theme).render().rows(10).columns(6).advances(1).into_lines();
         let expected =
             &["      ", "! A   ", "      ", "@@ B  ", "      ", "  C   ", "      ", "D     ", "      ", "E     "];
+        assert_eq!(lines, expected);
+    }
+
+    #[test]
+    fn heading_font_size() {
+        let input = "
+<!-- font_size: 3 -->
+# hi
+<!-- font_size: 2 -->
+## bye
+";
+        let lines = Test::new(input).render().rows(6).columns(10).into_lines();
+        let expected = &[
+            //
+            "          ",
+            "h  i      ",
+            "          ",
+            "          ", // text end (3 rows)
+            "          ", // a single new line
+            "b y e     ", // the next text
+        ];
         assert_eq!(lines, expected);
     }
 }


### PR DESCRIPTION
This changes the behavior when an explicit `font_size` is set and a heading other than a slide title is used, so that we only add a single extra line after the heading, rather than one line per font size (e.g. 3 lines for font size 3). This was a deliberate choice initially but I'm not exactly sure why. If this breaks someone's flow please comment here!

Closes #714