### PR TITLE
feat: allow setting headings to be bold/italics/underlined

### DIFF
--- a/src/theme/clean.rs
+++ b/src/theme/clean.rs
@@ -224,9 +224,18 @@ impl HeadingStyle {
         palette: &ColorPalette,
         options: &ThemeOptions,
     ) -> Result<Self, ProcessingThemeError> {
-        let raw::HeadingStyle { alignment, prefix, colors, font_size } = raw;
+        let raw::HeadingStyle { alignment, prefix, colors, font_size, bold, underlined, italics } = raw;
         let alignment = alignment.clone().unwrap_or_default().into();
-        let style = TextStyle::colored(colors.resolve(palette)?).size(options.adjust_font_size(*font_size));
+        let mut style = TextStyle::colored(colors.resolve(palette)?).size(options.adjust_font_size(*font_size));
+        if bold.unwrap_or_default() {
+            style = style.bold();
+        }
+        if underlined.unwrap_or_default() {
+            style = style.underlined();
+        }
+        if italics.unwrap_or_default() {
+            style = style.italics();
+        }
         Ok(Self { alignment, prefix: prefix.clone(), style })
     }
 }

--- a/src/theme/raw.rs
+++ b/src/theme/raw.rs
@@ -186,6 +186,18 @@ pub(crate) struct HeadingStyle {
     /// The font size to be used if the terminal supports it.
     #[serde(default)]
     pub(crate) font_size: Option<u8>,
+
+    /// Whether the heading is bold.
+    #[serde(default)]
+    pub(crate) bold: Option<bool>,
+
+    /// Whether the heading is underlined.
+    #[serde(default)]
+    pub(crate) underlined: Option<bool>,
+
+    /// Whether the heading uses italics.
+    #[serde(default)]
+    pub(crate) italics: Option<bool>,
 }
 
 /// The style of a block quote.


### PR DESCRIPTION
This allows setting bold, underlined, and italics for headings in the theme:

```markdown
---
theme:
  override:
    headings:
      h2:
        bold: true
        underlined: true
        italics: true
---

## title
```

Closes #720