### PR TITLE
fix: Overwrite colors when merging text styles

### DIFF
--- a/src/markdown/parse.rs
+++ b/src/markdown/parse.rs
@@ -546,7 +546,7 @@ impl<'a> InlinesParser<'a> {
                     }
                 };
                 style = base_style.clone();
-                for html_style in html_styles.iter().rev() {
+                for html_style in html_styles.iter() {
                     style.merge(&html_style.0);
                 }
             }

--- a/src/markdown/text_style.rs
+++ b/src/markdown/text_style.rs
@@ -115,11 +115,14 @@ where
     }
 
     /// Merge this style with another one.
+    ///
+    /// If `other` defines a background or foreground color, that overwrites the respective color
+    /// in `self`.
     pub(crate) fn merge(&mut self, other: &TextStyle<C>) {
         self.flags |= other.flags;
         self.size = self.size.max(other.size);
-        self.colors.background = self.colors.background.clone().or(other.colors.background.clone());
-        self.colors.foreground = self.colors.foreground.clone().or(other.colors.foreground.clone());
+        self.colors.background = other.colors.background.clone().or(self.colors.background.clone());
+        self.colors.foreground = other.colors.foreground.clone().or(self.colors.foreground.clone());
     }
 
     /// Return a new style merged with the one passed in.

--- a/src/markdown/text_style.rs
+++ b/src/markdown/text_style.rs
@@ -505,7 +505,7 @@ mod tests {
     #[case::strikethrough(TextStyle::default().strikethrough(), &[TextAttribute::Strikethrough])]
     #[case::underlined(TextStyle::default().underlined(), &[TextAttribute::Underlined])]
     #[case::bg_color(TextStyle::default().bg_color(Color::Red), &[TextAttribute::BackgroundColor(Color::Red)])]
-    #[case::bg_color(TextStyle::default().fg_color(Color::Red), &[TextAttribute::ForegroundColor(Color::Red)])]
+    #[case::fg_color(TextStyle::default().fg_color(Color::Red), &[TextAttribute::ForegroundColor(Color::Red)])]
     #[case::all(
         TextStyle::default().bold().code().italics().strikethrough().underlined().bg_color(Color::Black).fg_color(Color::Red),
         &[

--- a/src/markdown/text_style.rs
+++ b/src/markdown/text_style.rs
@@ -521,4 +521,30 @@ mod tests {
         let attrs: Vec<_> = style.iter_attributes().collect();
         assert_eq!(attrs, expected);
     }
+
+    #[rstest]
+    #[case::fg_color(
+        TextStyle::default().bold().fg_color(Color::Red),
+        TextStyle::default().fg_color(Color::Blue),
+        TextStyle::default().bold().fg_color(Color::Blue)
+    )]
+    #[case::fg_color(
+        TextStyle::default().fg_color(Color::Red),
+        TextStyle::default().bold().fg_color(Color::Blue),
+        TextStyle::default().bold().fg_color(Color::Blue)
+    )]
+    #[case::bg_color(
+        TextStyle::default().bold().bg_color(Color::Yellow),
+        TextStyle::default().bg_color(Color::Green),
+        TextStyle::default().bold().bg_color(Color::Green)
+    )]
+    #[case::bg_color(
+        TextStyle::default().bg_color(Color::Yellow),
+        TextStyle::default().bold().bg_color(Color::Green),
+        TextStyle::default().bold().bg_color(Color::Green)
+    )]
+    fn merge_overwrites_colors(#[case] mut some: TextStyle, #[case] other: TextStyle, #[case] output: TextStyle) {
+        some.merge(&other);
+        assert_eq!(some, output);
+    }
 }

--- a/src/terminal/virt.rs
+++ b/src/terminal/virt.rs
@@ -143,7 +143,7 @@ impl VirtualTerminal {
     }
 
     fn print_text(&mut self, content: &str, style: &TextStyle) -> io::Result<()> {
-        let style = style.merged(&TextStyle::default().colors(self.colors));
+        let style = TextStyle::default().colors(self.colors).merged(style);
         for c in content.chars() {
             let Some(cell) = self.current_cell_mut() else {
                 continue;

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -235,6 +235,10 @@ struct ContentRow {
 }
 
 impl ContentRow {
+    /// Overwrite the style of a content row.
+    ///
+    /// The current background and foreground style is overwritten with the respective definitions
+    /// of `style`, if they are set.
     fn with_style(mut self, style: TextStyle) -> ContentRow {
         for chunk in &mut self.content {
             chunk.style.merge(&style);


### PR DESCRIPTION
Rewrite `TextStyle::merge` to always overwrite the colors defined in *self* with those of *other*, if *other* defines background/foreground colors.

Previously, the colors in *self* were kept (if previously defined, e.g. from default values), meaning that merging would only modify text size and attributes after colors had been set for the first time (from whatever source).

I noticed this while rewriting my theme config today, since the style configured for modal dialogs wasn't applied any longer. I remember an earlier release (I think 0.13, but I might be wrong) still applied the colors for modal dialogs correctly, but from 0.14 that feature was apparently broken.

As a fun side-effect of this change, the themes in parsed HTML don't have to be iterated *in reverse* any more.

I wrote a test to ensure this behavior is upheld in the future. I also tried a debug version on some of my own slides and all other theming aspects look correct to me.


## User-facing changes

Users can now properly theme their [modal dialogs][1] again. Modal dialogs will no longer have the default colors applied for all elements of their UI.


[1]: https://mfontanini.github.io/presenterm/features/introduction.html?highlight=modal#modals