### PR TITLE
feat: allow setting `+pty` mode on standby

### DIFF
--- a/src/theme/clean.rs
+++ b/src/theme/clean.rs
@@ -35,6 +35,7 @@ pub(crate) struct PresentationTheme {
     pub(crate) slide_title: SlideTitleStyle,
     pub(crate) code: CodeBlockStyle,
     pub(crate) execution_output: ExecutionOutputBlockStyle,
+    pub(crate) pty_output: PtyOutputBlockStyle,
     pub(crate) inline_code: ModifierStyle,
     pub(crate) bold: ModifierStyle,
     pub(crate) italics: ModifierStyle,
@@ -63,6 +64,7 @@ impl PresentationTheme {
             slide_title,
             code,
             execution_output,
+            pty_output,
             inline_code,
             bold,
             italics,
@@ -88,6 +90,7 @@ impl PresentationTheme {
             slide_title: SlideTitleStyle::new(slide_title, &palette, options)?,
             code: CodeBlockStyle::new(code),
             execution_output: ExecutionOutputBlockStyle::new(execution_output, &palette)?,
+            pty_output: PtyOutputBlockStyle::new(pty_output, &palette)?,
             inline_code: ModifierStyle::new(inline_code, &palette)?,
             bold: ModifierStyle::new(bold, &palette)?,
             italics: ModifierStyle::new(italics, &palette)?,
@@ -633,6 +636,53 @@ impl ExecutionStatusBlockStyle {
         let failure_style = TextStyle::colored(failure.resolve(palette)?);
         let not_started_style = TextStyle::colored(not_started.resolve(palette)?);
         Ok(Self { running_style, success_style, failure_style, not_started_style })
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct PtyOutputBlockStyle {
+    pub(crate) style: TextStyle,
+    pub(crate) standby: PtyStandbyStyle,
+}
+
+impl PtyOutputBlockStyle {
+    fn new(raw: &raw::PtyOutputBlockStyle, palette: &ColorPalette) -> Result<Self, ProcessingThemeError> {
+        let raw::PtyOutputBlockStyle { colors, standby } = raw;
+        let colors = colors.resolve(palette)?;
+        let style = TextStyle::colored(colors);
+        let standby = match standby {
+            Some(raw::PtyStandbyStyle::LargePlay) => PtyStandbyStyle::LargePlay,
+            None => Default::default(),
+        };
+        Ok(Self { style, standby })
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) enum PtyStandbyStyle {
+    #[default]
+    LargePlay,
+}
+
+impl PtyStandbyStyle {
+    pub(crate) fn as_lines(&self) -> &[&str] {
+        match self {
+            Self::LargePlay => &[
+                "⠀⠀⠀⠀⠀⠀⠀⢀⣠⣤⣤⣶⣶⣶⣶⣤⣤⣄⡀⠀⠀⠀⠀⠀⠀⠀",
+                "⠀⠀⠀⠀⢀⣤⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣷⣤⡀⠀⠀⠀⠀",
+                "⠀⠀⠀⣴⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣦⠀⠀⠀",
+                "⠀⢀⣾⣿⣿⣿⣿⣿⣿⣿⡿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣷⡀⠀",
+                "⠀⣾⣿⣿⣿⣿⣿⣿⣿⣿⡇⠈⠙⢿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣷⠀",
+                "⢠⣿⣿⣿⣿⣿⣿⣿⣿⣿⡇⠀⠀⠀⠈⠻⢿⣿⣿⣿⣿⣿⣿⣿⣿⡄",
+                "⢸⣿⣿⣿⣿⣿⣿⣿⣿⣿⡇⠀⠀⠀⠀⠀⠀⣉⣿⣿⣿⣿⣿⣿⣿⡇",
+                "⠘⣿⣿⣿⣿⣿⣿⣿⣿⣿⡇⠀⠀⠀⢀⣴⣾⣿⣿⣿⣿⣿⣿⣿⣿⠃",
+                "⠀⢿⣿⣿⣿⣿⣿⣿⣿⣿⡇⢀⣠⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿⠀",
+                "⠀⠈⢿⣿⣿⣿⣿⣿⣿⣿⣷⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿⠁⠀",
+                "⠀⠀⠀⠻⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠟⠀⠀⠀",
+                "⠀⠀⠀⠀⠈⠛⢿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿⠛⠁⠀⠀⠀⠀",
+                "⠀⠀⠀⠀⠀⠀⠀⠈⠙⠛⠛⠿⠿⠿⠿⠛⠛⠋⠁⠀⠀⠀⠀⠀⠀⠀",
+            ],
+        }
     }
 }
 

--- a/src/theme/raw.rs
+++ b/src/theme/raw.rs
@@ -31,6 +31,10 @@ pub struct PresentationTheme {
     #[serde(default)]
     pub(crate) execution_output: ExecutionOutputBlockStyle,
 
+    /// The style for the pty output of a piece of code.
+    #[serde(default)]
+    pub(crate) pty_output: PtyOutputBlockStyle,
+
     /// The style for inline code.
     #[serde(default)]
     pub(crate) inline_code: ModifierStyle,
@@ -686,6 +690,25 @@ pub(crate) struct ExecutionOutputBlockStyle {
     /// The padding.
     #[serde(default)]
     pub(crate) padding: PaddingRect,
+}
+
+/// The style for the output of a code execution block running in pty mode.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub(crate) struct PtyOutputBlockStyle {
+    /// The colors to be used for the output pane.
+    #[serde(default)]
+    pub(crate) colors: RawColors,
+
+    /// The style for the standby state.
+    #[serde(default)]
+    pub(crate) standby: Option<PtyStandbyStyle>,
+}
+
+/// The style for the standby state.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) enum PtyStandbyStyle {
+    /// Show a play icon.
+    LargePlay,
 }
 
 /// The style for the status of a code execution block.

--- a/themes/catppuccin-frappe.yaml
+++ b/themes/catppuccin-frappe.yaml
@@ -42,6 +42,11 @@ execution_output:
     horizontal: 2
     vertical: 1
 
+pty_output:
+  colors:
+    foreground: palette:text
+    background: palette:surface0
+
 inline_code:
   colors:
     foreground: palette:green

--- a/themes/catppuccin-latte.yaml
+++ b/themes/catppuccin-latte.yaml
@@ -42,6 +42,11 @@ execution_output:
     horizontal: 2
     vertical: 1
 
+pty_output:
+  colors:
+    foreground: palette:text
+    background: palette:surface0
+
 inline_code:
   colors:
     foreground: palette:green

--- a/themes/catppuccin-macchiato.yaml
+++ b/themes/catppuccin-macchiato.yaml
@@ -42,6 +42,11 @@ execution_output:
     horizontal: 2
     vertical: 1
 
+pty_output:
+  colors:
+    foreground: palette:text
+    background: palette:surface0
+
 inline_code:
   colors:
     foreground: palette:green

--- a/themes/catppuccin-mocha.yaml
+++ b/themes/catppuccin-mocha.yaml
@@ -42,6 +42,11 @@ execution_output:
     horizontal: 2
     vertical: 1
 
+pty_output:
+  colors:
+    foreground: palette:text
+    background: palette:surface0
+
 inline_code:
   colors:
     foreground: palette:green

--- a/themes/dark.yaml
+++ b/themes/dark.yaml
@@ -42,6 +42,11 @@ execution_output:
     horizontal: 2
     vertical: 1
 
+pty_output:
+  colors:
+    foreground: palette:white
+    background: palette:black
+
 inline_code:
   colors:
     foreground: "04de20"

--- a/themes/gruvbox-dark.yaml
+++ b/themes/gruvbox-dark.yaml
@@ -42,6 +42,11 @@ execution_output:
     horizontal: 2
     vertical: 1
 
+pty_output:
+  colors:
+    foreground: "ebdbb2"
+    background: "3c3836"
+
 inline_code:
   colors:
     foreground: "b8bb26"

--- a/themes/light.yaml
+++ b/themes/light.yaml
@@ -42,6 +42,11 @@ execution_output:
     horizontal: 2
     vertical: 1
 
+pty_output:
+  colors:
+    foreground: "212529"
+    background: "e9ecef"
+
 inline_code:
   colors:
     foreground: "f07167"

--- a/themes/terminal-dark.yaml
+++ b/themes/terminal-dark.yaml
@@ -42,6 +42,10 @@ execution_output:
     horizontal: 2
     vertical: 1
 
+pty_output:
+  colors:
+    foreground: white
+
 inline_code:
   colors:
     foreground: green

--- a/themes/terminal-light.yaml
+++ b/themes/terminal-light.yaml
@@ -42,6 +42,10 @@ execution_output:
     horizontal: 2
     vertical: 1
 
+pty_output:
+  colors:
+    foreground: black
+
 inline_code:
   colors:
     foreground: dark_green

--- a/themes/tokyonight-day.yaml
+++ b/themes/tokyonight-day.yaml
@@ -42,6 +42,11 @@ execution_output:
     horizontal: 2
     vertical: 1
 
+pty_output:
+  colors:
+    foreground: "3760bf"
+    background: "2d2d2d"
+
 inline_code:
   colors:
     foreground: "587539"

--- a/themes/tokyonight-moon.yaml
+++ b/themes/tokyonight-moon.yaml
@@ -42,6 +42,11 @@ execution_output:
     horizontal: 2
     vertical: 1
 
+pty_output:
+  colors:
+    foreground: "c8d3f5"
+    background: "2d2d2d"
+
 inline_code:
   colors:
     foreground: "c3e88d"

--- a/themes/tokyonight-night.yaml
+++ b/themes/tokyonight-night.yaml
@@ -42,6 +42,11 @@ execution_output:
     horizontal: 2
     vertical: 1
 
+pty_output:
+  colors:
+    foreground: "c0caf5"
+    background: "2d2d2d"
+
 inline_code:
   colors:
     foreground: "9ece6a"

--- a/themes/tokyonight-storm.yaml
+++ b/themes/tokyonight-storm.yaml
@@ -42,6 +42,11 @@ execution_output:
     horizontal: 2
     vertical: 1
 
+pty_output:
+  colors:
+    foreground: "c0caf5"
+    background: "2d2d2d"
+
 inline_code:
   colors:
     foreground: "9ece6a"


### PR DESCRIPTION
This adds a new `standby` optional property to the `+pty` snippet attribute (the format is now `+pty[:standby][:columns:rows]`). This indicates the output pane for the snippet should always be visible even when the snippet hasn't been run, including some form of styling (for now only a "play" ascii art icon). This attribute also causes `+exec_replace` blocks to require a `<c-e>` to run.

The goal of this is to allow `+exec_replace +pty` blocks to wait for user action. Just like a `+exec` snippet normally would, but without showing the code in the snippet. This is useful if e.g. you're trying to play some animation like running an `asciinema` session.

Example:

~~~markdown
```bash +exec_replace +pty:standby:80:24
asciinema play /tmp/tmpvql9d152-ascii.cast
```
~~~

https://github.com/user-attachments/assets/72fe6581-7531-4ab1-b77f-81c6cba08227

Relates to #537

