### PR TITLE
docs: sync supported terminals

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Visit the [documentation][docs-introduction] to get started.
 # Features
 
 * Presentations consist of one [or more][docs-include] markdown files.
-* [Images and animated gifs][docs-images] on terminals like _kitty_, _iterm2_, and _wezterm_.
+* [Images and animated gifs][docs-images] on terminals like _kitty_, _iterm2_, _wezterm_, _ghostty_ and _foot_.
 * [Customizable themes][docs-themes] including colors, margins, layout (left/center aligned content), footer for every 
   slide, etc. Several [built-in themes][docs-builtin-themes] can give your presentation the look you want without 
   having to define your own.

--- a/docs/src/features/images.md
+++ b/docs/src/features/images.md
@@ -8,6 +8,7 @@ the terminals where at least one of these is supported are:
 * [kitty](https://sw.kovidgoyal.net/kitty/)
 * [iterm2](https://iterm2.com/)
 * [WezTerm](https://wezfurlong.org/wezterm/index.html)
+* [ghostty](https://ghostty.org/)
 * [foot](https://codeberg.org/dnkl/foot)
 
 Sixel support is experimental so it needs to be explicitly enabled via the `sixel` configuration flag:
@@ -56,4 +57,3 @@ horizontally.
 By default the image protocol to be used will be automatically detected. In cases where this detection fails, you can 
 set it manually via the `--image-protocol` parameter or by setting it in the [config 
 file](../configuration/settings.md#preferred-image-protocol).
-

--- a/examples/demo.md
+++ b/examples/demo.md
@@ -138,6 +138,7 @@ Images and animated gifs are supported in terminals such as:
 * iterm2
 * wezterm
 * ghostty
+* foot
 * Any sixel enabled terminal
 
 <!-- column_layout: [1, 3, 1] -->


### PR DESCRIPTION
Just a small patch to have the same lists of supported terminals in `docs/src/features/images.md`, `examples/demo.md` and `README.md`