### PR TITLE
fix: use legible color in tokyonight-day's block quote/alert style

### DIFF
--- a/themes/tokyonight-day.yaml
+++ b/themes/tokyonight-day.yaml
@@ -106,14 +106,14 @@ block_quote:
   prefix: "▍ "
   colors:
     foreground: "3760bf"
-    background: "545c7e"
+    background: "d4d6e4"
     prefix: "8c6c3e"
 
 alert:
   prefix: "▍ "
   base_colors:
     foreground: "3760bf"
-    background: "545c7e"
+    background: "d4d6e4"
   styles:
     note:
       color: "2e7de9"


### PR DESCRIPTION
This fixes the illegible block quotes / alerts in tokyonight-day themes added in #751