### PR TITLE
feat: allow configuring a global alignment in theme

### DIFF
--- a/src/presentation/builder/quote.rs
+++ b/src/presentation/builder/quote.rs
@@ -5,7 +5,7 @@ use crate::{
     },
     presentation::builder::{BuildResult, PresentationBuilder},
     render::operation::{BlockLine, RenderOperation},
-    theme::{Alignment, raw::RawColor},
+    theme::{Alignment, ElementType, raw::RawColor},
 };
 use comrak::nodes::AlertType;
 use unicode_width::UnicodeWidthStr;
@@ -19,7 +19,7 @@ impl PresentationBuilder<'_, '_> {
             prefix,
             self.theme.block_quote.base_style.colors,
             prefix_style,
-            self.theme.block_quote.alignment,
+            self.theme.alignment(&ElementType::BlockQuote),
         )
     }
 

--- a/src/theme/raw.rs
+++ b/src/theme/raw.rs
@@ -350,6 +350,10 @@ pub(crate) struct DefaultStyle {
     /// The colors to be used.
     #[serde(default)]
     pub(crate) colors: RawColors,
+
+    /// The alignment for all elements.
+    #[serde(flatten, default)]
+    pub(crate) alignment: Option<Alignment>,
 }
 
 /// A simple style.


### PR DESCRIPTION
This allows configuring the `default.alignment` key in the config file which allows setting the alignment globally. This can still be overridden on each element type but this will be the default otherwise.

Closes #770