### PR TITLE
support unsized terminals

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,16 @@
           "executors.yaml"
         ];
 
+        testPresentation = pkgs.writeText "test.md" ''
+          ---
+          title: Test
+          ---
+
+          # Hello
+
+          This is a test slide.
+        '';
+
         buildSrc = flakeboxLib.filterSubPaths {
           root = builtins.path {
             name = projectName;
@@ -55,6 +65,13 @@
       in
       {
         packages.default = multiBuild.${projectName};
+
+        packages.test-export-html = pkgs.runCommand "test-export-html" {
+          nativeBuildInputs = [ multiBuild.${projectName} ];
+        } ''
+          mkdir -p $out
+          presenterm -E --theme dark -o $out/index.html ${testPresentation}
+        '';
 
         legacyPackages = multiBuild;
 

--- a/src/export/exporter.rs
+++ b/src/export/exporter.rs
@@ -177,12 +177,7 @@ impl<'a> Exporter<'a> {
 
         render.generate(&pdf_path, &config.fonts)?;
 
-        execute!(
-            io::stdout(),
-            PrintStyledContent(
-                format!("output file is at {}\n", pdf_path.display()).stylize().with(Color::Green.into())
-            )
-        )?;
+        Self::log_success(&format!("output file is at {}", pdf_path.display()))?;
         Ok(())
     }
 
@@ -207,12 +202,7 @@ impl<'a> Exporter<'a> {
 
         render.generate(&output_path, &None)?;
 
-        execute!(
-            io::stdout(),
-            PrintStyledContent(
-                format!("output file is at {}\n", output_path.display()).stylize().with(Color::Green.into())
-            )
-        )?;
+        Self::log_success(&format!("output file is at {}", output_path.display()))?;
         Ok(())
     }
 
@@ -298,14 +288,28 @@ impl<'a> Exporter<'a> {
     }
 
     fn log(text: &str) -> io::Result<()> {
-        execute!(
-            io::stdout(),
-            MoveUp(1),
-            Clear(ClearType::CurrentLine),
-            MoveToColumn(0),
-            Print(text),
-            MoveToNextLine(1)
-        )
+        if crate::terminal::has_sized_terminal() {
+            execute!(
+                io::stdout(),
+                MoveUp(1),
+                Clear(ClearType::CurrentLine),
+                MoveToColumn(0),
+                Print(text),
+                MoveToNextLine(1)
+            )
+        } else {
+            println!("{text}");
+            Ok(())
+        }
+    }
+
+    fn log_success(text: &str) -> io::Result<()> {
+        if crate::terminal::has_sized_terminal() {
+            execute!(io::stdout(), PrintStyledContent(format!("{text}\n").stylize().with(Color::Green.into())))
+        } else {
+            println!("{text}");
+            Ok(())
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,8 @@ const DEFAULT_THEME: &str = "dark";
 const DEFAULT_THEME_DYNAMIC_DETECTION_TIMEOUT: u64 = 100;
 const DEFAULT_EXPORT_PIXELS_PER_COLUMN: u16 = 20;
 const DEFAULT_EXPORT_PIXELS_PER_ROW: u16 = DEFAULT_EXPORT_PIXELS_PER_COLUMN * 2;
+const DEFAULT_EXPORT_COLUMNS: u16 = 200;
+const DEFAULT_EXPORT_ROWS: u16 = 50;
 
 /// Run slideshows from your terminal.
 #[derive(Parser)]
@@ -326,6 +328,9 @@ impl CoreComponents {
                 config::ThemeConfig::None => DEFAULT_THEME.into(),
                 config::ThemeConfig::Some(theme_name) => theme_name.clone(),
                 config::ThemeConfig::Dynamic { dark, light, timeout } => {
+                    if !terminal::has_sized_terminal() {
+                        return dark.clone();
+                    }
                     let default_timeout = timeout.unwrap_or(DEFAULT_THEME_DYNAMIC_DETECTION_TIMEOUT);
                     let timeout_duration = Duration::from_millis(default_timeout);
                     if let Ok(theme) = termbg::theme(timeout_duration) {
@@ -450,6 +455,12 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         builder_options.validate_snippets = cli.validate_snippets;
     }
     if cli.export_pdf || cli.export_html {
+        let default_dimensions = WindowSize {
+            rows: DEFAULT_EXPORT_ROWS,
+            columns: DEFAULT_EXPORT_COLUMNS,
+            height: DEFAULT_EXPORT_ROWS * DEFAULT_EXPORT_PIXELS_PER_ROW,
+            width: DEFAULT_EXPORT_COLUMNS * DEFAULT_EXPORT_PIXELS_PER_COLUMN,
+        };
         let dimensions = match config.export.dimensions {
             Some(dimensions) => WindowSize {
                 rows: dimensions.rows,
@@ -457,6 +468,7 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 height: dimensions.rows * DEFAULT_EXPORT_PIXELS_PER_ROW,
                 width: dimensions.columns * DEFAULT_EXPORT_PIXELS_PER_COLUMN,
             },
+            None if !terminal::has_sized_terminal() => default_dimensions,
             None => WindowSize::current(config.defaults.terminal_font_size)?,
         };
         let exporter = Exporter::new(
@@ -521,8 +533,14 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
 fn main() {
     let cli = Cli::parse();
     if let Err(e) = run(cli) {
-        let _ =
-            execute!(io::stdout(), PrintStyledContent(format!("{e}\n").stylize().with(crossterm::style::Color::Red)));
+        if terminal::has_sized_terminal() {
+            let _ = execute!(
+                io::stdout(),
+                PrintStyledContent(format!("{e}\n").stylize().with(crossterm::style::Color::Red))
+            );
+        } else {
+            eprintln!("{e}");
+        }
         std::process::exit(1);
     }
 }

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -7,6 +7,13 @@ pub(crate) mod virt;
 
 pub(crate) use printer::{Terminal, TerminalWrite, should_hide_cursor};
 
+/// Check whether stdout is a terminal with non-zero dimensions.
+pub(crate) fn has_sized_terminal() -> bool {
+    use std::io::IsTerminal;
+    std::io::stdout().is_terminal()
+        && crossterm::terminal::size().is_ok_and(|(cols, rows)| cols > 0 && rows > 0)
+}
+
 #[derive(Clone, Debug)]
 pub enum GraphicsMode {
     Iterm2,

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -10,8 +10,7 @@ pub(crate) use printer::{Terminal, TerminalWrite, should_hide_cursor};
 /// Check whether stdout is a terminal with non-zero dimensions.
 pub(crate) fn has_sized_terminal() -> bool {
     use std::io::IsTerminal;
-    std::io::stdout().is_terminal()
-        && crossterm::terminal::size().is_ok_and(|(cols, rows)| cols > 0 && rows > 0)
+    std::io::stdout().is_terminal() && crossterm::terminal::size().is_ok_and(|(cols, rows)| cols > 0 && rows > 0)
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
In CI environments or container builds, there's not always a full terminal. I use presenterm to build HTML / PDF files as part of a CI process.

However, by default, it fails! Running `presenterm -E` inside a nix or Docker build produces:

```
Gf=32,a=q,t=f,i=2665712073,s=1,v=1;L25peC9...AAAAAA==
exporting using rows=0, columns=0, width=0, height=0
^[[1A^[[2K^[[1Gwaiting for images to be generated...^[[1E
^[[1A^[[2K^[[1Gprocessing slide 1...^[[1E
^[[38;5;9mrender: screen is too small^[[39m
```

Note: `render: screen is too small`.

This is because:

1. `termbg::theme()` writes a terminal probe to stdout, producing the Gf=32,... output
2. `WindowSize::current()` returns 0x0 without a real terminal - that causes "render: screen is too small"
3. Crossterm cursor movement (MoveUp, Clear) emits raw ANSI escapes into build logs

I worked around the issue by building slides inside `tmux`:

```nix
mkSlides = pkgs: pkgs.runCommand "slides"
  {
    nativeBuildInputs = [ pkgs.presenterm pkgs.tmux pkgs.d2 pkgs.typst ];
  } ''
  cp -r ${./images} images
  cp ${./slides.md} slides.md
  cp ${./presenterm-export.yaml} presenterm-export.yaml
  mkdir -p $out/slides
  export HOME=$(mktemp -d)
  export TERM=xterm-256color
  tmux new-session -d -s export -x 200 -y 50 "PATH=$PATH HOME=$HOME TERM=$TERM presenterm --image-protocol ascii-blocks -E slides.md -o $out/slides/index.html; tmux wait-for -S done"
  tmux wait-for done
  cp -r images $out/slides/images
'';
```

But it's quite complex and requires the extra `tmux` dependency in the build.

This PR adds a function (`terminal::has_sized_terminal()`) which checks both `is_terminal()` and that terminal dimensions are non-zero.

If the terminal is not sized:

  - Fall back to 200x50 default export dimensions
  - Skip `termbg::theme()` and use the dark variant
  - Use plain `println!` instead of crossterm cursor movement in export logging
  - Use `eprintln!` for error output
