### PR TITLE
fix: clippy useless conversion

### DIFF
--- a/src/presentation/builder/error.rs
+++ b/src/presentation/builder/error.rs
@@ -230,7 +230,7 @@ mod tests {
     }
 
     fn make_builder<'a>(source_line: &'a str, error: &'a str) -> ErrorContextBuilder<'a> {
-        let mut builder = ErrorContextBuilder::new(source_line.into(), error.into());
+        let mut builder = ErrorContextBuilder::new(source_line, error);
         builder.prefix_style = Default::default();
         builder.error_style = Default::default();
         builder


### PR DESCRIPTION
Rust analyzer report `useless-conversion` in `src/presentation/builder/error.rs:233`