### PR TITLE
fix: add pytest as an alternative executor for python

### DIFF
--- a/executors.yaml
+++ b/executors.yaml
@@ -177,6 +177,10 @@ python:
       filename: "snippet.py"
       commands:
         - ["uv", "run", "--script", "-q", "$pwd/snippet.py"]
+    pytest:
+      filename: "test_snippet.py"
+      commands:
+        - ["pytest", "$pwd/test_snippet.py"]
 r:
   filename: snippet.R
   commands:


### PR DESCRIPTION
Documentation currently claims that pytest is an available alternative executor but it is not. This commit adds pytest as an executor.

[Issue](https://github.com/mfontanini/presenterm/issues/891)