### PR TITLE
fix: render modals at the center of the screen

### DIFF
--- a/src/render/engine.rs
+++ b/src/render/engine.rs
@@ -149,6 +149,7 @@ where
             RenderOperation::RenderImage(image, properties) => self.render_image(image, properties),
             RenderOperation::RenderBlockLine(operation) => self.render_block_line(operation),
             RenderOperation::RenderDynamic(generator) => self.render_dynamic(generator.as_ref()),
+            RenderOperation::RenderDynamicTopLevel(generator) => self.render_dynamic_top_level(generator.as_ref()),
             RenderOperation::RenderAsync(generator) => self.render_async(generator.as_ref()),
             RenderOperation::InitColumnLayout { columns, grid } => self.init_column_layout(columns, *grid),
             RenderOperation::EnterColumn { column } => self.enter_column(*column),
@@ -351,6 +352,15 @@ where
 
     fn render_dynamic(&mut self, generator: &dyn AsRenderOperations) -> RenderResult {
         let operations = generator.as_render_operations(&self.current_available_dimensions());
+        for operation in operations {
+            self.render_one(&operation)?;
+        }
+        Ok(())
+    }
+
+    fn render_dynamic_top_level(&mut self, generator: &dyn AsRenderOperations) -> RenderResult {
+        let dimensions = self.window_rects.first().expect("no rects").dimensions;
+        let operations = generator.as_render_operations(&dimensions);
         for operation in operations {
             self.render_one(&operation)?;
         }

--- a/src/render/operation.rs
+++ b/src/render/operation.rs
@@ -74,6 +74,9 @@ pub(crate) enum RenderOperation {
     /// [RenderOperation] with the screen itself.
     RenderDynamic(Rc<dyn AsRenderOperations>),
 
+    /// Render a dynamically sequence of render operations drawing it at the top level margin
+    RenderDynamicTopLevel(Rc<dyn AsRenderOperations>),
+
     /// An operation that is rendered asynchronously.
     RenderAsync(Rc<dyn RenderAsync>),
 

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -57,7 +57,7 @@ impl IndexBuilder {
             selection_style,
             background: self.background,
         };
-        vec![RenderOperation::RenderDynamic(Rc::new(drawer))]
+        vec![RenderOperation::RenderDynamicTopLevel(Rc::new(drawer))]
     }
 }
 
@@ -319,6 +319,6 @@ impl AsRenderOperations for CenterModalContent {
 
 impl From<CenterModalContent> for RenderOperation {
     fn from(op: CenterModalContent) -> Self {
-        Self::RenderDynamic(Rc::new(op))
+        Self::RenderDynamicTopLevel(Rc::new(op))
     }
 }


### PR DESCRIPTION
This is a pretty :hankey: fix but it works. In the future the way margins are handled should be changed so we can say "draw this at the top level", providing the operations we want to run there. The current push/pop margin strategy is not great and leads to repetition and issues.

Fixes #844