### PR TITLE
feat: allow styling bold/italics

### DIFF
--- a/src/markdown/text_style.rs
+++ b/src/markdown/text_style.rs
@@ -105,6 +105,16 @@ where
         self.has_flag(TextFormatFlags::Code)
     }
 
+    /// Check whether this text is bold.
+    pub(crate) fn is_bold(&self) -> bool {
+        self.has_flag(TextFormatFlags::Bold)
+    }
+
+    /// Check whether this text is italics.
+    pub(crate) fn is_italics(&self) -> bool {
+        self.has_flag(TextFormatFlags::Italics)
+    }
+
     /// Merge this style with another one.
     pub(crate) fn merge(&mut self, other: &TextStyle<C>) {
         self.flags |= other.flags;

--- a/src/presentation/builder/mod.rs
+++ b/src/presentation/builder/mod.rs
@@ -531,7 +531,13 @@ impl<'a, 'b> PresentationBuilder<'a, 'b> {
 
     fn apply_theme_text_style(&self, text: &mut Text) {
         if text.style.is_code() {
-            text.style.colors = self.theme.inline_code.style.colors;
+            text.style.merge(&self.theme.inline_code.style);
+        }
+        if text.style.is_bold() {
+            text.style.merge(&self.theme.bold.style);
+        }
+        if text.style.is_italics() {
+            text.style.merge(&self.theme.italics.style);
         }
     }
 

--- a/src/theme/clean.rs
+++ b/src/theme/clean.rs
@@ -35,7 +35,9 @@ pub(crate) struct PresentationTheme {
     pub(crate) slide_title: SlideTitleStyle,
     pub(crate) code: CodeBlockStyle,
     pub(crate) execution_output: ExecutionOutputBlockStyle,
-    pub(crate) inline_code: InlineCodeStyle,
+    pub(crate) inline_code: ModifierStyle,
+    pub(crate) bold: ModifierStyle,
+    pub(crate) italics: ModifierStyle,
     pub(crate) table: Alignment,
     pub(crate) block_quote: BlockQuoteStyle,
     pub(crate) alert: AlertStyle,
@@ -62,6 +64,8 @@ impl PresentationTheme {
             code,
             execution_output,
             inline_code,
+            bold,
+            italics,
             table,
             block_quote,
             alert,
@@ -84,7 +88,9 @@ impl PresentationTheme {
             slide_title: SlideTitleStyle::new(slide_title, &palette, options)?,
             code: CodeBlockStyle::new(code),
             execution_output: ExecutionOutputBlockStyle::new(execution_output, &palette)?,
-            inline_code: InlineCodeStyle::new(inline_code, &palette)?,
+            inline_code: ModifierStyle::new(inline_code, &palette)?,
+            bold: ModifierStyle::new(bold, &palette)?,
+            italics: ModifierStyle::new(italics, &palette)?,
             table: table.clone().unwrap_or_default().into(),
             block_quote: BlockQuoteStyle::new(block_quote, &palette)?,
             alert: AlertStyle::new(alert, &palette)?,
@@ -626,13 +632,13 @@ impl ExecutionStatusBlockStyle {
 }
 
 #[derive(Clone, Debug, Default)]
-pub(crate) struct InlineCodeStyle {
+pub(crate) struct ModifierStyle {
     pub(crate) style: TextStyle,
 }
 
-impl InlineCodeStyle {
-    fn new(raw: &raw::InlineCodeStyle, palette: &ColorPalette) -> Result<Self, ProcessingThemeError> {
-        let raw::InlineCodeStyle { colors } = raw;
+impl ModifierStyle {
+    fn new(raw: &raw::ModifierStyle, palette: &ColorPalette) -> Result<Self, ProcessingThemeError> {
+        let raw::ModifierStyle { colors } = raw;
         let style = TextStyle::colored(colors.resolve(palette)?);
         Ok(Self { style })
     }

--- a/src/theme/raw.rs
+++ b/src/theme/raw.rs
@@ -33,7 +33,15 @@ pub struct PresentationTheme {
 
     /// The style for inline code.
     #[serde(default)]
-    pub(crate) inline_code: InlineCodeStyle,
+    pub(crate) inline_code: ModifierStyle,
+
+    /// The style for bold text.
+    #[serde(default)]
+    pub(crate) bold: ModifierStyle,
+
+    /// The style for italics.
+    #[serde(default)]
+    pub(crate) italics: ModifierStyle,
 
     /// The style for a table.
     #[serde(default)]
@@ -692,9 +700,8 @@ pub(crate) struct ExecutionStatusBlockStyle {
     pub(crate) not_started: RawColors,
 }
 
-/// The style for inline code.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-pub(crate) struct InlineCodeStyle {
+pub(crate) struct ModifierStyle {
     /// The colors to be used.
     #[serde(default)]
     pub(crate) colors: RawColors,


### PR DESCRIPTION
This allows configuring a color for bold/italics text in the theme. When text is both bold and italics and both have a style defined in the theme, you'll get a mix (first bold style applied, then italics). This means that if both set e.g. the foreground color, the last one will win, but if one defines background and the other one foreground you'll get the mix you expect.

See the example below:

```markdown
---
theme:
  override:
    bold:
      colors:
        foreground: red
    italics:
      colors:
        background: blue
---


hi **hi** _hi_

**_both_**

```

<img width="1122" height="950" alt="image" src="https://github.com/user-attachments/assets/e251fa82-1963-44ff-bae8-2e3b29891fe4" />

Closes #501