### PR TITLE
feat: respect markdown table alignments

### DIFF
--- a/src/markdown/elements.rs
+++ b/src/markdown/elements.rs
@@ -216,26 +216,42 @@ pub(crate) enum ListItemType {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct Table {
     /// The table's header.
-    pub(crate) header: TableRow,
+    pub(crate) columns: Vec<TableColumn>,
 
     /// All of the rows in this table, excluding the header.
     pub(crate) rows: Vec<TableRow>,
 }
 
 impl Table {
-    /// gets the number of columns in this table.
+    /// Gets the number of columns in this table.
     pub(crate) fn columns(&self) -> usize {
-        self.header.0.len()
+        self.columns.len()
     }
 
     /// Iterates all the text entries in a column.
     ///
     /// This includes the header.
     pub(crate) fn iter_column(&self, column: usize) -> impl Iterator<Item = &Line<RawColor>> {
-        let header_element = &self.header.0[column];
+        let header_element = &self.columns[column].text;
         let row_elements = self.rows.iter().map(move |row| &row.0[column]);
         iter::once(header_element).chain(row_elements)
     }
+}
+
+/// The alignment for a table column.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) enum TableColumnAlignment {
+    #[default]
+    Left,
+    Center,
+    Right,
+}
+
+/// A table Header.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct TableColumn {
+    pub(crate) text: Line<RawColor>,
+    pub(crate) alignment: TableColumnAlignment,
 }
 
 /// A table row.

--- a/src/markdown/parse.rs
+++ b/src/markdown/parse.rs
@@ -3,14 +3,20 @@ use super::{
     html::{HtmlInline, HtmlParser, ParseHtmlError},
     text_style::TextStyle,
 };
-use crate::{markdown::html::HtmlTag, theme::raw::RawColor};
+use crate::{
+    markdown::{
+        elements::{TableColumn, TableColumnAlignment},
+        html::HtmlTag,
+    },
+    theme::raw::RawColor,
+};
 use comrak::{
     Arena, Options,
     arena_tree::Node,
     format_commonmark,
     nodes::{
         Ast, AstNode, ListDelimType, ListType, NodeAlert, NodeCodeBlock, NodeFootnoteDefinition, NodeHeading,
-        NodeHtmlBlock, NodeList, NodeValue, Sourcepos,
+        NodeHtmlBlock, NodeList, NodeTable, NodeValue, Sourcepos,
     },
     parse_document,
 };
@@ -106,7 +112,7 @@ impl<'a> MarkdownParser<'a> {
                 let items = self.parse_list(node, list.marker_offset as u8 / 2)?;
                 MarkdownElement::List(items)
             }
-            NodeValue::Table(_) => self.parse_table(node)?,
+            NodeValue::Table(table) => self.parse_table(table, node)?,
             NodeValue::CodeBlock(block) => Self::parse_code_block(block, data.sourcepos)?,
             NodeValue::ThematicBreak => MarkdownElement::ThematicBreak,
             NodeValue::HtmlBlock(block) => self.parse_html_block(block, data.sourcepos)?,
@@ -311,9 +317,19 @@ impl<'a> MarkdownParser<'a> {
         Ok(elements)
     }
 
