### PR TITLE
fix: handle dark/light colors properly when converting from 8bt

### DIFF
--- a/src/markdown/text_style.rs
+++ b/src/markdown/text_style.rs
@@ -313,14 +313,22 @@ impl Color {
 
     pub(crate) fn from_8bit(color: u8) -> Option<Self> {
         match color {
-            0 | 8 => Self::Black.into(),
-            1 | 9 => Self::Red.into(),
-            2 | 10 => Self::Green.into(),
-            3 | 11 => Self::Yellow.into(),
-            4 | 12 => Self::Blue.into(),
-            5 | 13 => Self::Magenta.into(),
-            6 | 14 => Self::Cyan.into(),
-            7 | 15 => Self::White.into(),
+            0 => Self::Black.into(),
+            1 => Self::DarkRed.into(),
+            2 => Self::DarkGreen.into(),
+            3 => Self::DarkYellow.into(),
+            4 => Self::DarkBlue.into(),
+            5 => Self::DarkMagenta.into(),
+            6 => Self::DarkCyan.into(),
+            7 => Self::Grey.into(),
+            8 => Self::DarkGrey.into(),
+            9 => Self::Red.into(),
+            10 => Self::Green.into(),
+            11 => Self::Yellow.into(),
+            12 => Self::Blue.into(),
+            13 => Self::Magenta.into(),
+            14 => Self::Cyan.into(),
+            15 => Self::White.into(),
             16..=231 => {
                 let mapping = [0, 95, 95 + 40, 95 + 80, 95 + 120, 95 + 160];
                 let mut value = color - 16;

--- a/src/terminal/ansi.rs
+++ b/src/terminal/ansi.rs
@@ -169,11 +169,11 @@ mod tests {
     )]
     #[case::standard_foreground1(
         "\x1b[38;5;1mhi", 
-        Line::from(Text::new("hi", TextStyle::default().fg_color(Color::Red)))
+        Line::from(Text::new("hi", TextStyle::default().fg_color(Color::DarkRed)))
     )]
     #[case::standard_foreground2(
         "\x1b[31mhi", 
-        Line::from(Text::new("hi", TextStyle::default().fg_color(Color::Red)))
+        Line::from(Text::new("hi", TextStyle::default().fg_color(Color::DarkRed)))
     )]
     #[case::rgb_foreground(
         "\x1b[38;2;3;4;5mhi", 
@@ -181,11 +181,11 @@ mod tests {
     )]
     #[case::standard_background1(
         "\x1b[48;5;1mhi", 
-        Line::from(Text::new("hi", TextStyle::default().bg_color(Color::Red)))
+        Line::from(Text::new("hi", TextStyle::default().bg_color(Color::DarkRed)))
     )]
     #[case::standard_background2(
         "\x1b[41mhi", 
-        Line::from(Text::new("hi", TextStyle::default().bg_color(Color::Red)))
+        Line::from(Text::new("hi", TextStyle::default().bg_color(Color::DarkRed)))
     )]
     #[case::rgb_background(
         "\x1b[48;2;3;4;5mhi", 

--- a/src/ui/execution/output.rs
+++ b/src/ui/execution/output.rs
@@ -361,7 +361,7 @@ mod tests {
 
         // Expect to see the output lines
         let inner = handle.0.lock().unwrap();
-        let line = Line::from(Text::new("hi mom", TextStyle::default().fg_color(Color::Red).bold()));
+        let line = Line::from(Text::new("hi mom", TextStyle::default().fg_color(Color::DarkRed).bold()));
         assert_eq!(inner.output_lines, vec![line]);
     }
 


### PR DESCRIPTION
This fixes the handling of dark/light colors when converting from 8bit since we weren't using the `dark` variants.