### PR TITLE
chore: increase polling speed

### DIFF
--- a/src/commands/listener.rs
+++ b/src/commands/listener.rs
@@ -36,7 +36,7 @@ impl CommandListener {
                 return Ok(Some(command));
             }
         }
-        match self.keyboard.poll_next_command(Duration::from_millis(100))? {
+        match self.keyboard.poll_next_command(Duration::from_millis(20))? {
             Some(command) => Ok(Some(command)),
             None => Ok(None),
         }


### PR DESCRIPTION
This reduces the keyboard polling timeout, hence increasing the polling speed. This makes a noticeable impact when using `+pty` blocks, since otherwise we were rendering at most 10 frames a second; now this is rendering up to 50 which is hopefully enough for a presentation.