### PR TITLE
fix: don't crash sending event if presentation is in error state

### DIFF
--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -165,12 +165,15 @@ impl<'a> Presenter<'a> {
                     CommandSideEffect::None => (),
                 };
             }
-            let slide_index = self.state.presentation().current_slide_index() as u32 + 1;
-            let slide = self.state.presentation().current_slide();
-            self.publish_event(SpeakerNotesEvent::GoTo {
-                slide: slide_index,
-                chunk: slide.current_chunk_index() as u32,
-            })?;
+
+            if !matches!(self.state, PresenterState::Failure { .. }) {
+                let slide_index = self.state.presentation().current_slide_index() as u32 + 1;
+                let slide = self.state.presentation().current_slide();
+                self.publish_event(SpeakerNotesEvent::GoTo {
+                    slide: slide_index,
+                    chunk: slide.current_chunk_index() as u32,
+                })?;
+            }
         }
     }
 


### PR DESCRIPTION
This fixes an issue where this would crash if the presentation started and had errors. Upon reloading (e.g. because a change happened in the presentation file) if the presentation was still in an error state, it would blow up.

This was a regression in #735 which isn't in any public release yet.