### PR TITLE
feat: allow specifying `mmdc` puppeteer config path

### DIFF
--- a/config-file-schema.json
+++ b/config-file-schema.json
@@ -536,6 +536,13 @@
     "MermaidConfig": {
       "type": "object",
       "properties": {
+        "pupeteer_config_path": {
+          "description": "A path to a pupeteer JSON configuration file to be used by the `mmdc` tool.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "scale": {
           "description": "The scaling parameter to be used in the mermaid CLI.",
           "default": 2,

--- a/src/config.rs
+++ b/src/config.rs
@@ -338,11 +338,14 @@ pub struct MermaidConfig {
     /// The scaling parameter to be used in the mermaid CLI.
     #[serde(default = "default_mermaid_scale")]
     pub scale: u32,
+
+    /// A path to a pupeteer JSON configuration file to be used by the `mmdc` tool.
+    pub pupeteer_config_path: Option<String>,
 }
 
 impl Default for MermaidConfig {
     fn default() -> Self {
-        Self { scale: default_mermaid_scale() }
+        Self { scale: default_mermaid_scale(), pupeteer_config_path: None }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -254,6 +254,7 @@ impl CoreComponents {
         let third_party_config = ThirdPartyConfigs {
             typst_ppi: config.typst.ppi.to_string(),
             mermaid_scale: config.mermaid.scale.to_string(),
+            mermaid_pupeteer_file: config.mermaid.pupeteer_config_path.clone(),
             d2_scale: config.d2.scale.map(|s| s.to_string()).unwrap_or_else(|| "-1".to_string()),
             threads: config.snippet.render.threads,
         };


### PR DESCRIPTION
This allows specifying `mermaid.pupeteer_config_path` in the config file to point to a pupeteer config file to be passed to the mermaid cli tool (mmdc).

Closes #824