### PR TITLE
feat: add mobile device support to HTML export

### DIFF
--- a/src/export/output.rs
+++ b/src/export/output.rs
@@ -174,6 +174,11 @@ impl ExportRenderer {
 
         {font_face} 
 
+        html {{
+            overflow: hidden;
+            background-color: {background_color};
+        }}
+
         body {{
             margin: 0;
             font-size: {FONT_SIZE}px;
@@ -224,6 +229,7 @@ let originalHeight = {height};
                 "
 <head>
 <meta charset=\"UTF-8\">
+<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">
 <style>
 {css}
 </style>

--- a/src/export/script.js
+++ b/src/export/script.js
@@ -1,56 +1,95 @@
 document.addEventListener('DOMContentLoaded', function() {
-  const allLines = document.querySelectorAll('body > div');
-  const pageBreakMarkers = document.querySelectorAll('.container');
+  const slides = document.querySelectorAll('body > div');
+  const totalSlides = document.querySelectorAll('.container').length;
 
-  function getCurrentPageIndex() {
+  function getInitialSlideIndex() {
     const hash = window.location.hash;
     const match = hash.match(/^#slide-(\d+)$/);
     if (match) {
       const idx = parseInt(match[1], 10);
-      const max = pageBreakMarkers.length;
-      if (idx >= 0 && idx < max) return idx;
+      if (idx >= 0 && idx < totalSlides) return idx;
     }
     return 0;
   }
 
-  let currentPageIndex = getCurrentPageIndex();
+  let currentSlideIndex = getInitialSlideIndex();
 
-  function showCurrentPage() {
-    allLines.forEach((line) => {
-      line.classList.add('hidden');
+  function showCurrentSlide() {
+    slides.forEach((slide) => {
+      slide.classList.add('hidden');
     });
-
-    allLines[currentPageIndex].classList.remove('hidden');
-    history.replaceState(null, '', '#slide-' + currentPageIndex);
+    slides[currentSlideIndex].classList.remove('hidden');
+    window.location.hash = 'slide-' + currentSlideIndex;
   }
 
-  function scaler() {
-    var w = document.documentElement.clientWidth;
-    var h = document.documentElement.clientHeight;
-    let widthScaledAmount= w/originalWidth;
-    let heightScaledAmount= h/originalHeight;
-    let scaledAmount = Math.min(widthScaledAmount, heightScaledAmount);
-    document.querySelector("body").style.transform = `scale(${scaledAmount})`;
+  function showNextSlide() {
+    if (currentSlideIndex >= totalSlides - 1) return;
+    currentSlideIndex++;
+    showCurrentSlide();
+  }
+
+  function showPreviousSlide() {
+    if (currentSlideIndex <= 0) return;
+    currentSlideIndex--;
+    showCurrentSlide();
+  }
+
+  function scaleToFit() {
+    const w = window.innerWidth;
+    const h = window.innerHeight;
+    const scale = Math.min(w / originalWidth, h / originalHeight);
+    const offsetX = (w - originalWidth * scale) / 2;
+    const offsetY = (h - originalHeight * scale) / 2;
+    const body = document.querySelector("body");
+    body.style.transform = `translate(${offsetX}px, ${offsetY}px) scale(${scale})`;
   }
 
   function handleKeyPress(event) {
-    if (event.key === 'ArrowLeft') {
-      if (currentPageIndex > 0) {
-        currentPageIndex--;
-        showCurrentPage();
-      }
-    } else if (event.key === 'ArrowRight') {
-      if (currentPageIndex < pageBreakMarkers.length - 1) {
-        currentPageIndex++;
-        showCurrentPage();
-      }
+    switch (event.key) {
+      case 'ArrowLeft':
+        showPreviousSlide();
+        break;
+      case 'ArrowRight':
+        showNextSlide();
+        break;
     }
   }
 
+  let touchStartX = 0;
+  let touchStartY = 0;
+  const swipeThreshold = 50;
+
+  function handleTouchStart(event) {
+    touchStartX = event.touches[0].clientX;
+    touchStartY = event.touches[0].clientY;
+  }
+
+  function handleTouchEnd(event) {
+    const dx = event.changedTouches[0].clientX - touchStartX;
+    const dy = event.changedTouches[0].clientY - touchStartY;
+    if (Math.abs(dx) < swipeThreshold || Math.abs(dy) > Math.abs(dx)) return;
+    const swipedLeft = dx < 0;
+    if (swipedLeft) {
+      showNextSlide();
+      return;
+    }
+    showPreviousSlide();
+  }
+
+  function handleClick(event) {
+    if (event.clientX < document.documentElement.clientWidth / 3) {
+      showPreviousSlide();
+      return;
+    }
+    showNextSlide();
+  }
+
   document.addEventListener('keydown', handleKeyPress);
-  window.addEventListener("resize", scaler);
+  document.addEventListener('touchstart', handleTouchStart, { passive: true });
+  document.addEventListener('touchend', handleTouchEnd);
+  document.addEventListener('click', handleClick);
+  window.addEventListener("resize", scaleToFit);
 
-  scaler();
-  showCurrentPage();
+  scaleToFit();
+  showCurrentSlide();
 });
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -457,16 +457,7 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 height: dimensions.rows * DEFAULT_EXPORT_PIXELS_PER_ROW,
                 width: dimensions.columns * DEFAULT_EXPORT_PIXELS_PER_COLUMN,
             },
-            None => {
-                const DEFAULT_EXPORT_ROWS: u16 = 40;
-                const DEFAULT_EXPORT_COLUMNS: u16 = 120;
-                WindowSize {
-                    rows: DEFAULT_EXPORT_ROWS,
-                    columns: DEFAULT_EXPORT_COLUMNS,
-                    height: DEFAULT_EXPORT_ROWS * DEFAULT_EXPORT_PIXELS_PER_ROW,
-                    width: DEFAULT_EXPORT_COLUMNS * DEFAULT_EXPORT_PIXELS_PER_COLUMN,
-                }
-            }
+            None => WindowSize::current(config.defaults.terminal_font_size)?,
         };
         let exporter = Exporter::new(
             parser,

--- a/src/main.rs
+++ b/src/main.rs
@@ -422,8 +422,8 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         }
         return Ok(());
     }
-    // Disable this so we don't mess things up when generating PDFs
-    if cli.export_pdf {
+    // Disable this so we don't mess things up when exporting.
+    if cli.export_pdf || cli.export_html {
         TerminalEmulator::disable_capability_detection();
     }
 
@@ -457,7 +457,16 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 height: dimensions.rows * DEFAULT_EXPORT_PIXELS_PER_ROW,
                 width: dimensions.columns * DEFAULT_EXPORT_PIXELS_PER_COLUMN,
             },
-            None => WindowSize::current(config.defaults.terminal_font_size)?,
+            None => {
+                const DEFAULT_EXPORT_ROWS: u16 = 40;
+                const DEFAULT_EXPORT_COLUMNS: u16 = 120;
+                WindowSize {
+                    rows: DEFAULT_EXPORT_ROWS,
+                    columns: DEFAULT_EXPORT_COLUMNS,
+                    height: DEFAULT_EXPORT_ROWS * DEFAULT_EXPORT_PIXELS_PER_ROW,
+                    width: DEFAULT_EXPORT_COLUMNS * DEFAULT_EXPORT_PIXELS_PER_COLUMN,
+                }
+            }
         };
         let exporter = Exporter::new(
             parser,


### PR DESCRIPTION
I noticed that if you open a HTML slide export on a mobile device, you can't progress the slide content, because there's no tap/touch and swipe support.

I've updated the script to do this, and also updated the export code to not require a TTY to run, choosing some defaults targeted towards a 13" laptop display, but that work well in landscape mode on mobile devices.

I also fixed a bug where you might get an error like this in the browser console when trying to load the slide content from a file on disk instead of from a web server:

```
presenterm-demo.html#slide-2:1 Unsafe attempt to load URL file:///private/tmp/presenterm-demo.html#slide-2 from frame with URL file:///private/tmp/presenterm-demo.html#slide-2. 'file:' URLs are treated as unique security origins.
```

1600x900

<img width="3200" height="1800" alt="1600_900" src="https://github.com/user-attachments/assets/198c5a82-cdc3-4ba7-bc06-29b4232f7aa1" />

iPhone 12 Pro

<img width="2532" height="1170" alt="iphone_12_pro" src="https://github.com/user-attachments/assets/94cb3b09-49d5-4a3f-941d-9934793e5d2b" />

Pixel 7

<img width="2402" height="1081" alt="pixel_7" src="https://github.com/user-attachments/assets/84e9ef49-19c5-477f-aa0e-dda370b5bc31" />
