### PR TITLE
fix: preserve footnote definition location

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,9 +209,9 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "comrak"
-version = "0.47.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13263e1b6ee0147fb4dce60678f8b9634deac47c9b87c3dd5cdb959cc0334d3"
+checksum = "48bf2260aceee247c6c5639f5751dc635211895066d782d2a28fb87f2e0d5613"
 dependencies = [
  "caseless",
  "entities",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ anyhow = "1"
 base64 = "0.22"
 bincode = "1.3"
 clap = { version = "4.4", features = ["derive", "string", "env"] }
-comrak = { version = "0.47.0", default-features = false }
+comrak = { version = "0.48.0", default-features = false }
 crossterm = { version = "0.29", default-features = false, features = ["events", "windows"] }
 directories = "6.0"
 hex = "0.4"


### PR DESCRIPTION
This causes the footnote definition to show up where it should. This is possible thanks to the comrak fix https://github.com/kivikakk/comrak/issues/669

Fixes #766