### PR TITLE
fix: 759 - allow relative paths for custom d2 icons

### DIFF
--- a/examples/custom-d2-icon.md
+++ b/examples/custom-d2-icon.md
@@ -1,0 +1,14 @@
+---
+title: Custom d2 icon
+---
+
+Custom D2 Icon
+===
+
+```d2 +render
+custom_image: "" {
+  shape: image
+  icon: "doge.png"
+}
+```
+

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -1,6 +1,7 @@
 use itertools::Itertools;
 use std::{
     io::{self, Write},
+    path::Path,
     process::{Command, Output, Stdio},
 };
 
@@ -47,6 +48,11 @@ impl Tool {
 
     pub(crate) fn stdin(mut self, stdin: Vec<u8>) -> Self {
         self.stdin = Some(stdin);
+        self
+    }
+
+    pub(crate) fn current_dir(mut self, path: &Path) -> Self {
+        self.command.current_dir(path);
         self
     }
 


### PR DESCRIPTION
**Sorry but I don't know anything about rust. This is 100% vibe coded.**

I almost didn't submit this, but it does solve the issue I raised in #759. I don't know about the code quality.

This is a significant change to the d2 rendering. Instead of creating a temp directory it creates the temp the input/output files in the same directory as the presentation. This allows the d2 command-line tool to correctly resolve relative paths for assets like custom icons. The downside to this approach is: if the program crashes before the temp files are cleaned up, we will have cluttered the user's presentation directory.

I have another implementation [here](https://github.com/seantwie03/presenterm/blob/fix/d2-relative-icon-paths-temp-dir/src/third_party.rs#L223). This implementation keeps the temp dir. It tries to parse the input for `icon:` then it checks if the token immediately following is a file. If it is, it will copy it to the temp dir. This implementation has a lot of nested if statements.

I tried to vibe code some tests, but it wasn't working because it couldn't load the images in the test environment.

If you don't like either of these approaches or don't want to merge this for any reason that is 100% OK. I just wanted to submit it because I don't like submitting issues without at least trying to help.