### PR TITLE
fix: keep state between pauses on pause-new-slide

### DIFF
--- a/src/presentation/builder/comment.rs
+++ b/src/presentation/builder/comment.rs
@@ -540,6 +540,22 @@ bye
     }
 
     #[test]
+    fn pause_layout_new_slide() {
+        let input = r"
+<!-- column_layout: [1, 1] -->
+<!-- column: 0 -->
+hi
+<!-- pause -->
+<!-- column: 1 -->
+bye
+";
+        let options = PresentationBuilderOptions { pause_create_new_slide: true, ..Default::default() };
+        let lines = Test::new(input).options(options).render().rows(3).columns(15).advances(1).into_lines();
+        let expected = &["               ", "hi         bye ", "               "];
+        assert_eq!(lines, expected);
+    }
+
+    #[test]
     fn skip_slide() {
         let input = "
 hi

--- a/src/presentation/builder/error.rs
+++ b/src/presentation/builder/error.rs
@@ -124,7 +124,7 @@ pub(crate) enum InvalidPresentation {
     SnippetAlreadyExists(String),
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) struct FileSourcePosition {
     pub(crate) source_position: SourcePosition,
     pub(crate) file: PathBuf,

--- a/src/presentation/builder/mod.rs
+++ b/src/presentation/builder/mod.rs
@@ -445,8 +445,10 @@ impl<'a, 'b> PresentationBuilder<'a, 'b> {
     fn push_pause(&mut self) {
         if self.options.pause_create_new_slide {
             let operations = self.chunk_operations.clone();
+            let slide_state = self.slide_state.clone();
             self.terminate_slide();
             self.chunk_operations = operations;
+            self.slide_state = slide_state;
             return;
         }
         self.slide_state.last_chunk_ended_in_list = matches!(self.slide_state.last_element, LastElement::List { .. });
@@ -570,7 +572,7 @@ impl PresentationReader for FilesystemPresentationReader {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 struct SlideState {
     ignore_element_line_break: bool,
     ignore_footer: bool,
@@ -587,7 +589,7 @@ struct SlideState {
     last_layout_comment: Option<FileSourcePosition>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 enum LayoutState {
     #[default]
     Default,
@@ -600,7 +602,7 @@ enum LayoutState {
     },
 }
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 enum LastElement {
     #[default]
     None,


### PR DESCRIPTION
Using `export.pauses: new_slide` would cause the slide state to be tossed away, which meant any state (e.g. layout, font size, etc) before the pause was tossed away.

Closes #730