### PR TITLE
feat: style cursor in PTY output

### DIFF
--- a/src/theme/clean.rs
+++ b/src/theme/clean.rs
@@ -18,6 +18,7 @@ const DEFAULT_TYPST_VERTICAL_MARGIN: u16 = 7;
 const DEFAULT_MERMAID_THEME: &str = "default";
 const DEFAULT_MERMAID_BACKGROUND: &str = "transparent";
 const DEFAULT_D2_THEME: u32 = 0;
+const DEFAULT_PTY_CURSOR_SYMBOL: char = '█';
 
 #[derive(Clone, Debug, Default)]
 pub(crate) struct ThemeOptions {
@@ -647,18 +648,35 @@ impl ExecutionStatusBlockStyle {
 pub(crate) struct PtyOutputBlockStyle {
     pub(crate) style: TextStyle,
     pub(crate) standby: PtyStandbyStyle,
+    pub(crate) cursor: PtyCursorStyle,
 }
 
 impl PtyOutputBlockStyle {
     fn new(raw: &raw::PtyOutputBlockStyle, palette: &ColorPalette) -> Result<Self, ProcessingThemeError> {
-        let raw::PtyOutputBlockStyle { colors, standby } = raw;
+        let raw::PtyOutputBlockStyle { colors, standby, cursor } = raw;
         let colors = colors.resolve(palette)?;
         let style = TextStyle::colored(colors);
         let standby = match standby {
             Some(raw::PtyStandbyStyle::LargePlay) => PtyStandbyStyle::LargePlay,
             None => Default::default(),
         };
-        Ok(Self { style, standby })
+        let cursor = PtyCursorStyle::new(cursor, palette)?;
+        Ok(Self { style, standby, cursor })
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct PtyCursorStyle {
+    pub(crate) symbol: String,
+    pub(crate) highlight_style: TextStyle,
+}
+
+impl PtyCursorStyle {
+    fn new(raw: &raw::PtyCursorStyle, palette: &ColorPalette) -> Result<Self, ProcessingThemeError> {
+        let raw::PtyCursorStyle { symbol, highlight_colors } = raw;
+        let symbol = symbol.unwrap_or(DEFAULT_PTY_CURSOR_SYMBOL).to_string();
+        let highlight_style = TextStyle::colored(highlight_colors.resolve(palette)?);
+        Ok(Self { symbol, highlight_style })
     }
 }
 

--- a/src/theme/raw.rs
+++ b/src/theme/raw.rs
@@ -706,6 +706,21 @@ pub(crate) struct PtyOutputBlockStyle {
     /// The style for the standby state.
     #[serde(default)]
     pub(crate) standby: Option<PtyStandbyStyle>,
+
+    #[serde(default)]
+    pub(crate) cursor: PtyCursorStyle,
+}
+
+/// The style for a PTY's cursor.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub(crate) struct PtyCursorStyle {
+    /// The symbol to use on the cursor.
+    #[serde(default)]
+    pub(crate) symbol: Option<char>,
+
+    /// The colors used when the cursor is on top of non empty cells.
+    #[serde(default)]
+    pub(crate) highlight_colors: RawColors,
 }
 
 /// The style for the standby state.

--- a/themes/catppuccin-frappe.yaml
+++ b/themes/catppuccin-frappe.yaml
@@ -46,6 +46,10 @@ pty_output:
   colors:
     foreground: palette:text
     background: palette:surface0
+  cursor:
+    highlight_colors:
+      foreground: palette:surface0
+      background: palette:text
 
 inline_code:
   colors:

--- a/themes/catppuccin-latte.yaml
+++ b/themes/catppuccin-latte.yaml
@@ -46,6 +46,10 @@ pty_output:
   colors:
     foreground: palette:text
     background: palette:surface0
+  cursor:
+    highlight_colors:
+      foreground: palette:surface0
+      background: palette:text
 
 inline_code:
   colors:

--- a/themes/catppuccin-macchiato.yaml
+++ b/themes/catppuccin-macchiato.yaml
@@ -46,6 +46,10 @@ pty_output:
   colors:
     foreground: palette:text
     background: palette:surface0
+  cursor:
+    highlight_colors:
+      foreground: palette:surface0
+      background: palette:text
 
 inline_code:
   colors:

--- a/themes/catppuccin-mocha.yaml
+++ b/themes/catppuccin-mocha.yaml
@@ -46,6 +46,10 @@ pty_output:
   colors:
     foreground: palette:text
     background: palette:surface0
+  cursor:
+    highlight_colors:
+      foreground: palette:surface0
+      background: palette:text
 
 inline_code:
   colors:

--- a/themes/dark.yaml
+++ b/themes/dark.yaml
@@ -46,6 +46,10 @@ pty_output:
   colors:
     foreground: palette:white
     background: palette:black
+  cursor:
+    highlight_colors:
+      foreground: palette:black
+      background: palette:white
 
 inline_code:
   colors:

--- a/themes/gruvbox-dark.yaml
+++ b/themes/gruvbox-dark.yaml
@@ -46,6 +46,10 @@ pty_output:
   colors:
     foreground: "ebdbb2"
     background: "3c3836"
+  cursor:
+    highlight_colors:
+      foreground: "3c3836"
+      background: "ebdbb2"
 
 inline_code:
   colors:

--- a/themes/light.yaml
+++ b/themes/light.yaml
@@ -46,6 +46,10 @@ pty_output:
   colors:
     foreground: "212529"
     background: "e9ecef"
+  cursor:
+    highlight_colors:
+      foreground: "e9ecef"
+      background: "212529"
 
 inline_code:
   colors:

--- a/themes/terminal-dark.yaml
+++ b/themes/terminal-dark.yaml
@@ -45,6 +45,10 @@ execution_output:
 pty_output:
   colors:
     foreground: white
+  cursor:
+    highlight_colors:
+      foreground: black
+      background: white
 
 inline_code:
   colors:

--- a/themes/terminal-light.yaml
+++ b/themes/terminal-light.yaml
@@ -45,6 +45,10 @@ execution_output:
 pty_output:
   colors:
     foreground: black
+  cursor:
+    highlight_colors:
+      foreground: white
+      background: black
 
 inline_code:
   colors:

--- a/themes/tokyonight-day.yaml
+++ b/themes/tokyonight-day.yaml
@@ -46,6 +46,10 @@ pty_output:
   colors:
     foreground: "3760bf"
     background: "2d2d2d"
+  cursor:
+    highlight_colors:
+      foreground: "2d2d2d"
+      background: "3760bf"
 
 inline_code:
   colors:

--- a/themes/tokyonight-moon.yaml
+++ b/themes/tokyonight-moon.yaml
@@ -46,6 +46,10 @@ pty_output:
   colors:
     foreground: "c8d3f5"
     background: "2d2d2d"
+  cursor:
+    highlight_colors:
+      foreground: "2d2d2d"
+      background: "c8d3f5"
 
 inline_code:
   colors:

--- a/themes/tokyonight-night.yaml
+++ b/themes/tokyonight-night.yaml
@@ -46,6 +46,10 @@ pty_output:
   colors:
     foreground: "c0caf5"
     background: "2d2d2d"
+  cursor:
+    highlight_colors:
+      foreground: "2d2d2d"
+      background: "c0caf5"
 
 inline_code:
   colors:

--- a/themes/tokyonight-storm.yaml
+++ b/themes/tokyonight-storm.yaml
@@ -46,6 +46,10 @@ pty_output:
   colors:
     foreground: "c0caf5"
     background: "2d2d2d"
+  cursor:
+    highlight_colors:
+      foreground: "2d2d2d"
+      background: "c0caf5"
 
 inline_code:
   colors:


### PR DESCRIPTION
This adds support for displaying the cursor. This adds some new styles for the cursor (e.g. the cursor character and colors for it). In all built-in themes the color for the cursor is the inverse of the color for the PTY output itself.

https://github.com/user-attachments/assets/65b204b7-3aa2-4b95-b62f-cf66cc248256

Part of #537

