### PR TITLE
feat: respect `pause` in speaker notes

### DIFF
--- a/src/commands/keyboard.rs
+++ b/src/commands/keyboard.rs
@@ -96,6 +96,7 @@ impl CommandKeyBindings {
             ToggleLayoutGrid => Command::ToggleLayoutGrid,
             CloseModal => Command::CloseModal,
             SkipPauses => Command::SkipPauses,
+            GoToSlideChunk => panic!("go to slide chunk is not configurable"),
         };
         InputAction::Emit(command)
     }

--- a/src/commands/listener.rs
+++ b/src/commands/listener.rs
@@ -30,7 +30,7 @@ impl CommandListener {
         if let Some(receiver) = &self.speaker_notes_event_listener {
             if let Some(msg) = receiver.try_recv()? {
                 let command = match msg {
-                    SpeakerNotesEvent::GoToSlide { slide } => Command::GoToSlide(slide),
+                    SpeakerNotesEvent::GoTo { slide, chunk } => Command::GoToSlideChunk { slide, chunk },
                     SpeakerNotesEvent::Exit => Command::Exit,
                 };
                 return Ok(Some(command));
@@ -72,6 +72,9 @@ pub(crate) enum Command {
 
     /// Go to one particular slide.
     GoToSlide(u32),
+
+    /// Go to one particular slide + chunk.
+    GoToSlideChunk { slide: u32, chunk: u32 },
 
     /// Render any async render operations in the current slide.
     RenderAsyncOperations,

--- a/src/commands/speaker_notes.rs
+++ b/src/commands/speaker_notes.rs
@@ -68,7 +68,7 @@ impl SpeakerNotesEventListener {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "command")]
 pub(crate) enum SpeakerNotesEvent {
-    GoToSlide { slide: u32 },
+    GoTo { slide: u32, chunk: u32 },
     Exit,
 }
 

--- a/src/presentation/builder/comment.rs
+++ b/src/presentation/builder/comment.rs
@@ -129,8 +129,10 @@ impl PresentationBuilder<'_, '_> {
                     self.push_text(line.into(), ElementType::Paragraph);
                     self.push_line_break();
                 }
+                self.push_line_break();
             }
             CommentCommand::EndSlide => self.terminate_slide(),
+            CommentCommand::Pause => self.push_pause(),
             CommentCommand::SkipSlide => self.slide_state.skip_slide = true,
             _ => {}
         }
@@ -621,8 +623,23 @@ hi
 <!-- speaker_note: bye -->
 ";
         let options = PresentationBuilderOptions { render_speaker_notes_only: true, ..Default::default() };
-        let lines = Test::new(input).options(options).render().rows(3).columns(3).into_lines();
-        let expected = &["   ", "hi ", "bye"];
+        let lines = Test::new(input).options(options).render().rows(4).columns(3).into_lines();
+        let expected = &["   ", "hi ", "   ", "bye"];
+        assert_eq!(lines, expected);
+    }
+
+    #[test]
+    fn speaker_notes_pause() {
+        let input = "
+<!-- speaker_note: hi -->
+
+<!-- pause -->
+
+<!-- speaker_note: bye -->
+";
+        let options = PresentationBuilderOptions { render_speaker_notes_only: true, ..Default::default() };
+        let lines = Test::new(input).options(options).render().rows(4).columns(3).advances(0).into_lines();
+        let expected = &["   ", "hi ", "   ", "   "];
         assert_eq!(lines, expected);
     }
 

--- a/src/presentation/mod.rs
+++ b/src/presentation/mod.rs
@@ -268,15 +268,15 @@ impl Slide {
         self.chunks.iter()
     }
 
-    fn jump_chunk(&mut self, chunk_index: usize) {
+    pub(crate) fn current_chunk_index(&self) -> usize {
+        self.visible_chunks.saturating_sub(1)
+    }
+
+    pub(crate) fn jump_chunk(&mut self, chunk_index: usize) {
         self.visible_chunks = chunk_index.saturating_add(1).min(self.chunks.len());
         for chunk in self.chunks.iter().take(self.visible_chunks - 1) {
             chunk.apply_all_mutations();
         }
-    }
-
-    fn current_chunk_index(&self) -> usize {
-        self.visible_chunks.saturating_sub(1)
     }
 
     fn current_chunk(&self) -> &SlideChunk {

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -165,8 +165,11 @@ impl<'a> Presenter<'a> {
                     CommandSideEffect::None => (),
                 };
             }
-            self.publish_event(SpeakerNotesEvent::GoToSlide {
-                slide: self.state.presentation().current_slide_index() as u32 + 1,
+            let slide_index = self.state.presentation().current_slide_index() as u32 + 1;
+            let slide = self.state.presentation().current_slide();
+            self.publish_event(SpeakerNotesEvent::GoTo {
+                slide: slide_index,
+                chunk: slide.current_chunk_index() as u32,
             })?;
         }
     }
@@ -310,6 +313,11 @@ impl<'a> Presenter<'a> {
             Command::FirstSlide => presentation.jump_first_slide(),
             Command::LastSlide => presentation.jump_last_slide(),
             Command::GoToSlide(number) => presentation.go_to_slide(number.saturating_sub(1) as usize),
+            Command::GoToSlideChunk { slide, chunk } => {
+                presentation.go_to_slide(slide.saturating_sub(1) as usize);
+                presentation.current_slide_mut().jump_chunk(chunk as usize);
+                true
+            }
             Command::RenderAsyncOperations => {
                 let pollables = Self::trigger_slide_async_renders(presentation);
                 if !pollables.is_empty() {


### PR DESCRIPTION
This changes the speaker notes listener mode so it respects pauses.

This makes the following presentation work the following way from a speaker notes listener:

```markdown
title
===

I will talk about `foo`

<!-- speaker_note: |
    do not forget to mention the `foo`
    this is very important as otherwise nobody will understand 
-->

<!-- pause -->

I will talk about `bar`

<!-- speaker_note: 
    saying `bar` repeatedly will captivate my audience
-->

<!-- end_slide -->

other

```

[![asciicast](https://asciinema.org/a/KXmipmlok9T5RfYlW0Nqn2Trr.svg)](https://asciinema.org/a/KXmipmlok9T5RfYlW0Nqn2Trr)

Closes #543