### PR TITLE
chore: add script to generate config file JSON schema

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -83,4 +83,8 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
       - name: Validate config file schema
-        run: ./scripts/validate-config-file-schema.sh
+        run: |
+          if ! ./scripts/validate-config-file-schema.sh; then
+            echo -e "\033[31;1mRun ./scripts/generate-config-file-schema.sh to regenerate JSON schema"
+            exit 1
+          fi

--- a/scripts/generate-config-file-schema.sh
+++ b/scripts/generate-config-file-schema.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -euo pipefail
+
+script_dir=$(dirname "$0")
+root_dir="${script_dir}/../"
+
+current_schema=$(mktemp)
+docker run \
+  --rm \
+  -v "${root_dir}:/tmp/workspace" \
+  -w "/tmp/workspace" \
+  rust:1.86 \
+  cargo run --features json-schema -q -- --generate-config-file-schema >"${current_schema}"
+
+cp "$current_schema" "${root_dir}/config-file-schema.json"
+rm "$current_schema"


### PR DESCRIPTION
This adds a script that generates the config file JSON schema inside docker so it always runs in linux + a step in the CI that suggests running it if it failed.