### PR TITLE
fix: progress bar footer shows actual progress now, fixes issue #900

### DIFF
--- a/src/ui/footer.rs
+++ b/src/ui/footer.rs
@@ -116,7 +116,7 @@ impl AsRenderOperations for FooterGenerator {
             ProgressBar { character, style } => {
                 let character = character.to_string();
                 let total_columns = dimensions.columns as usize / character.width();
-                let progress_ratio = (self.current_slide + 1) as f64 / self.total_slides as f64;
+                let progress_ratio = (self.current_slide - 1) as f64 / (self.total_slides - 1) as f64;
                 let columns_ratio = (total_columns as f64 * progress_ratio).ceil();
                 let bar = character.repeat(columns_ratio as usize);
                 let bar = Text::new(bar, *style);


### PR DESCRIPTION
The current behaviour stems from [footer.rs#119](https://github.com/mfontanini/presenterm/blob/5f8add11a24af9d257fd18da48c8004dd9c516f8/src/ui/footer.rs#L119) that increments the current slide counter by 1, thus completely filling the progress bar one slide before the presentation ends.

By reducing both `current_slide` and `total_slides` by 1, `progress_ratio` remains the same, but the progress bar ends (and starts!) at the proper time.

Fixes issue #900 