### PR TITLE
feat: add --temp-dir flag for configurable temp directory location

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -81,6 +81,10 @@ struct Cli {
     #[clap(long, requires = "export")]
     export_temporary_path: Option<PathBuf>,
 
+    /// The path in which to store temporary files used when rendering typst/latex.
+    #[clap(long)]
+    temp_dir: Option<PathBuf>,
+
     /// The output path for the exported PDF.
     #[clap(short = 'o', long = "output", requires = "export")]
     export_output: Option<PathBuf>,
@@ -259,6 +263,7 @@ impl CoreComponents {
             mermaid_config_file: config.mermaid.config_path.clone(),
             d2_scale: config.d2.scale.map(|s| s.to_string()).unwrap_or_else(|| "-1".to_string()),
             threads: config.snippet.render.threads,
+            temp_dir: cli.temp_dir.map(|p| p.to_string_lossy().to_string()),
         };
         let third_party = ThirdPartyRender::new(third_party_config, registry, &resources_path);
         let code_executor = Arc::new(code_executor);

--- a/src/third_party.rs
+++ b/src/third_party.rs
@@ -36,6 +36,7 @@ pub struct ThirdPartyConfigs {
     pub mermaid_config_file: Option<String>,
     pub d2_scale: String,
     pub threads: usize,
+    pub temp_dir: Option<String>,
 }
 
 pub struct ThirdPartyRender {
@@ -75,6 +76,7 @@ impl Default for ThirdPartyRender {
             mermaid_config_file: None,
             d2_scale: "-1".to_string(),
             threads: default_snippet_render_threads(),
+            temp_dir: None,
         };
         Self::new(config, Default::default(), Path::new("."))
     }
@@ -256,7 +258,14 @@ impl Worker {
         input: &str,
         style: &TypstStyle,
     ) -> Result<Image, ThirdPartyRenderError> {
-        let workdir = tempfile::Builder::default().prefix(".presenterm").tempdir_in(&self.shared.root_dir)?;
+        let workdir = match &self.shared.config.temp_dir {
+            Some(temp_dir) => {
+                let path = Path::new(temp_dir);
+                fs::create_dir_all(path)?;
+                tempfile::Builder::default().prefix(".presenterm").tempdir_in(path)?
+            }
+            None => tempfile::Builder::default().prefix(".presenterm").tempdir()?,
+        };
         let mut typst_input = Self::generate_page_header(style)?;
         typst_input.push_str(input);
 


### PR DESCRIPTION
## Summary

Add a new `--temp-dir` CLI flag that allows users to specify where presenterm should create temporary directories when rendering typst and LaTeX content.

## Problem

Presenterm creates temporary directories in the presentation file's directory when rendering typst/latex content. This fails when presentations are stored in read-only directories such as the nix store.

## Solution

- Add `--temp-dir` CLI flag to specify a custom temporary directory
- When provided, temporary directories are created in the specified location
- When not provided, the system temp directory is used (changed from presentation directory)

## Changes

- Added `temp_dir` field to `ThirdPartyConfigs`
- Added `--temp-dir` CLI argument
- Modified `do_render_typst` to use configured temp dir or system temp

## Use Case

This is particularly useful for nix users who want to run presentations directly from the nix store:

```bash
presenterm --temp-dir /tmp /nix/store/.../presentation.md
```

Fixes rendering issues when running presenterm on presentations stored in read-only filesystems.