### PR TITLE
feat: add common es executors and support jsx and ts(x) snippets

### DIFF
--- a/executors.yaml
+++ b/executors.yaml
@@ -7,18 +7,31 @@ bash:
 c++:
   filename: snippet.cpp
   commands:
-    - ["g++", "-std=c++20", "-fdiagnostics-color=always", "$pwd/snippet.cpp", "-o", "$pwd/snippet"]
+    - [
+        "g++",
+        "-std=c++20",
+        "-fdiagnostics-color=always",
+        "$pwd/snippet.cpp",
+        "-o",
+        "$pwd/snippet",
+      ]
     - ["$pwd/snippet"]
   hidden_line_prefix: "/// "
 c:
   filename: snippet.c
   commands:
-    - ["gcc", "$pwd/snippet.c", "-fdiagnostics-color=always", "-o", "$pwd/snippet"]
+    - [
+        "gcc",
+        "$pwd/snippet.c",
+        "-fdiagnostics-color=always",
+        "-o",
+        "$pwd/snippet",
+      ]
     - ["$pwd/snippet"]
   hidden_line_prefix: "/// "
 elixir:
   filename: snippet.exs
-  commands: 
+  commands:
     - ["elixir", "$pwd/snippet.exs"]
   hidden_line_prefix: "## "
 fish:
@@ -44,9 +57,84 @@ java:
   hidden_line_prefix: "/// "
 js:
   filename: snippet.js
+  environment:
+    FORCE_COLOR: "true"
   commands:
     - ["node", "$pwd/snippet.js"]
   hidden_line_prefix: "/// "
+  alternative:
+    deno:
+      filename: "snippet.js"
+      environment:
+        FORCE_COLOR: "true"
+      commands:
+        - ["deno", "run", "-A", "$pwd/snippet.js"]
+    bun:
+      filename: "snippet.js"
+      environment:
+        FORCE_COLOR: "true"
+      commands:
+        - ["bun", "run", "$pwd/snippet.js"]
+jsx:
+  filename: snippet.jsx
+  environment:
+    FORCE_COLOR: "true"
+  commands:
+    - ["node", "$pwd/snippet.jsx"]
+  hidden_line_prefix: "/// "
+  alternative:
+    deno:
+      filename: "snippet.jsx"
+      environment:
+        FORCE_COLOR: "true"
+      commands:
+        - ["deno", "run", "-A", "$pwd/snippet.jsx"]
+    bun:
+      filename: "snippet.jsx"
+      environment:
+        FORCE_COLOR: "true"
+      commands:
+        - ["bun", "run", "$pwd/snippet.jsx"]
+ts:
+  filename: snippet.ts
+  environment:
+    FORCE_COLOR: "true"
+  commands:
+    - ["node", "$pwd/snippet.ts"]
+  hidden_line_prefix: "/// "
+  alternative:
+    deno:
+      filename: "snippet.ts"
+      environment:
+        FORCE_COLOR: "true"
+      commands:
+        - ["deno", "run", "-A", "$pwd/snippet.ts"]
+    bun:
+      filename: "snippet.ts"
+      environment:
+        FORCE_COLOR: "true"
+      commands:
+        - ["bun", "run", "$pwd/snippet.ts"]
+tsx:
+  filename: snippet.tsx
+  environment:
+    FORCE_COLOR: "true"
+  commands:
+    - ["node", "$pwd/snippet.tsx"]
+  hidden_line_prefix: "/// "
+  alternative:
+    deno:
+      filename: "snippet.tsx"
+      environment:
+        FORCE_COLOR: "true"
+      commands:
+        - ["deno", "run", "-A", "$pwd/snippet.tsx"]
+    bun:
+      filename: "snippet.tsx"
+      environment:
+        FORCE_COLOR: "true"
+      commands:
+        - ["bun", "run", "$pwd/snippet.tsx"]
 julia:
   filename: snippet.jl
   commands:
@@ -107,7 +195,16 @@ rust-script:
 rust:
   filename: snippet.rs
   commands:
-    - ["rustc", "--crate-name", "presenterm_snippet", "$pwd/snippet.rs", "-o", "$pwd/snippet", "--color", "always"]
+    - [
+        "rustc",
+        "--crate-name",
+        "presenterm_snippet",
+        "$pwd/snippet.rs",
+        "-o",
+        "$pwd/snippet",
+        "--color",
+        "always",
+      ]
     - ["$pwd/snippet"]
   hidden_line_prefix: "# "
   alternative:


### PR DESCRIPTION
# Motivation

Currently on js executor is built-in and only for node, but ecmascript is strongly written in ts and node has 2 major alternatives.

# Description

- I add the 3 main ecmascript runtime: `node`, `deno`, `bun` with `node` as main executor (for legacy reason) and the others as alternatives.
- I add the native support of `jsx`, `ts`, and `tsx`.
- I add `FORCE_COLOR` to all js runtime because presenterm break color output since some releases.

Here a presentation example

````md
# Ecmascript runtime demo

<!-- column_layout: [1, 1, 1] -->

<!-- column: 0 -->

## Deno

### Typescript

```ts +exec:deno
const value: Record<string, number> = { number: 1, string: "text" };
console.log(value);
```

### TSX

```tsx +exec:deno
/** @jsxImportSource npm:preact */
console.log(navigator.userAgent);
const html = <span>Test</span>;
console.log(html);
```

<!-- column: 1 -->

## Bun

### Typescript

```ts +exec:bun
const value: Record<string, number> = { number: 1, string: "text" };
console.log(value);
```

### TSX

```tsx +exec:bun
console.log(navigator.userAgent);
const html = <span>Test</span>;
console.log(html);
```

<!-- column: 2 -->

## Node

### Typescript

```ts +exec
const value: Record<string, number> = { number: 1, string: "text" };
console.log(value);
```

### TSX

```tsx +exec
/** @jsxImportSource npm:preact */
console.log(navigator.userAgent);
const html = <span>Test</span>;
console.log(html);
```
````

# Discussion

- `deno` natively supports `jsx`/`tsx` within codeblock snippet without any other file, `bun` need a config file and node modules to declare the jsx runtime and `node` doesn't support it yet (nodejs/node#56822). The most straightforward way to execute `tsx`/`jsx` is `deno`. I use consistency for default and always set node as main executor, maybe a `jsx`/`tsx` need to break this rule.
-  `deno` (and now `node` with a flag) supports permissions flags for executing code, since I don't know direct or simple method to specify custom flags per codeblock in presenterm I use the `-A`/`--allow-all` flag to `deno` executor. It is necessary but not ideal, maybe a way to add executor parameter (a future issue ?) will be a better solution.
  ```yml
  # executors.yml
  ts:
    filename: "snippet.ts"
    hidden_line_prefix: "/// "
    commands:
      - ["deno", "run", "$options:runtime", "$pwd/snippet.ts", "$options:snippet"]
  ```
  ````md
  # My snippet with custom options
  ```md +exec +exec_options:runtime="--allow-read,--allow-net" +exec_options:snippet="1,2,3"
  await Deno.read(/* */) // allowed
  console.log(Deno.args) // set by $options:script
  await Deno.write(/* */) // denied
  ```
  ````
  with `$options:<your-option-name>`