### PR TITLE
feat: allow passing in a mermaid config file

### DIFF
--- a/config-file-schema.json
+++ b/config-file-schema.json
@@ -536,6 +536,13 @@
     "MermaidConfig": {
       "type": "object",
       "properties": {
+        "config_path": {
+          "description": "A path to a mermaid JSON configuration file to be used by the `mmdc` tool.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "pupeteer_config_path": {
           "description": "A path to a pupeteer JSON configuration file to be used by the `mmdc` tool.",
           "type": [

--- a/src/config.rs
+++ b/src/config.rs
@@ -341,11 +341,14 @@ pub struct MermaidConfig {
 
     /// A path to a pupeteer JSON configuration file to be used by the `mmdc` tool.
     pub pupeteer_config_path: Option<String>,
+
+    /// A path to a mermaid JSON configuration file to be used by the `mmdc` tool.
+    pub config_path: Option<String>,
 }
 
 impl Default for MermaidConfig {
     fn default() -> Self {
-        Self { scale: default_mermaid_scale(), pupeteer_config_path: None }
+        Self { scale: default_mermaid_scale(), pupeteer_config_path: None, config_path: None }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -255,6 +255,7 @@ impl CoreComponents {
             typst_ppi: config.typst.ppi.to_string(),
             mermaid_scale: config.mermaid.scale.to_string(),
             mermaid_pupeteer_file: config.mermaid.pupeteer_config_path.clone(),
+            mermaid_config_file: config.mermaid.config_path.clone(),
             d2_scale: config.d2.scale.map(|s| s.to_string()).unwrap_or_else(|| "-1".to_string()),
             threads: config.snippet.render.threads,
         };

--- a/src/third_party.rs
+++ b/src/third_party.rs
@@ -32,6 +32,7 @@ pub struct ThirdPartyConfigs {
     pub typst_ppi: String,
     pub mermaid_scale: String,
     pub mermaid_pupeteer_file: Option<String>,
+    pub mermaid_config_file: Option<String>,
     pub d2_scale: String,
     pub threads: usize,
 }
@@ -69,6 +70,7 @@ impl Default for ThirdPartyRender {
             typst_ppi: default_typst_ppi().to_string(),
             mermaid_scale: default_mermaid_scale().to_string(),
             mermaid_pupeteer_file: None,
+            mermaid_config_file: None,
             d2_scale: "-1".to_string(),
             threads: default_snippet_render_threads(),
         };
@@ -213,8 +215,11 @@ impl Worker {
             "-b",
             &style.background,
         ];
-        if let Some(pupeteer_config_path) = &self.shared.config.mermaid_pupeteer_file {
-            args.extend(&["-p", pupeteer_config_path]);
+        if let Some(path) = &self.shared.config.mermaid_pupeteer_file {
+            args.extend(&["-p", path]);
+        }
+        if let Some(path) = &self.shared.config.mermaid_config_file {
+            args.extend(&["-c", path]);
         }
 
         ThirdPartyTools::mermaid(&args).run()?;


### PR DESCRIPTION
This adds a `mermaid.config_file` config parameter that allows pointing to a [mermaid config file](https://mermaid.ai/open-source/config/schema-docs/config.html). This can be used to, among other things, set the font family to use for diagrams.

Closes #832