### PR TITLE
fix(doc): typo in config theme section

### DIFF
--- a/config-file-schema.json
+++ b/config-file-schema.json
@@ -987,11 +987,11 @@
           "type": "null"
         },
         {
-          "description": "Theme of the presentation",
+          "description": "Theme of the presentation.",
           "type": "string"
         },
         {
-          "description": "Automatic dark/light theme switch based on the terminal background luminance",
+          "description": "Automatic dark/light theme switch based on the terminal background luminance.",
           "type": "object",
           "required": [
             "dark",
@@ -999,15 +999,15 @@
           ],
           "properties": {
             "dark": {
-              "description": "Dark theme of the presentation",
+              "description": "Dark theme of the presentation.",
               "type": "string"
             },
             "light": {
-              "description": "Light theme of ther presentation",
+              "description": "Light theme of the presentation.",
               "type": "string"
             },
             "timeout": {
-              "description": "Light/Dark detection timeout in ms",
+              "description": "Light/Dark detection timeout in ms.",
               "type": [
                 "integer",
                 "null"

--- a/src/config.rs
+++ b/src/config.rs
@@ -82,15 +82,15 @@ pub enum ConfigLoadError {
 pub enum ThemeConfig {
     #[default]
     None,
-    /// Theme of the presentation
+    /// Theme of the presentation.
     Some(String),
-    /// Automatic dark/light theme switch based on the terminal background luminance
+    /// Automatic dark/light theme switch based on the terminal background luminance.
     Dynamic {
-        /// Dark theme of the presentation
+        /// Dark theme of the presentation.
         dark: String,
-        /// Light theme of ther presentation
+        /// Light theme of the presentation.
         light: String,
-        /// Light/Dark detection timeout in ms
+        /// Light/Dark detection timeout in ms.
         #[cfg_attr(feature = "json-schema", validate(range(min = 1)))]
         timeout: Option<u64>,
     },


### PR DESCRIPTION
- Typos in doc for theme in `src/config.rs` (and then json schema)
- Align doc format of theme doc (add dot)