### PR TITLE
chore!: rename puppeteer config parameter

### DIFF
--- a/config-file-schema.json
+++ b/config-file-schema.json
@@ -543,8 +543,8 @@
             "null"
           ]
         },
-        "pupeteer_config_path": {
-          "description": "A path to a pupeteer JSON configuration file to be used by the `mmdc` tool.",
+        "puppeteer_config_path": {
+          "description": "A path to a puppeteer JSON configuration file to be used by the `mmdc` tool.",
           "type": [
             "string",
             "null"

--- a/src/config.rs
+++ b/src/config.rs
@@ -339,8 +339,8 @@ pub struct MermaidConfig {
     #[serde(default = "default_mermaid_scale")]
     pub scale: u32,
 
-    /// A path to a pupeteer JSON configuration file to be used by the `mmdc` tool.
-    pub pupeteer_config_path: Option<String>,
+    /// A path to a puppeteer JSON configuration file to be used by the `mmdc` tool.
+    pub puppeteer_config_path: Option<String>,
 
     /// A path to a mermaid JSON configuration file to be used by the `mmdc` tool.
     pub config_path: Option<String>,
@@ -348,7 +348,7 @@ pub struct MermaidConfig {
 
 impl Default for MermaidConfig {
     fn default() -> Self {
-        Self { scale: default_mermaid_scale(), pupeteer_config_path: None, config_path: None }
+        Self { scale: default_mermaid_scale(), puppeteer_config_path: None, config_path: None }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -254,7 +254,7 @@ impl CoreComponents {
         let third_party_config = ThirdPartyConfigs {
             typst_ppi: config.typst.ppi.to_string(),
             mermaid_scale: config.mermaid.scale.to_string(),
-            mermaid_pupeteer_file: config.mermaid.pupeteer_config_path.clone(),
+            mermaid_puppeteer_file: config.mermaid.puppeteer_config_path.clone(),
             mermaid_config_file: config.mermaid.config_path.clone(),
             d2_scale: config.d2.scale.map(|s| s.to_string()).unwrap_or_else(|| "-1".to_string()),
             threads: config.snippet.render.threads,

--- a/src/third_party.rs
+++ b/src/third_party.rs
@@ -31,7 +31,7 @@ use std::{
 pub struct ThirdPartyConfigs {
     pub typst_ppi: String,
     pub mermaid_scale: String,
-    pub mermaid_pupeteer_file: Option<String>,
+    pub mermaid_puppeteer_file: Option<String>,
     pub mermaid_config_file: Option<String>,
     pub d2_scale: String,
     pub threads: usize,
@@ -69,7 +69,7 @@ impl Default for ThirdPartyRender {
         let config = ThirdPartyConfigs {
             typst_ppi: default_typst_ppi().to_string(),
             mermaid_scale: default_mermaid_scale().to_string(),
-            mermaid_pupeteer_file: None,
+            mermaid_puppeteer_file: None,
             mermaid_config_file: None,
             d2_scale: "-1".to_string(),
             threads: default_snippet_render_threads(),
@@ -215,7 +215,7 @@ impl Worker {
             "-b",
             &style.background,
         ];
-        if let Some(path) = &self.shared.config.mermaid_pupeteer_file {
+        if let Some(path) = &self.shared.config.mermaid_puppeteer_file {
             args.extend(&["-p", path]);
         }
         if let Some(path) = &self.shared.config.mermaid_config_file {


### PR DESCRIPTION
This renames the parameter introduced in #830 since it had a typo. Before `pupeteer_config_path`, now `puppeteer_config_path`.