### PR TITLE
feat: add exec support for scala 3

### DIFF
--- a/executors.yaml
+++ b/executors.yaml
@@ -256,3 +256,8 @@ fsharp:
   commands:
     - ["dotnet", "fsi", "$pwd/snippet.fsx"]
   hidden_line_prefix: "/// "
+scala:
+  filename: Snippet.scala
+  commands:
+    - ["scala", "run", "$pwd/Snippet.scala"]
+  hidden_line_prefix: "/// "


### PR DESCRIPTION
Adds support for executing Scala code snippets. Note that it works with Scala 3, not Scala 2.

I spent some time trying to add an alternative executor for Scala 2, doing a `scalac` to compile and a `scala` to execute. I could get it to work if the class in the snippet was called `Snippet`, which seems like an esoteric restriction. So I gave up on Scala 2.