-    fn parse_table(&self, node: &'a AstNode<'a>) -> ParseResult<MarkdownElement> {
-        let mut header = TableRow(Vec::new());
+    fn parse_table(&self, table: &NodeTable, node: &'a AstNode<'a>) -> ParseResult<MarkdownElement> {
+        let mut columns = Vec::new();
         let mut rows = Vec::new();
+        let alignments: Vec<_> = table
+            .alignments
+            .iter()
+            .map(|a| match a {
+                comrak::nodes::TableAlignment::None => TableColumnAlignment::default(),
+                comrak::nodes::TableAlignment::Left => TableColumnAlignment::Left,
+                comrak::nodes::TableAlignment::Center => TableColumnAlignment::Center,
+                comrak::nodes::TableAlignment::Right => TableColumnAlignment::Right,
+            })
+            .collect();
         for node in node.children() {
             let data = node.data.borrow();
             let NodeValue::TableRow(_) = &data.value else {
@@ -324,13 +340,18 @@ impl<'a> MarkdownParser<'a> {
                 .with_sourcepos(data.sourcepos));
             };
             let row = self.parse_table_row(node)?;
-            if header.0.is_empty() {
-                header = row;
+            if columns.is_empty() {
+                let TableRow(texts) = row;
+                columns = texts
+                    .into_iter()
+                    .zip(alignments.iter().copied())
+                    .map(|(text, alignment)| TableColumn { text, alignment })
+                    .collect();
             } else {
                 rows.push(row)
             }
         }
-        Ok(MarkdownElement::Table(Table { header, rows }))
+        Ok(MarkdownElement::Table(Table { columns, rows }))
     }
 
     fn parse_table_row(&self, node: &'a AstNode<'a>) -> ParseResult<TableRow> {
@@ -990,8 +1011,8 @@ let q = 42;
 | Carrot | Yuck |
 ",
         );
-        let MarkdownElement::Table(Table { header, rows }) = parsed else { panic!("not a table: {parsed:?}") };
-        assert_eq!(header.0.len(), 2);
+        let MarkdownElement::Table(Table { columns, rows }) = parsed else { panic!("not a table: {parsed:?}") };
+        assert_eq!(columns.len(), 2);
         assert_eq!(rows.len(), 2);
         assert_eq!(rows[0].0.len(), 2);
         assert_eq!(rows[1].0.len(), 2);

--- a/src/presentation/builder/table.rs
+++ b/src/presentation/builder/table.rs
@@ -1,7 +1,7 @@
 use crate::{
-    markdown::elements::{Line, Table, TableRow, Text},
+    markdown::elements::{Line, Table, TableColumnAlignment, Text},
     presentation::builder::{BuildResult, PresentationBuilder, error::BuildError},
-    theme::ElementType,
+    theme::{ElementType, raw::RawColor},
 };
 use std::iter;
 
@@ -11,7 +11,10 @@ impl PresentationBuilder<'_, '_> {
             .map(|column| table.iter_column(column).map(|text| text.width()).max().unwrap_or(0))
             .collect();
         let incremental = self.slide_state.incremental_tables.unwrap_or(self.options.incremental_tables);
-        let flattened_header = self.prepare_table_row(table.header, &widths)?;
+        let alignments: Vec<_> = table.columns.iter().map(|c| c.alignment).collect();
+        let column_texts = table.columns.into_iter().map(|c| c.text);
+        let flattened_header =
+            self.prepare_table_row(column_texts, iter::repeat(TableColumnAlignment::Center), &widths)?;
         if incremental && self.options.pause_before_incremental_tables {
             self.push_pause();
         }
@@ -40,7 +43,7 @@ impl PresentationBuilder<'_, '_> {
             if incremental {
                 self.push_pause();
             }
-            let flattened_row = self.prepare_table_row(row, &widths)?;
+            let flattened_row = self.prepare_table_row(row.0, alignments.iter().copied(), &widths)?;
             self.push_text(flattened_row, ElementType::Table);
             self.push_line_break();
         }
@@ -50,20 +53,41 @@ impl PresentationBuilder<'_, '_> {
         Ok(())
     }
 
-    fn prepare_table_row(&self, row: TableRow, widths: &[usize]) -> Result<Line, BuildError> {
+    fn prepare_table_row<I, A>(&self, texts: I, alignments: A, widths: &[usize]) -> Result<Line, BuildError>
+    where
+        I: IntoIterator<Item = Line<RawColor>>,
+        A: IntoIterator<Item = TableColumnAlignment>,
+    {
         let mut flattened_row = Line(Vec::new());
-        for (column, text) in row.0.into_iter().enumerate() {
+        for (column, (text, alignment)) in texts.into_iter().zip(alignments).enumerate() {
             let text = text.resolve(&self.theme.palette)?;
             if column > 0 {
                 flattened_row.0.push(Text::from(" │ "));
             }
             let text_length = text.width();
-            flattened_row.0.extend(text.0.into_iter());
-
             let cell_width = widths[column];
-            if text_length < cell_width {
-                let padding = " ".repeat(cell_width - text_length);
-                flattened_row.0.push(Text::from(padding));
+            let padding = cell_width.saturating_sub(text_length);
+            if padding == 0 {
+                flattened_row.0.extend(text.0.into_iter());
+            } else {
+                match alignment {
+                    TableColumnAlignment::Left => {
+                        flattened_row.0.extend(text.0.into_iter());
+                        flattened_row.0.push(Text::from(" ".repeat(padding)));
+                    }
+                    TableColumnAlignment::Center => {
+                        let padding_after = padding / 2;
+                        let padding_before = padding_after + (padding % 2);
+                        flattened_row.0.push(Text::from(" ".repeat(padding_before)));
+                        flattened_row.0.extend(text.0.into_iter());
+                        flattened_row.0.push(Text::from(" ".repeat(padding_after)));
+                    }
+                    TableColumnAlignment::Right => {
+                        let padding = " ".repeat(padding);
+                        flattened_row.0.push(Text::from(padding));
+                        flattened_row.0.extend(text.0.into_iter());
+                    }
+                }
             }
         }
         Ok(flattened_row)
@@ -77,19 +101,79 @@ mod tests {
     #[test]
     fn table() {
         let input = "
-| Name   | Taste  |
-| ------ | ------ |
-| Potato | Great  |
-| Carrot | Yuck   |
+| Name       | Taste  |
+| ---------- | ------ |
+| Potatooo   | Great  |
+| Carrot     | Yuck   |
 ";
-        let lines = Test::new(input).render().rows(6).columns(22).into_lines();
+        let lines = Test::new(input).render().rows(6).columns(18).into_lines();
         let expected_lines = &[
-            "                      ",
-            "Name   │ Taste        ",
-            "───────┼──────        ",
-            "Potato │ Great        ",
-            "Carrot │ Yuck         ",
-            "                      ",
+            "                  ",
+            "  Name   │ Taste  ",
+            "─────────┼──────  ",
+            "Potatooo │ Great  ",
+            "Carrot   │ Yuck   ",
+            "                  ",
+        ];
+        assert_eq!(lines, expected_lines);
+    }
+
+    #[test]
+    fn table_left_aligned() {
+        let input = "
+| Name       | Taste  |
+| :--------- | ------ |
+| Potatooo   | Great  |
+| Carrot     | Yuck   |
+";
+        let lines = Test::new(input).render().rows(6).columns(18).into_lines();
+        let expected_lines = &[
+            "                  ",
+            "  Name   │ Taste  ",
+            "─────────┼──────  ",
+            "Potatooo │ Great  ",
+            "Carrot   │ Yuck   ",
+            "                  ",
+        ];
+        assert_eq!(lines, expected_lines);
+    }
+
+    #[test]
+    fn table_center_aligned() {
+        let input = "
+| Name       | Taste  |
+| :--------: | ------ |
+| Potatooo   | Great  |
+| Carrot     | Yuck   |
+";
+        let lines = Test::new(input).render().rows(6).columns(18).into_lines();
+        let expected_lines = &[
+            "                  ",
+            "  Name   │ Taste  ",
+            "─────────┼──────  ",
+            "Potatooo │ Great  ",
+            " Carrot  │ Yuck   ",
+            "                  ",
+        ];
+        assert_eq!(lines, expected_lines);
+    }
+
+    #[test]
+    fn table_right_aligned() {
+        let input = "
+| Name       | Taste  |
+| ---------: | ------ |
+| Potatooo   | Great  |
+| Carrot     | Yuck   |
+";
+        let lines = Test::new(input).render().rows(6).columns(18).into_lines();
+        let expected_lines = &[
+            "                  ",
+            "  Name   │ Taste  ",
+            "─────────┼──────  ",
+            "Potatooo │ Great  ",
+            "  Carrot │ Yuck   ",
+            "                  ",
         ];
         assert_eq!(lines, expected_lines);
     }


### PR DESCRIPTION
This makes presenterm respect alignments in tables (e.g. by using `:-----` or `:-----:` or `-----:` in markdown tables). Since now we support alignment, the table headings are now center aligned because it looks better. Rows are still left aligned by default which seems to be the default.

Closes #854