### PR TITLE
feat: theme can overwrite code block background color

### DIFF
--- a/docs/src/features/themes/definition.md
+++ b/docs/src/features/themes/definition.md
@@ -277,6 +277,24 @@ code:
     vertical: 1
 ```
 
+#### Background
+
+By default the code block background comes from theme given theme, but you're able to override it or disable it completely:
+
+```yaml
+code:
+  # Use the theme's default background color (the default)
+  background: true
+
+  # Disable the background (transparent)
+  background: false
+
+  # Use a specific color
+  background: "898989"
+```
+
+This is particularly useful when combining presentation themes with code highlighting themes that have matching or conflicting backgrounds. For example, you might want to use a Catppuccin presentation theme with a Catppuccin code highlighting theme, but override the background to avoid having identical colors.
+
 #### Custom highlighting themes
 
 Besides the built-in highlighting themes, you can drop any `.tmTheme` theme in the `themes/highlighting` directory under 

--- a/src/code/highlighting.rs
+++ b/src/code/highlighting.rs
@@ -4,7 +4,7 @@ use crate::{
         elements::{Line, Text},
         text_style::{Color, TextStyle},
     },
-    theme::CodeBlockStyle,
+    theme::{CodeBlockStyle, CodeBlockStyleBackground},
 };
 use flate2::read::ZlibDecoder;
 use once_cell::sync::Lazy;
@@ -228,8 +228,10 @@ pub(crate) struct StyledTokens<'a> {
 
 impl<'a> StyledTokens<'a> {
     pub(crate) fn new(style: Style, tokens: &'a str, block_style: &CodeBlockStyle) -> Self {
-        let has_background = block_style.background;
-        let background = has_background.then_some(parse_color(style.background)).flatten();
+        let background = match block_style.background {
+            CodeBlockStyleBackground::Color(color) => color,
+            CodeBlockStyleBackground::Enabled(enabled) => enabled.then_some(parse_color(style.background)).flatten(),
+        };
         let foreground = parse_color(style.foreground);
         let mut style = TextStyle::default();
         style.colors.background = background;

--- a/src/presentation/builder/snippet.rs
+++ b/src/presentation/builder/snippet.rs
@@ -14,7 +14,7 @@ use crate::{
         operation::{AsRenderOperations, RenderAsyncStartPolicy, RenderOperation},
         properties::WindowSize,
     },
-    theme::{Alignment, CodeBlockStyle},
+    theme::{Alignment, CodeBlockStyle, CodeBlockStyleBackground},
     third_party::ThirdPartyRenderRequest,
     ui::execution::{
         RunAcquireTerminalSnippet, RunImageSnippet, SnippetExecutionDisabledOperation, SnippetOutputOperation,
@@ -302,7 +302,7 @@ impl PresentationBuilder<'_, '_> {
     fn code_style(&self, snippet: &Snippet) -> CodeBlockStyle {
         let mut style = self.theme.code.clone();
         if snippet.attributes.no_background {
-            style.background = false;
+            style.background = CodeBlockStyleBackground::Enabled(false);
         }
         style
     }


### PR DESCRIPTION
Closes #814

Updates the `code.background` theme option to also support a color allowing users to easily overwrite the background colour of a code block theme. The tests I added were generated with AI and reviewed by me.
