### PR TITLE
Add styling docs to `slide_title`

### DIFF
--- a/docs/src/features/themes/definition.md
+++ b/docs/src/features/themes/definition.md
@@ -219,7 +219,7 @@ footer:
 
 ## Slide title
 
-Slide titles, as specified by using a setext header, has the following properties:
+Slide titles, as specified by using a setext header, has the following properties in addition to styling and colors, just like any other element:
 
 * `font_size` which specifies the font size to be used.
 * `prefix` which specifies a prefix to use on a slide title.
@@ -234,6 +234,9 @@ slide_title:
   padding_bottom: 1
   padding_top: 1
   separator: true
+  bold: true
+  colors:
+    foreground: "beeeeff"
 ```
 
 ## Headings


### PR DESCRIPTION
Out of interest, I tried to style the title, and it worked! I've updated the docs to reflect this.

Interestingly, I couldn't get `italic: true` to work, though bold and underline were fine.