### PR TITLE
feat: make typst background transparent

### DIFF
--- a/docs/src/features/code/latex.md
+++ b/docs/src/features/code/latex.md
@@ -86,3 +86,5 @@ typst:
   horizontal_margin: 2
   vertical_margin: 2
 ```
+
+You can also make use of an alpha channel for typst colours, e.g. `background: ff0000aa`.

--- a/src/export/html.rs
+++ b/src/export/html.rs
@@ -84,6 +84,7 @@ pub(crate) fn color_to_html(color: &Color) -> String {
         Color::White => "#ffffff".into(),
         Color::Grey => "#808080".into(),
         Color::Rgb { r, g, b } => format!("#{r:02x}{g:02x}{b:02x}"),
+        Color::Rgba { r, g, b, a } => format!("#{r:02x}{g:02x}{b:02x}{a:02x}"),
     }
 }
 
@@ -105,6 +106,8 @@ mod test {
     )]
     #[case::foreground_color(TextStyle::default().fg_color(Color::new(1,2,3)), "color: #010203")]
     #[case::background_color(TextStyle::default().bg_color(Color::new(1,2,3)), "background-color: #010203")]
+    #[case::foreground_color_alpha(TextStyle::default().fg_color(Color::Rgba {r: 1, g: 2, b: 3, a:4 }), "color: #01020304")]
+    #[case::background_color_alpha(TextStyle::default().bg_color(Color::Rgba { r: 1, g: 2, b: 3, a: 4 }), "background-color: #01020304")]
     #[case::font_size(TextStyle::default().size(3), "font-size: 6px")]
     fn html_text(#[case] style: TextStyle, #[case] expected_style: &str) {
         let html_text = HtmlText::new("", &style, FontSize::Pixels(2));

--- a/src/markdown/text_style.rs
+++ b/src/markdown/text_style.rs
@@ -304,6 +304,7 @@ pub(crate) enum Color {
     White,
     Grey,
     Rgb { r: u8, g: u8, b: u8 },
+    Rgba { r: u8, g: u8, b: u8, a: u8 },
 }
 
 impl Color {
@@ -346,6 +347,15 @@ impl Color {
     pub(crate) fn as_rgb(&self) -> Option<(u8, u8, u8)> {
         match self {
             Self::Rgb { r, g, b } => Some((*r, *g, *b)),
+            Self::Rgba { r, g, b, .. } => Some((*r, *g, *b)),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn as_rgba(&self) -> Option<(u8, u8, u8, u8)> {
+        match self {
+            Self::Rgb { r, g, b } => Some((*r, *g, *b, u8::MAX)),
+            Self::Rgba { r, g, b, a } => Some((*r, *g, *b, *a)),
             _ => None,
         }
     }
@@ -387,6 +397,7 @@ impl From<Color> for crossterm::style::Color {
             Color::White => C::White,
             Color::Grey => C::Grey,
             Color::Rgb { r, g, b } => C::Rgb { r, g, b },
+            Color::Rgba { r, g, b, .. } => C::Rgb { r, g, b },
         }
     }
 }
@@ -517,5 +528,21 @@ mod tests {
     fn iterate_attributes(#[case] style: TextStyle, #[case] expected: &[TextAttribute]) {
         let attrs: Vec<_> = style.iter_attributes().collect();
         assert_eq!(attrs, expected);
+    }
+
+    #[rstest]
+    #[case::constant(Color::Green, None)]
+    #[case::rgb(Color::Rgb { r: 12, g: 38, b: 42 }, Some((12, 38, 42)))]
+    #[case::rgba(Color::Rgba { r: 12, g: 38, b: 42, a: 72 }, Some((12, 38, 42)))]
+    fn as_rgb(#[case] color: Color, #[case] expected: Option<(u8, u8, u8)>) {
+        assert_eq!(color.as_rgb(), expected);
+    }
+
+    #[rstest]
+    #[case::constant(Color::Green, None)]
+    #[case::rgb(Color::Rgb { r: 12, g: 38, b: 42 }, Some((12, 38, 42, 255)))]
+    #[case::rgba(Color::Rgba { r: 12, g: 38, b: 42, a: 72 }, Some((12, 38, 42, 72)))]
+    fn as_rgba(#[case] color: Color, #[case] expected: Option<(u8, u8, u8, u8)>) {
+        assert_eq!(color.as_rgba(), expected);
     }
 }

--- a/src/third_party.rs
+++ b/src/third_party.rs
@@ -299,8 +299,8 @@ impl Worker {
     }
 
     fn as_typst_color(color: &Color) -> Result<String, ThirdPartyRenderError> {
-        match color.as_rgb() {
-            Some((r, g, b)) => Ok(format!("rgb(\"#{r:02x}{g:02x}{b:02x}\")")),
+        match color.as_rgba() {
+            Some((r, g, b, a)) => Ok(format!("rgb(\"#{r:02x}{g:02x}{b:02x}{a:02x}\")")),
             None => Err(ThirdPartyRenderError::UnsupportedColor(RawColor::from(*color).to_string())),
         }
     }
@@ -427,5 +427,22 @@ impl Pollable for OperationPollable {
             }
             RenderResult::Pending => PollableState::Unmodified,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn as_typst_color() {
+        let rgb = Worker::as_typst_color(&Color::Rgb { r: 19, g: 57, b: 72 });
+        assert!(rgb.is_ok());
+        assert_eq!("rgb(\"#133948ff\")".to_string(), rgb.unwrap());
+        let rgba = Worker::as_typst_color(&Color::Rgba { r: 102, g: 2, b: 37, a: 24 });
+        assert!(rgba.is_ok());
+        assert_eq!("rgb(\"#66022518\")".to_string(), rgba.unwrap());
+        let err = Worker::as_typst_color(&Color::Red);
+        assert!(err.is_err());
     }
 }


### PR DESCRIPTION
## What

support alpha channels for typst colours

## Why

At the moment, if the theme you're using specifies typst colours, there is no way to go back to a transparent background.