### PR TITLE
feat: allow executing snippets inside a PTY

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,12 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
@@ -142,6 +148,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "clap"
@@ -223,7 +235,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "crossterm_winapi",
  "document-features",
  "mio",
@@ -283,6 +295,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -329,6 +347,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
 ]
 
 [[package]]
@@ -453,6 +482,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47f142fe24a9c9944451e8349de0a56af5f3e7226dc46f3ed4d4ecc0b85af75e"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -464,7 +499,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "libc",
 ]
 
@@ -550,6 +585,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -582,7 +629,7 @@ version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "libc",
  "once_cell",
  "onig_sys",
@@ -662,11 +709,32 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "crc32fast",
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "portable-pty"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a596a2b3d2752d94f51fac2d4a96737b8705dddd311a32b9af47211f08671e"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix",
+ "serial2",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg",
 ]
 
 [[package]]
@@ -695,6 +763,7 @@ dependencies = [
  "merge-struct",
  "once_cell",
  "os_pipe",
+ "portable-pty",
  "rstest",
  "schemars",
  "serde",
@@ -705,9 +774,10 @@ dependencies = [
  "strum",
  "syntect",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.17",
  "tl",
  "unicode-width",
+ "vt100",
  "vte",
 ]
 
@@ -753,7 +823,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -764,7 +834,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -843,7 +913,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -967,6 +1037,33 @@ dependencies = [
  "serde",
  "unsafe-libyaml",
 ]
+
+[[package]]
+name = "serial2"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cc76fa68e25e771492ca1e3c53d447ef0be3093e05cd3b47f4b712ba10c6f3c"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "shlex"
@@ -1098,7 +1195,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.17",
  "walkdir",
 ]
 
@@ -1116,11 +1213,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.17",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1230,6 +1347,17 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "vt100"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ff75fb8fa83e609e685106df4faeffdf3a735d3c74ebce97ec557d5d36fd9"
+dependencies = [
+ "itoa",
+ "unicode-width",
+ "vte",
+]
 
 [[package]]
 name = "vte"
@@ -1382,6 +1510,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "zune-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ sixel-rs = { version = "0.4.1", optional = true }
 merge-struct = "0.1.0"
 itertools = "0.14"
 once_cell = "1.19"
+portable-pty = "0.9"
 schemars = { version = "0.8", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
@@ -37,6 +38,7 @@ unicode-width = "0.2"
 os_pipe = "1.1.5"
 libc = "0.2"
 vte = "0.15"
+vt100 = "0.16"
 
 [dev-dependencies]
 rstest = { version = "0.26", default-features = false }

--- a/src/code/snippet.rs
+++ b/src/code/snippet.rs
@@ -247,6 +247,11 @@ impl SnippetParser {
                         attributes.execution = SnippetExec::AutoExec(spec);
                     }
                 }
