### PR TITLE
feat: add --list-comment-commands CLI option

### DIFF
--- a/docs/src/features/commands.md
+++ b/docs/src/features/commands.md
@@ -149,3 +149,71 @@ centered
 right aligned
 ```
 
+## Listing available comment commands
+
+The `--list-comment-commands` CLI option outputs all available comment commands to stdout, making it easy to discover and use them in external tools and editors.
+
+### Purpose
+
+This feature is designed to:
+- Provide a machine-readable list of all comment commands
+- Enable editor integrations for autocompletion and snippets
+- Allow validation of comment commands in external tools
+- Serve as a quick reference without consulting documentation
+
+### Usage
+
+```bash
+# List all available comment commands
+presenterm --list-comment-commands
+
+# Use with fzf for interactive selection
+presenterm --list-comment-commands | fzf
+
+# Pipe to grep to filter specific commands
+presenterm --list-comment-commands | grep alignment
+```
+
+### Output format
+
+Each command is output on a separate line with appropriate default values where applicable:
+
+```
+<!-- pause -->
+<!-- end_slide -->
+<!-- new_line -->
+<!-- new_lines: 2 -->
+<!-- jump_to_middle -->
+<!-- column_layout: [1, 2] -->
+<!-- column: 0 -->
+<!-- reset_layout -->
+<!-- incremental_lists: true -->
+<!-- incremental_lists: false -->
+<!-- no_footer -->
+<!-- font_size: 2 -->
+<!-- alignment: left -->
+<!-- alignment: center -->
+<!-- alignment: right -->
+<!-- skip_slide -->
+<!-- list_item_newlines: 2 -->
+<!-- include: file.md -->
+<!-- speaker_note: Your note here -->
+<!-- snippet_output: identifier -->
+```
+
+### Editor integration example: Vim
+
+For Vim users with fzf.vim installed, you can add this to your `.vimrc` to enable quick insertion of comment commands:
+
+```vim
+" Presenterm comment command helper
+if executable('presenterm') && executable('fzf')
+  inoremap <expr> <c-k> fzf#vim#complete(fzf#wrap({
+        \ 'source':  'presenterm --list-comment-commands',
+        \ 'options': '--header "Comment Command Selection" --no-hscroll',
+        \ 'reducer': { lines -> split(lines[0])[0] } }))
+endif
+```
+
+With this configuration, pressing `Ctrl+K` in insert mode will open an fzf picker with all available comment commands, allowing you to quickly select and insert them into your presentation.
+

--- a/docs/src/features/commands.md
+++ b/docs/src/features/commands.md
@@ -211,7 +211,7 @@ if executable('presenterm') && executable('fzf')
   inoremap <expr> <c-k> fzf#vim#complete(fzf#wrap({
         \ 'source':  'presenterm --list-comment-commands',
         \ 'options': '--header "Comment Command Selection" --no-hscroll',
-        \ 'reducer': { lines -> split(lines[0])[0] } }))
+        \ 'reducer': { lines -> lines[0] } }))
 endif
 ```
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use crate::{
     demo::ThemesDemo,
     export::exporter::Exporter,
     markdown::parse::MarkdownParser,
-    presentation::builder::{PresentationBuilderOptions, Themes},
+    presentation::builder::{CommentCommand, PresentationBuilderOptions, Themes},
     presenter::{PresentMode, Presenter, PresenterOptions},
     resource::Resources,
     terminal::{
@@ -139,6 +139,10 @@ struct Cli {
     /// Whether to validate snippets.
     #[clap(long)]
     validate_snippets: bool,
+
+    /// List all available comment commands.
+    #[clap(long, group = "target")]
+    list_comment_commands: bool,
 }
 
 fn create_splash() -> String {
@@ -387,6 +391,12 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         let theme_name =
             cli.theme.as_ref().or(config.defaults.theme.as_ref()).map(|s| s.as_str()).unwrap_or(DEFAULT_THEME);
         println!("{theme_name}");
+        return Ok(());
+    } else if cli.list_comment_commands {
+        let samples = CommentCommand::generate_samples();
+        for sample in samples {
+            println!("{}", sample);
+        }
         return Ok(());
     }
     // Disable this so we don't mess things up when generating PDFs

--- a/src/presentation/builder/comment.rs
+++ b/src/presentation/builder/comment.rs
@@ -182,7 +182,7 @@ impl PresentationBuilder<'_, '_> {
 
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 #[serde(rename_all = "snake_case")]
-enum CommentCommand {
+pub(crate) enum CommentCommand {
     Alignment(CommentCommandAlignment),
     Column(usize),
     EndSlide,
@@ -205,6 +205,34 @@ enum CommentCommand {
     SnippetOutput(String),
 }
 
+impl CommentCommand {
+    /// Generate sample comment strings for all available commands
+    pub(crate) fn generate_samples() -> Vec<String> {
+        vec![
+            format!("<!-- pause -->"),
+            format!("<!-- end_slide -->"),
+            format!("<!-- new_line -->"),
+            format!("<!-- new_lines: 2 -->"),
+            format!("<!-- jump_to_middle -->"),
+            format!("<!-- column_layout: [1, 2] -->"),
+            format!("<!-- column: 0 -->"),
+            format!("<!-- reset_layout -->"),
+            format!("<!-- incremental_lists: true -->"),
+            format!("<!-- incremental_lists: false -->"),
+            format!("<!-- no_footer -->"),
+            format!("<!-- font_size: 2 -->"),
+            format!("<!-- alignment: left -->"),
+            format!("<!-- alignment: center -->"),
+            format!("<!-- alignment: right -->"),
+            format!("<!-- skip_slide -->"),
+            format!("<!-- list_item_newlines: 2 -->"),
+            format!("<!-- include: file.md -->"),
+            format!("<!-- speaker_note: Your note here -->"),
+            format!("<!-- snippet_output: identifier -->"),
+        ]
+    }
+}
+
 impl FromStr for CommentCommand {
     type Err = CommandParseError;
 
@@ -219,7 +247,7 @@ impl FromStr for CommentCommand {
 
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 #[serde(rename_all = "snake_case")]
-enum CommentCommandAlignment {
+pub(crate) enum CommentCommandAlignment {
     Left,
     Center,
     Right,

--- a/src/presentation/builder/mod.rs
+++ b/src/presentation/builder/mod.rs
@@ -49,6 +49,8 @@ use std::{
 pub(crate) mod error;
 
 mod comment;
+pub(crate) use comment::CommentCommand;
+
 mod frontmatter;
 mod heading;
 mod images;


### PR DESCRIPTION
## Summary

This PR adds a new CLI option `--list-comment-commands` that outputs all available presenterm comment commands to stdout.

## Motivation

The intention is to enable external tools and editors (like vim with fzf) to:
- Use this output as a source for snippet generation
- Validate comment commands
- Provide better autocompletion and tooling support

## Implementation

- Made the `CommentCommand` enum accessible internally
- Added a `generate_samples()` method that creates example strings for all comment types
- Added the CLI flag `--list-comment-commands` that outputs each command on a separate line

## Usage Example

```bash
# List all available commands
presenterm --list-comment-commands

# Use with fzf for interactive selection
presenterm --list-comment-commands | fzf

# Use in vim for snippet generation
:r !presenterm --list-comment-commands | fzf
```

## Output Format

Each command is output on its own line with appropriate default values:
```
<!-- pause -->
<!-- font_size: 2 -->
<!-- column_layout: [1, 2] -->
<!-- alignment: center -->
...
```

This format is designed to be easily parsed by external tools while also being valid presenterm syntax that can be directly inserted into markdown files.

## Usage with vim

```vimscript
" Presenterm comment command helper
if executable('presenterm') && executable('fzf')
  inoremap <expr> <c-k> fzf#vim#complete(fzf#wrap({
        \ 'source':  'presenterm --list-comment-commands',
        \ 'options': '--header "Comment Command Selection" --no-hscroll',
        \ 'reducer': { lines -> lines[0] } }))
endif
```

So when on insert mode I hit `ctrl+k` and I can choose which comment command to use.

## Why not just using snippets?

Using present itself to output the available commands makes it always up to date.