### PR TITLE
feat: Allow mirroring the main slide

### DIFF
--- a/docs/src/features/speaker-notes.md
+++ b/docs/src/features/speaker-notes.md
@@ -6,6 +6,9 @@ Starting on version 0.10.0, _presenterm_ allows presentations to define speaker 
 which you will present like you usually do.
 * Another instance should be started using the `--listen-speaker-notes` parameter. This instance will only display 
 speaker notes in the presentation and will automatically change slides whenever the main instance does so.
+* Optionally, you can start another instance using the `--mirror-main-slide` parameter. This instance will display the
+main slide content (what the audience sees) and will automatically follow the main instance. This is useful when the
+speaker cannot directly see the projected screen.
 
 For example:
 
@@ -15,6 +18,9 @@ presenterm demo.md --publish-speaker-notes
 
 # In another shell: start the speaker notes instance
 presenterm demo.md --listen-speaker-notes
+
+# Optionally, in a third shell: mirror the main slide for the speaker
+presenterm demo.md --mirror-main-slide
 ```
 
 [![asciicast](https://asciinema.org/a/ETusvlmHuHrcLKzwa0CMQRX2J.svg)](https://asciinema.org/a/ETusvlmHuHrcLKzwa0CMQRX2J)

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,6 +136,10 @@ struct Cli {
     #[clap(short, long, group = "speaker-notes")]
     listen_speaker_notes: bool,
 
+    /// Whether to mirror the main slide being presented.
+    #[clap(short = 'M', long, group = "speaker-notes")]
+    mirror_main_slide: bool,
+
     /// Whether to validate snippets.
     #[clap(long)]
     validate_snippets: bool,
@@ -337,15 +341,14 @@ impl SpeakerNotesComponents {
     fn new(cli: &Cli, config: &Config, path: &Path) -> anyhow::Result<Self> {
         let full_presentation_path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
         let publish_speaker_notes =
-            cli.publish_speaker_notes || (config.speaker_notes.always_publish && !cli.listen_speaker_notes);
+            cli.publish_speaker_notes || (config.speaker_notes.always_publish && !cli.listen_speaker_notes && !cli.mirror_main_slide);
         let events_publisher = publish_speaker_notes
             .then(|| {
                 SpeakerNotesEventPublisher::new(config.speaker_notes.publish_address, full_presentation_path.clone())
             })
             .transpose()
             .map_err(|e| anyhow!("failed to create speaker notes publisher: {e}"))?;
-        let events_listener = cli
-            .listen_speaker_notes
+        let events_listener = (cli.listen_speaker_notes || cli.mirror_main_slide)
             .then(|| SpeakerNotesEventListener::new(config.speaker_notes.listen_address, full_presentation_path))
             .transpose()
             .map_err(|e| anyhow!("failed to create speaker notes listener: {e}"))?;


### PR DESCRIPTION
Add support for launching a secondary instance that mirrors the main instance.

Chunks are supported. Code selective highlighting is not supported at this time.

Closes https://github.com/mfontanini/presenterm/issues/758