+                ExecPty(spec) => {
+                    if !matches!(attributes.execution, SnippetExec::AcquireTerminal(_)) {
+                        attributes.execution = SnippetExec::ExecPty(spec);
+                    }
+                }
                 ExecReplace(spec) => {
                     attributes.representation = SnippetRepr::ExecReplace;
                     attributes.execution = SnippetExec::Exec(spec);
@@ -294,6 +299,7 @@ impl SnippetParser {
                     "render" => SnippetAttribute::Render,
                     "no_background" => SnippetAttribute::NoBackground,
                     "acquire_terminal" => SnippetAttribute::AcquireTerminal(SnippetExecutorSpec::default()),
+                    "pty" => SnippetAttribute::ExecPty(SnippetExecutorSpec::default()),
                     other => {
                         let (attribute, parameter) = other
                             .split_once(':')
@@ -306,6 +312,7 @@ impl SnippetParser {
                             "exec_replace" => {
                                 SnippetAttribute::ExecReplace(SnippetExecutorSpec::Alternative(parameter.to_string()))
                             }
+                            "pty" => SnippetAttribute::ExecPty(SnippetExecutorSpec::Alternative(parameter.to_string())),
                             "id" => SnippetAttribute::Id(parameter.to_string()),
                             "validate" => {
                                 SnippetAttribute::Validate(SnippetExecutorSpec::Alternative(parameter.to_string()))
@@ -436,6 +443,7 @@ enum SnippetAttribute {
     Exec(SnippetExecutorSpec),
     AutoExec(SnippetExecutorSpec),
     ExecReplace(SnippetExecutorSpec),
+    ExecPty(SnippetExecutorSpec),
     Validate(SnippetExecutorSpec),
     Image,
     Render,
@@ -697,6 +705,7 @@ pub(crate) enum SnippetExec {
     None,
     Exec(SnippetExecutorSpec),
     AutoExec(SnippetExecutorSpec),
+    ExecPty(SnippetExecutorSpec),
     AcquireTerminal(SnippetExecutorSpec),
     Validate(SnippetExecutorSpec),
 }

--- a/src/markdown/text_style.rs
+++ b/src/markdown/text_style.rs
@@ -311,6 +311,30 @@ impl Color {
         Self::Rgb { r, g, b }
     }
 
+    pub(crate) fn from_8bit(color: u8) -> Option<Self> {
+        match color {
+            0 | 8 => Self::Black.into(),
+            1 | 9 => Self::Red.into(),
+            2 | 10 => Self::Green.into(),
+            3 | 11 => Self::Yellow.into(),
+            4 | 12 => Self::Blue.into(),
+            5 | 13 => Self::Magenta.into(),
+            6 | 14 => Self::Cyan.into(),
+            7 | 15 => Self::White.into(),
+            16..=231 => {
+                let mapping = [0, 95, 95 + 40, 95 + 80, 95 + 120, 95 + 160];
+                let mut value = color - 16;
+                let b = (value % 6) as usize;
+                value /= 6;
+                let g = (value % 6) as usize;
+                value /= 6;
+                let r = (value % 6) as usize;
+                Some(Self::new(mapping[r], mapping[g], mapping[b]))
+            }
+            _ => None,
+        }
+    }
+
     pub(crate) fn as_rgb(&self) -> Option<(u8, u8, u8)> {
         match self {
             Self::Rgb { r, g, b } => Some((*r, *g, *b)),

--- a/src/presentation/builder/mod.rs
+++ b/src/presentation/builder/mod.rs
@@ -31,7 +31,7 @@ use crate::{
     },
     third_party::ThirdPartyRender,
     ui::{
-        execution::output::SnippetHandle,
+        execution::output::WrappedSnippetHandle,
         footer::{FooterGenerator, FooterVariables},
         modals::{IndexBuilder, KeyBindingsModalBuilder},
         separator::RenderSeparator,
@@ -171,7 +171,7 @@ pub(crate) struct PresentationBuilder<'a, 'b> {
     bindings_config: KeyBindingsConfig,
     slides_without_footer: HashSet<usize>,
     markdown_parser: &'a MarkdownParser<'b>,
-    executable_snippets: HashMap<String, SnippetHandle>,
+    executable_snippets: HashMap<String, WrappedSnippetHandle>,
     sources: MarkdownSources,
     options: PresentationBuilderOptions,
 }

--- a/src/render/properties.rs
+++ b/src/render/properties.rs
@@ -5,7 +5,7 @@ use std::io::{self, ErrorKind};
 ///
 /// This is the same as [crossterm::terminal::window_size] except with some added functionality,
 /// like implementing `Clone`.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) struct WindowSize {
     pub(crate) rows: u16,
     pub(crate) columns: u16,

--- a/src/terminal/virt.rs
+++ b/src/terminal/virt.rs
@@ -14,6 +14,7 @@ use crate::{
     },
     terminal::printer::TerminalCommand,
 };
+use core::fmt;
 use std::{collections::HashMap, io};
 
 #[derive(Clone, Debug, PartialEq)]
@@ -194,6 +195,20 @@ impl VirtualTerminal {
             }
         };
         Ok(())
+    }
+}
+
+impl fmt::Debug for VirtualTerminal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VirtualTerminal")
+            .field("row", &self.row)
+            .field("column", &self.column)
+            .field("colors", &self.colors)
+            .field("background_color", &self.background_color)
+            .field("images", &self.images)
+            .field("row_heights", &self.row_heights)
+            .field("image_behavior", &self.image_behavior)
+            .finish()
     }
 }
 

--- a/src/ui/execution/mod.rs
+++ b/src/ui/execution/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod acquire_terminal;
 pub(crate) mod disabled;
 pub(crate) mod image;
 pub(crate) mod output;
+pub(crate) mod pty;
 pub(crate) mod validator;
 
 pub(crate) use acquire_terminal::RunAcquireTerminalSnippet;

--- a/src/ui/execution/output.rs
+++ b/src/ui/execution/output.rs
@@ -16,7 +16,10 @@ use crate::{
     },
     terminal::ansi::AnsiParser,
     theme::{Alignment, ExecutionOutputBlockStyle, ExecutionStatusBlockStyle},
-    ui::separator::{RenderSeparator, SeparatorWidth},
+    ui::{
+        execution::pty::PtySnippetHandle,
+        separator::{RenderSeparator, SeparatorWidth},
+    },
 };
 use std::{
     io::BufRead,
@@ -150,7 +153,7 @@ impl Pollable for OperationPollable {
         // Pull data out of the process' output and drop the handle state.
         let mut state = handle.state.lock().unwrap();
         let ExecutionState { output, status } = &mut *state;
-        let status = status.clone();
+        let status = *status;
 
         let modified = output.len() != self.last_length;
         let mut lines = Vec::new();
@@ -245,16 +248,43 @@ pub(crate) struct ExecIndicatorStyle {
     pub(crate) alignment: Alignment,
 }
 
+#[derive(Clone, Debug)]
+pub(crate) enum WrappedSnippetHandle {
+    Normal(SnippetHandle),
+    Pty(PtySnippetHandle),
+}
+
+impl WrappedSnippetHandle {
+    pub(crate) fn process_status(&self) -> Option<ProcessStatus> {
+        match self {
+            Self::Normal(handle) => handle.0.lock().unwrap().process_status,
+            Self::Pty(handle) => handle.process_status(),
+        }
+    }
+}
+
+impl From<SnippetHandle> for WrappedSnippetHandle {
+    fn from(handle: SnippetHandle) -> Self {
+        Self::Normal(handle)
+    }
+}
+
+impl From<PtySnippetHandle> for WrappedSnippetHandle {
+    fn from(handle: PtySnippetHandle) -> Self {
+        Self::Pty(handle)
+    }
+}
+
 #[derive(Debug)]
 pub(crate) struct ExecIndicator {
-    handle: SnippetHandle,
+    handle: WrappedSnippetHandle,
     separator_width: SeparatorWidth,
     theme: ExecutionStatusBlockStyle,
     font_size: u8,
 }
 
 impl ExecIndicator {
-    pub(crate) fn new(handle: SnippetHandle, style: ExecIndicatorStyle) -> Self {
+    pub(crate) fn new<T: Into<WrappedSnippetHandle>>(handle: T, style: ExecIndicatorStyle) -> Self {
         let ExecIndicatorStyle { theme, block_length, font_size, alignment } = style;
         let block_length = alignment.adjust_size(block_length);
         let separator_width = match &alignment {
@@ -265,14 +295,14 @@ impl ExecIndicator {
                 SeparatorWidth::Fixed(block_length.max(MINIMUM_SEPARATOR_WIDTH * font_size as u16))
             }
         };
+        let handle = handle.into();
         Self { handle, separator_width, theme, font_size }
     }
 }
 
 impl AsRenderOperations for ExecIndicator {
     fn as_render_operations(&self, _dimensions: &WindowSize) -> Vec<RenderOperation> {
-        let inner = self.handle.0.lock().unwrap();
-        let status = &inner.process_status;
+        let status = self.handle.process_status();
         let description = match status {
             Some(ProcessStatus::Running) => Text::new("running", self.theme.running_style),
             Some(ProcessStatus::Success) => Text::new("finished", self.theme.success_style),

--- a/src/ui/execution/pty.rs
+++ b/src/ui/execution/pty.rs
@@ -1,0 +1,322 @@
+use crate::{
+    code::{
+        execute::{LanguageSnippetExecutor, ProcessStatus, PtySnippetContext},
+        snippet::Snippet,
+    },
+    markdown::{
+        elements::Text,
+        text_style::{Color, TextStyle},
+    },
+    render::{
+        operation::{
+            AsRenderOperations, BlockLine, Pollable, PollableState, RenderAsync, RenderAsyncStartPolicy,
+            RenderOperation,
+        },
+        properties::WindowSize,
+    },
+    theme::ExecutionOutputBlockStyle,
+};
+use portable_pty::{MasterPty, PtySize, native_pty_system};
+use std::{
+    fmt, io, mem,
+    sync::{Arc, Mutex},
+    thread,
+};
+
+const OUTPUT_BOTTOM_MARGIN: f64 = 0.2;
+
+#[derive(Default, Debug)]
+enum State {
+    #[default]
+    Initial,
+    Running {
+        pty: PtyMaster,
+        dirty: bool,
+    },
+    ProcessTerminated(ProcessStatus),
+    Done(ProcessStatus),
+}
+
+struct Inner {
+    snippet: Snippet,
+    executor: LanguageSnippetExecutor,
+    parser: vt100::Parser,
+    size: WindowSize,
+    policy: RenderAsyncStartPolicy,
+    state: State,
+}
+
+impl fmt::Debug for Inner {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Inner")
+            .field("snippet", &self.snippet)
+            .field("executor", &self.executor)
+            .field("parser", &"...")
+            .field("policy", &self.policy)
+            .field("state", &"...")
+            .finish()
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct PtySnippetOutputOperation {
+    handle: PtySnippetHandle,
+    style: ExecutionOutputBlockStyle,
+    font_size: u8,
+}
+
+impl PtySnippetOutputOperation {
+    pub(crate) fn new(handle: PtySnippetHandle, style: ExecutionOutputBlockStyle, font_size: u8) -> Self {
+        Self { handle, style, font_size }
+    }
+}
+
+impl AsRenderOperations for PtySnippetOutputOperation {
+    fn as_render_operations(&self, dimensions: &WindowSize) -> Vec<RenderOperation> {
+        let mut inner = self.handle.0.lock().unwrap();
+        let dimensions = dimensions
+            .shrink_rows((dimensions.rows as f64 * OUTPUT_BOTTOM_MARGIN) as u16 / self.font_size as u16)
+            .shrink_columns(dimensions.columns - dimensions.columns / self.font_size as u16);
+
+        if inner.size != dimensions {
+            inner.size = dimensions;
+            inner.parser.screen_mut().set_size(dimensions.rows, dimensions.columns);
+        }
+        if matches!(inner.state, State::Initial) {
+            return Vec::new();
+        }
+
+        let screen = inner.parser.screen();
+        let (rows, columns) = screen.size();
+        let mut operations = vec![];
+
+        for row in 0..rows {
+            let mut line = Vec::new();
+            let mut current_text = String::new();
+            let mut current_style = TextStyle::default();
+            for column in 0..columns {
+                let cell = screen.cell(row, column).expect("no cell");
+                let mut style = TextStyle::from(cell).size(self.font_size);
+                if style.colors.foreground.is_none() {
+                    style.colors.foreground = self.style.style.colors.foreground;
+                }
+                if style.colors.background.is_none() {
+                    style.colors.background = self.style.style.colors.background;
+                }
+                let contents = cell.contents();
+                if current_style != style && !current_text.is_empty() {
+                    line.push(Text::new(mem::take(&mut current_text), current_style));
+                }
+                current_style = style;
+                if contents.is_empty() {
+                    current_text.push(' ');
+                } else {
+                    current_text.push_str(contents);
+                }
+            }
+            if !current_text.is_empty() {
+                line.push(Text::new(current_text, current_style));
+            }
+            operations.extend([
+                RenderOperation::RenderBlockLine(BlockLine {
+                    prefix: "".into(),
+                    right_padding_length: 0,
+                    repeat_prefix_on_wrap: false,
+                    text: line.into(),
+                    block_length: columns,
+                    block_color: None,
+                    alignment: Default::default(),
+                }),
+                RenderOperation::RenderLineBreak,
+            ]);
+        }
+        operations
+    }
+}
+
+impl RenderAsync for PtySnippetOutputOperation {
+    fn pollable(&self) -> Box<dyn Pollable> {
+        Box::new(OperationPollable { handle: self.handle.clone() })
+    }
+}
+
+#[derive(Debug)]
+struct OperationPollable {
+    handle: PtySnippetHandle,
+}
+
+impl OperationPollable {
+    fn spawn(ctx: PtySnippetContext, dimensions: WindowSize, handle: PtySnippetHandle) -> anyhow::Result<PtyMaster> {
+        let pty_system = native_pty_system();
+        let pty_size = PtySize {
+            rows: dimensions.rows,
+            cols: dimensions.columns,
+            pixel_width: dimensions.pixels_per_column() as u16,
+            pixel_height: dimensions.pixels_per_row() as u16,
+        };
+        let pair = pty_system.openpty(pty_size)?;
+        pair.slave.spawn_command(ctx.command.clone())?;
+        PtyMaster::new(pair.master, handle, ctx)
+    }
+}
+
+impl Pollable for OperationPollable {
+    fn poll(&mut self) -> PollableState {
+        let mut inner = self.handle.0.lock().unwrap();
+        let current_size = inner.size;
+        match &mut inner.state {
+            State::Initial => match inner.executor.pty_execution_context(&inner.snippet) {
+                Ok(ctx) => match Self::spawn(ctx, inner.size, self.handle.clone()) {
+                    Ok(pty) => {
+                        inner.state = State::Running { pty, dirty: true };
+                        PollableState::Modified
+                    }
+                    Err(e) => {
+                        inner.state = State::Done(ProcessStatus::Failure);
+                        PollableState::Failed { error: format!("failed to run script: {e}") }
+                    }
+                },
+                Err(e) => {
+                    inner.state = State::Done(ProcessStatus::Failure);
+                    PollableState::Failed { error: format!("failed to run script: {e}") }
+                }
+            },
+            State::Running { dirty, pty } => {
+                if let Ok(size) = pty._master.get_size() {
+                    if size.rows != current_size.rows || size.cols != current_size.columns {
+                        let size = PtySize {
+                            rows: current_size.rows,
+                            cols: current_size.columns,
+                            pixel_width: 0,
+                            pixel_height: 0,
+                        };
+                        let _ = pty._master.resize(size);
+                    }
+                }
+                if mem::take(dirty) { PollableState::Modified } else { PollableState::Unmodified }
+            }
+            State::ProcessTerminated(status) => {
+                inner.state = State::Done(*status);
+                PollableState::Modified
+            }
+            _ => PollableState::Unmodified,
+        }
+    }
+}
+
+pub(crate) struct PtyMaster {
+    _master: Box<dyn MasterPty>,
+    _ctx: PtySnippetContext,
+}
+
+impl PtyMaster {
+    fn new(master: Box<dyn MasterPty>, handle: PtySnippetHandle, ctx: PtySnippetContext) -> anyhow::Result<Self> {
+        let reader = master.try_clone_reader()?;
+        thread::spawn(|| process_output(reader, handle));
+        Ok(Self { _master: master, _ctx: ctx })
+    }
+}
+
+impl fmt::Debug for PtyMaster {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PtyMaster").field("master", &"...").finish()
+    }
+}
+
+fn process_output(mut reader: Box<dyn io::Read>, handle: PtySnippetHandle) {
+    let mut input_buffer = [0; 1024];
+    let status = loop {
+        let Ok(bytes_read) = reader.read(&mut input_buffer) else {
+            break ProcessStatus::Failure;
+        };
+        if bytes_read == 0 {
+            break ProcessStatus::Success;
+        }
+        let bytes = &input_buffer[..bytes_read];
+        let mut inner = handle.0.lock().unwrap();
+        inner.parser.process(bytes);
+        if let State::Running { dirty, .. } = &mut inner.state {
+            *dirty = true;
+        };
+    };
+    handle.0.lock().unwrap().state = State::ProcessTerminated(status);
+}
+
+impl From<&vt100::Cell> for TextStyle {
+    fn from(cell: &vt100::Cell) -> Self {
+        let mut style = TextStyle::default();
+        if cell.bold() {
+            style = style.bold();
+        }
+        if cell.italic() {
+            style = style.italics();
+        }
+        if cell.underline() {
+            style = style.underlined();
+        }
+        style.colors.foreground = parse_color(cell.fgcolor());
+        style.colors.background = parse_color(cell.bgcolor());
+        style
+    }
+}
+
+fn parse_color(color: vt100::Color) -> Option<Color> {
+    match color {
+        vt100::Color::Default => None,
+        vt100::Color::Idx(value) => Color::from_8bit(value),
+        vt100::Color::Rgb(r, g, b) => Some(Color::Rgb { r, g, b }),
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PtySnippetHandle(Arc<Mutex<Inner>>);
+
+impl PtySnippetHandle {
+    pub(crate) fn new(snippet: Snippet, executor: LanguageSnippetExecutor, policy: RenderAsyncStartPolicy) -> Self {
+        let size = WindowSize { columns: 80, rows: 24, height: 0, width: 0 };
+        let parser = vt100::Parser::new(size.rows, size.columns, 1000);
+        let inner = Inner { snippet, executor, parser, size, state: Default::default(), policy };
+        Self(Arc::new(Mutex::new(inner)))
+    }
+
+    pub(crate) fn executor(&self) -> LanguageSnippetExecutor {
+        self.0.lock().unwrap().executor.clone()
+    }
+
+    pub(crate) fn snippet(&self) -> Snippet {
+        self.0.lock().unwrap().snippet.clone()
+    }
+
+    pub(crate) fn process_status(&self) -> Option<ProcessStatus> {
+        match &self.0.lock().unwrap().state {
+            State::Initial => None,
+            State::Running { .. } => Some(ProcessStatus::Running),
+            State::ProcessTerminated(status) | State::Done(status) => Some(*status),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct RunPtySnippetTrigger(PtySnippetHandle);
+
+impl RunPtySnippetTrigger {
+    pub(crate) fn new(handle: PtySnippetHandle) -> Self {
+        Self(handle)
+    }
+}
+
+impl AsRenderOperations for RunPtySnippetTrigger {
+    fn as_render_operations(&self, _dimensions: &WindowSize) -> Vec<RenderOperation> {
+        vec![]
+    }
+}
+
+impl RenderAsync for RunPtySnippetTrigger {
+    fn pollable(&self) -> Box<dyn Pollable> {
+        Box::new(OperationPollable { handle: self.0.clone() })
+    }
+
+    fn start_policy(&self) -> RenderAsyncStartPolicy {
+        self.0.0.lock().unwrap().policy
+    }
+}


### PR DESCRIPTION
This implements the initial portion of #537: executing snippets inside a PTY when requested via code snippets that contain `+pty`. For now `+pty` is all you need to make a snippet executable inside a PTY but soon this will likely change to e.g. require either `+exec +pty` (e.g. so you can also do `+exec_replace +pty` or `+auto_exec +pty`). There's some internals that don't play well here with this so I'm putting this initial version out but this will for sure change before the next release.

For now you can't specify the terminal size but the terminal will take up as much size as possible. My idea is in the final version of this you'll be able to do something like `+exec +pty:80:24` or something like that (no size would imply the current behavior).

This is a sample of `htop` running inside a slide:

https://github.com/user-attachments/assets/2291b75b-a469-4288-aea8-c12e82774249

This is a sample of a ratatui example running in here (mind the gross layout, this is just a demo):

https://github.com/user-attachments/assets/e9cf734d-be24-44db-949b-356d82259b84
