### PR TITLE
feat: allow configuring code block line numbers at theme level

### DIFF
--- a/src/presentation/builder/snippet.rs
+++ b/src/presentation/builder/snippet.rs
@@ -33,6 +33,9 @@ impl PresentationBuilder<'_, '_> {
         if matches!(snippet.language, SnippetLanguage::File) {
             snippet = self.load_external_snippet(snippet, source_position)?;
         }
+        if self.theme.code.line_numbers {
+            snippet.attributes.line_numbers = true;
+        }
         if self.options.auto_render_languages.contains(&snippet.language) {
             snippet.attributes.representation = SnippetRepr::Render;
         }
@@ -434,6 +437,24 @@ language: bash
     fn line_numbers() {
         let input = "
 ```bash +line_numbers
+hi
+bye
+```";
+        let lines = Test::new(input).render().rows(4).columns(5).into_lines();
+        let expected = &["     ", "1 hi ", "2 bye", "     "];
+        assert_eq!(lines, expected);
+    }
+
+    #[test]
+    fn line_numbers_via_theme() {
+        let input = "---
+theme:
+  override:
+    code:
+      line_numbers: true
+---
+
+```bash
 hi
 bye
 ```";

--- a/src/theme/clean.rs
+++ b/src/theme/clean.rs
@@ -567,11 +567,12 @@ pub(crate) struct CodeBlockStyle {
     pub(crate) padding: PaddingRect,
     pub(crate) theme_name: String,
     pub(crate) background: bool,
+    pub(crate) line_numbers: bool,
 }
 
 impl CodeBlockStyle {
     fn new(raw: &raw::CodeBlockStyle) -> Self {
-        let raw::CodeBlockStyle { alignment, padding, theme_name, background } = raw;
+        let raw::CodeBlockStyle { alignment, padding, theme_name, background, line_numbers } = raw;
         let padding = PaddingRect {
             horizontal: padding.horizontal.unwrap_or_default(),
             vertical: padding.vertical.unwrap_or_default(),
@@ -581,6 +582,7 @@ impl CodeBlockStyle {
             padding,
             theme_name: theme_name.as_deref().unwrap_or(DEFAULT_CODE_HIGHLIGHT_THEME).to_string(),
             background: background.unwrap_or(true),
+            line_numbers: line_numbers.unwrap_or_default(),
         }
     }
 }

--- a/src/theme/raw.rs
+++ b/src/theme/raw.rs
@@ -666,6 +666,10 @@ pub(crate) struct CodeBlockStyle {
 
     /// Whether to use the theme's background color.
     pub(crate) background: Option<bool>,
+
+    /// Whether to show line numbers in all code blocks.
+    #[serde(default)]
+    pub(crate) line_numbers: Option<bool>,
 }
 
 /// The style for the output of a code execution block.


### PR DESCRIPTION
This allows setting `code.line_numbers` in the theme to define globally whether line numbers should always be visible in all code blocks without having to use `+line_numbers`.

Closes #765