### PR TITLE
feat: allow setting prefix on slide titles

### DIFF
--- a/src/theme/clean.rs
+++ b/src/theme/clean.rs
@@ -149,6 +149,7 @@ pub(crate) struct SlideTitleStyle {
     pub(crate) padding_top: u8,
     pub(crate) padding_bottom: u8,
     pub(crate) style: TextStyle,
+    pub(crate) prefix: String,
 }
 
 impl SlideTitleStyle {
@@ -167,6 +168,7 @@ impl SlideTitleStyle {
             italics,
             underlined,
             font_size,
+            prefix,
         } = raw;
         let colors = colors.resolve(palette)?;
         let mut style = TextStyle::colored(colors).size(options.adjust_font_size(*font_size));
@@ -185,6 +187,7 @@ impl SlideTitleStyle {
             padding_top: padding_top.unwrap_or_default(),
             padding_bottom: padding_bottom.unwrap_or_default(),
             style,
+            prefix: prefix.clone().unwrap_or_default(),
         })
     }
 }

--- a/src/theme/raw.rs
+++ b/src/theme/raw.rs
@@ -129,6 +129,10 @@ pub(crate) struct SlideTitleStyle {
     #[serde(default)]
     pub(crate) colors: RawColors,
 
+    /// The prefix to be added to the slide title.
+    #[serde(default)]
+    pub(crate) prefix: Option<String>,
+
     /// Whether to use bold font for slide titles.
     #[serde(default)]
     pub(crate) bold: Option<bool>,


### PR DESCRIPTION
This allows configuring a `prefix` on slide titles, which essentially allows you to make a slide title have the same style as a heading, since this was the only thing missing:

```markdown
---
theme:
  override:
    slide_title:
      prefix: "██"
      alignment: left
      font_size: 1
---

title
===
```

<img width="610" height="594" alt="image" src="https://github.com/user-attachments/assets/9270367e-a06e-4c65-b870-8964d920eebf" />

Closes #694
