### PR TITLE
feat: render links as clickable OSC 8 hyperlinks when supported

### DIFF
--- a/src/export/html.rs
+++ b/src/export/html.rs
@@ -3,12 +3,14 @@ use std::{borrow::Cow, fmt};
 
 pub(crate) enum HtmlText {
     Plain(String),
-    Styled { text: String, style: String },
+    Styled { text: String, style: String, link: Option<String> },
 }
 
 impl HtmlText {
     pub(crate) fn new(text: &str, style: &TextStyle, font_size: FontSize) -> Self {
         let mut text = text.to_string();
+        // Percent-encode the only character that could break out of the href attribute.
+        let link = style.link_target().map(|url| url.replace('"', "%22"));
         if style == &TextStyle::default() {
             return Self::Plain(text);
         }
@@ -40,7 +42,7 @@ impl HtmlText {
             css_styles.push(format!("font-size: {font_size}").into());
         }
         let css_style = css_styles.join("; ");
-        Self::Styled { text, style: css_style }
+        Self::Styled { text, style: css_style, link }
     }
 }
 
@@ -48,7 +50,10 @@ impl fmt::Display for HtmlText {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Plain(text) => write!(f, "{text}"),
-            Self::Styled { text, style } => write!(f, "<span style=\"{style}\">{text}</span>"),
+            Self::Styled { text, style, link: Some(href) } => {
+                write!(f, "<a href=\"{href}\"><span style=\"{style}\">{text}</span></a>")
+            }
+            Self::Styled { text, style, link: None } => write!(f, "<span style=\"{style}\">{text}</span>"),
         }
     }
 }
@@ -120,5 +125,13 @@ mod test {
         let html_text = HtmlText::new("hi", &TextStyle::default().bold(), FontSize::Pixels(1));
         let rendered = html_text.to_string();
         assert_eq!(rendered, "<span style=\"font-weight: bold\">hi</span>");
+    }
+
+    #[test]
+    fn render_link() {
+        let style = TextStyle::default().link_label().link("https://example.com");
+        let html_text = HtmlText::new("website", &style, FontSize::Pixels(1));
+        let rendered = html_text.to_string();
+        assert_eq!(rendered, "<a href=\"https://example.com\"><span style=\"font-weight: bold\">website</span></a>");
     }
 }

--- a/src/export/html.rs
+++ b/src/export/html.rs
@@ -1,16 +1,20 @@
-use crate::markdown::text_style::{Color, TextAttribute, TextStyle};
+use crate::markdown::text_style::{Color, LinkTarget, TextAttribute, TextStyle};
 use std::{borrow::Cow, fmt};
+
+/// Escape a value so it can be safely embedded in a double quoted HTML attribute.
+fn escape_attribute(value: &str) -> String {
+    value.replace('&', "&amp;").replace('<', "&lt;").replace('>', "&gt;").replace('"', "&quot;")
+}
 
 pub(crate) enum HtmlText {
     Plain(String),
-    Styled { text: String, style: String, link: Option<String> },
+    Styled { text: String, style: String, link: Option<LinkTarget> },
 }
 
 impl HtmlText {
     pub(crate) fn new(text: &str, style: &TextStyle, font_size: FontSize) -> Self {
         let mut text = text.to_string();
-        // Percent-encode the only character that could break out of the href attribute.
-        let link = style.link_target().map(|url| url.replace('"', "%22"));
+        let link = style.link_target();
         if style == &TextStyle::default() {
             return Self::Plain(text);
         }
@@ -50,8 +54,20 @@ impl fmt::Display for HtmlText {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Plain(text) => write!(f, "{text}"),
-            Self::Styled { text, style, link: Some(href) } => {
-                write!(f, "<a href=\"{href}\"><span style=\"{style}\">{text}</span></a>")
+            Self::Styled { text, style, link: Some(target) } => {
+                let href = escape_attribute(&target.url);
+                // Open in a new tab so clicking a link doesn't unload the presentation, inherit
+                // the surrounding styling rather than the browser's default link look, and don't
+                // let the presentation's click-to-advance handler see this click.
+                write!(
+                    f,
+                    "<a href=\"{href}\" target=\"_blank\" rel=\"noopener\" \
+                     style=\"color: inherit; text-decoration: inherit\""
+                )?;
+                if !target.title.is_empty() {
+                    write!(f, " title=\"{}\"", escape_attribute(&target.title))?;
+                }
+                write!(f, "><span style=\"{style}\">{text}</span></a>")
             }
             Self::Styled { text, style, link: None } => write!(f, "<span style=\"{style}\">{text}</span>"),
         }
@@ -132,6 +148,31 @@ mod test {
         let style = TextStyle::default().link_label().link("https://example.com");
         let html_text = HtmlText::new("website", &style, FontSize::Pixels(1));
         let rendered = html_text.to_string();
-        assert_eq!(rendered, "<a href=\"https://example.com\"><span style=\"font-weight: bold\">website</span></a>");
+        assert_eq!(
+            rendered,
+            "<a href=\"https://example.com\" target=\"_blank\" rel=\"noopener\" \
+             style=\"color: inherit; text-decoration: inherit\">\
+             <span style=\"font-weight: bold\">website</span></a>"
+        );
+    }
+
+    #[test]
+    fn render_link_escapes_href() {
+        // `&` must be escaped or legacy HTML entity parsing rewrites the URL.
+        let style = TextStyle::default().link_label().link("https://example.com/?a=1&copy=2\"x");
+        let html_text = HtmlText::new("report", &style, FontSize::Pixels(1));
+        let rendered = html_text.to_string();
+        assert!(
+            rendered.starts_with("<a href=\"https://example.com/?a=1&amp;copy=2&quot;x\""),
+            "unexpected href: {rendered}"
+        );
+    }
+
+    #[test]
+    fn render_link_with_title() {
+        let style = TextStyle::default().link_label().link_with_title("https://example.com", "The <docs> & more");
+        let html_text = HtmlText::new("docs", &style, FontSize::Pixels(1));
+        let rendered = html_text.to_string();
+        assert!(rendered.contains(" title=\"The &lt;docs&gt; &amp; more\""), "missing title: {rendered}");
     }
 }

--- a/src/export/script.js
+++ b/src/export/script.js
@@ -77,6 +77,10 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 
   function handleClick(event) {
+    // Don't hijack clicks on hyperlinks: let the browser follow them.
+    if (event.target.closest && event.target.closest('a')) {
+      return;
+    }
     if (event.clientX < document.documentElement.clientWidth / 3) {
       showPreviousSlide();
       return;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use crate::{
     resource::Resources,
     terminal::{
         GraphicsMode,
+        capabilities::TerminalCapabilities,
         image::printer::{ImagePrinter, ImageRegistry},
     },
     theme::{raw::PresentationTheme, registry::PresentationThemeRegistry},
@@ -452,10 +453,18 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
     } = CoreComponents::new(&cli, &path)?;
     let arena = Arena::new();
     // Only use OSC 8 hyperlinks when we know the terminal supports them; otherwise keep URLs
-    // visible next to their labels so they're not lost. Exports always use hyperlinks since
-    // they're turned into HTML anchors. This is set process-wide so every parsing path (body,
-    // footers, intro slide) renders links consistently.
-    let link_render = if cli.export_pdf || cli.export_html { LinkRender::Hyperlink } else { terminal_link_render() };
+    // visible next to their labels so they're not lost. Exports use hyperlinks since they're
+    // turned into HTML anchors, unless explicitly disabled via `FORCE_HYPERLINK=0` to keep URLs
+    // visible (e.g. for printable handouts). This is set process-wide so every parsing path
+    // (body, footers, intro slide) renders links consistently.
+    let link_render = if cli.export_pdf || cli.export_html {
+        match TerminalCapabilities::hyperlink_force_override() {
+            Some(false) => LinkRender::InlineUrl,
+            _ => LinkRender::Hyperlink,
+        }
+    } else {
+        terminal_link_render()
+    };
     LinkRender::set_global(link_render);
     let parser = MarkdownParser::new(&arena);
     let validate_overflows =

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use crate::{
     config::{Config, ImageProtocol, ValidateOverflows},
     demo::ThemesDemo,
     export::exporter::Exporter,
-    markdown::parse::MarkdownParser,
+    markdown::parse::{LinkRender, MarkdownParser},
     presentation::builder::{CommentCommand, PresentationBuilderOptions, Themes},
     presenter::{PresentMode, Presenter, PresenterOptions},
     resource::Resources,
@@ -389,6 +389,13 @@ fn overflow_validation_enabled(mode: &PresentMode, config: &ValidateOverflows) -
     }
 }
 
+fn terminal_link_render() -> LinkRender {
+    match TerminalEmulator::capabilities().hyperlinks {
+        true => LinkRender::Hyperlink,
+        false => LinkRender::InlineUrl,
+    }
+}
+
 fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(feature = "json-schema")]
     if cli.generate_config_file_schema {
@@ -403,6 +410,7 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
     } else if cli.list_themes {
         // Load this ahead of time so we don't do it when we're already in raw mode.
         TerminalEmulator::capabilities();
+        LinkRender::set_global(terminal_link_render());
         let Customizations { config, themes, .. } =
             Customizations::load(cli.config_file.clone().map(PathBuf::from), &current_dir()?)?;
         let bindings = config.bindings.try_into()?;
@@ -443,6 +451,12 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         graphics_mode,
     } = CoreComponents::new(&cli, &path)?;
     let arena = Arena::new();
+    // Only use OSC 8 hyperlinks when we know the terminal supports them; otherwise keep URLs
+    // visible next to their labels so they're not lost. Exports always use hyperlinks since
+    // they're turned into HTML anchors. This is set process-wide so every parsing path (body,
+    // footers, intro slide) renders links consistently.
+    let link_render = if cli.export_pdf || cli.export_html { LinkRender::Hyperlink } else { terminal_link_render() };
+    LinkRender::set_global(link_render);
     let parser = MarkdownParser::new(&arena);
     let validate_overflows =
         overflow_validation_enabled(&present_mode, &config.defaults.validate_overflows) || cli.validate_overflows;

--- a/src/markdown/parse.rs
+++ b/src/markdown/parse.rs
@@ -24,6 +24,7 @@ use std::{
     cell::RefCell,
     fmt::{self, Debug, Display},
     mem,
+    sync::OnceLock,
 };
 
 /// The result of parsing a markdown file.
@@ -47,18 +48,57 @@ impl Default for ParserOptions {
     }
 }
 
+/// How to render links.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum LinkRender {
+    /// Render the link as an OSC 8 terminal hyperlink, showing only its label and hiding the URL.
+    #[default]
+    Hyperlink,
+
+    /// Render the link's URL (and title, if any) inline next to its label.
+    ///
+    /// This is meant for terminals that don't support OSC 8 hyperlinks, where the URL would
+    /// otherwise be lost.
+    InlineUrl,
+}
+
+/// The process-wide link render mode used by [MarkdownParser::new].
+static GLOBAL_LINK_RENDER: OnceLock<LinkRender> = OnceLock::new();
+
+impl LinkRender {
+    /// Set the process-wide link render mode used by parsers that don't set one explicitly.
+    ///
+    /// This ensures every parsing path (presentation body, footers, intro slide, etc) renders
+    /// links consistently. It can only be set once; subsequent calls have no effect.
+    pub fn set_global(mode: LinkRender) {
+        let _ = GLOBAL_LINK_RENDER.set(mode);
+    }
+
+    fn global() -> LinkRender {
+        GLOBAL_LINK_RENDER.get().copied().unwrap_or_default()
+    }
+}
+
 /// A markdown parser.
 ///
 /// This takes the contents of a markdown file and parses it into a list of [MarkdownElement].
 pub struct MarkdownParser<'a> {
     arena: &'a Arena<'a>,
     options: comrak::Options<'static>,
+    link_render: LinkRender,
 }
 
 impl<'a> MarkdownParser<'a> {
     /// Construct a new markdown parser.
     pub fn new(arena: &'a Arena<'a>) -> Self {
-        Self { arena, options: ParserOptions::default().0 }
+        Self { arena, options: ParserOptions::default().0, link_render: LinkRender::global() }
+    }
+
+    /// Set how links should be rendered, overriding the process-wide default.
+    #[cfg(test)]
+    pub fn with_link_render(mut self, link_render: LinkRender) -> Self {
+        self.link_render = link_render;
+        self
     }
 
     /// Parse the contents of a markdown file.
@@ -86,7 +126,7 @@ impl<'a> MarkdownParser<'a> {
         let NodeValue::Paragraph = &data.value else {
             return Err(ParseInlinesError("inline must be simple text".into()));
         };
-        let parser = InlinesParser::new(self.arena, SoftBreak::Space, StringifyImages::No);
+        let parser = InlinesParser::new(self.arena, SoftBreak::Space, StringifyImages::No, self.link_render);
         let inlines = parser.parse(node).map_err(|e| ParseInlinesError(e.to_string()))?;
         let mut output = Line::default();
         for inline in inlines {
@@ -150,7 +190,8 @@ impl<'a> MarkdownParser<'a> {
 
     fn parse_block_quote(&self, node: &'a AstNode<'a>) -> ParseResult<MarkdownElement> {
         let mut lines = Vec::new();
-        let inlines = InlinesParser::new(self.arena, SoftBreak::Newline, StringifyImages::Yes).parse(node)?;
+        let inlines =
+            InlinesParser::new(self.arena, SoftBreak::Newline, StringifyImages::Yes, self.link_render).parse(node)?;
         for inline in inlines {
             match inline {
                 Inline::Text(text) => lines.push(text),
@@ -186,7 +227,8 @@ impl<'a> MarkdownParser<'a> {
         node: &'a AstNode<'a>,
     ) -> ParseResult<MarkdownElement> {
         let mut line = vec![Text::new(definition.name.clone(), TextStyle::default().superscript())];
-        let inlines = InlinesParser::new(self.arena, SoftBreak::Space, StringifyImages::Yes).parse(node)?;
+        let inlines =
+            InlinesParser::new(self.arena, SoftBreak::Space, StringifyImages::Yes, self.link_render).parse(node)?;
         for inline in inlines {
             match inline {
                 Inline::Text(text) => line.extend(text.0),
@@ -208,7 +250,8 @@ impl<'a> MarkdownParser<'a> {
 
     fn parse_paragraph(&self, node: &'a AstNode<'a>) -> ParseResult<Vec<MarkdownElement>> {
         let mut elements = Vec::new();
-        let inlines = InlinesParser::new(self.arena, SoftBreak::Space, StringifyImages::No).parse(node)?;
+        let inlines =
+            InlinesParser::new(self.arena, SoftBreak::Space, StringifyImages::No, self.link_render).parse(node)?;
         let mut paragraph_elements = Vec::new();
         for inline in inlines {
             match inline {
@@ -233,7 +276,8 @@ impl<'a> MarkdownParser<'a> {
     }
 
     fn parse_exheading(&self, node: &'a AstNode<'a>) -> ParseResult<Vec<Line<RawColor>>> {
-        let inlines = InlinesParser::new(self.arena, SoftBreak::Space, StringifyImages::No).parse(node)?;
+        let inlines =
+            InlinesParser::new(self.arena, SoftBreak::Space, StringifyImages::No, self.link_render).parse(node)?;
         let mut lines = Vec::new();
         let mut chunks = Vec::new();
         for inline in inlines {
@@ -254,7 +298,8 @@ impl<'a> MarkdownParser<'a> {
     }
 
     fn parse_text(&self, node: &'a AstNode<'a>) -> ParseResult<Line<RawColor>> {
-        let inlines = InlinesParser::new(self.arena, SoftBreak::Space, StringifyImages::No).parse(node)?;
+        let inlines =
+            InlinesParser::new(self.arena, SoftBreak::Space, StringifyImages::No, self.link_render).parse(node)?;
         let mut chunks = Vec::new();
         for inline in inlines {
             match inline {
@@ -388,11 +433,17 @@ struct InlinesParser<'a> {
     arena: &'a Arena<'a>,
     soft_break: SoftBreak,
     stringify_images: StringifyImages,
+    link_render: LinkRender,
 }
 
 impl<'a> InlinesParser<'a> {
-    fn new(arena: &'a Arena<'a>, soft_break: SoftBreak, stringify_images: StringifyImages) -> Self {
-        Self { inlines: Vec::new(), pending_text: Vec::new(), arena, soft_break, stringify_images }
+    fn new(
+        arena: &'a Arena<'a>,
+        soft_break: SoftBreak,
+        stringify_images: StringifyImages,
+        link_render: LinkRender,
+    ) -> Self {
+        Self { inlines: Vec::new(), pending_text: Vec::new(), arena, soft_break, stringify_images, link_render }
     }
 
     fn parse(mut self, node: &'a AstNode<'a>) -> ParseResult<Vec<Inline>> {
@@ -434,22 +485,35 @@ impl<'a> InlinesParser<'a> {
                     SoftBreak::Space => self.pending_text.push(Text::new(" ", style)),
                 };
             }
-            NodeValue::Link(link) => {
-                let has_label = node.first_child().is_some();
-                if has_label {
-                    self.process_children(node, TextStyle::default().link_label())?;
-                    self.pending_text.push(Text::from(" ("));
+            NodeValue::Link(link) => match self.link_render {
+                LinkRender::Hyperlink => {
+                    if node.first_child().is_some() {
+                        // Render the label as a clickable hyperlink (OSC 8), hiding the raw URL
+                        // just like a GitHub markdown preview does.
+                        self.process_children(node, TextStyle::default().link_label().link(link.url.clone()))?;
+                    } else {
+                        // No label: show the URL itself, made clickable.
+                        self.pending_text
+                            .push(Text::new(link.url.clone(), TextStyle::default().link_url().link(link.url.clone())));
+                    }
                 }
-                self.pending_text.push(Text::new(link.url.clone(), TextStyle::default().link_url()));
-                if !link.title.is_empty() {
-                    self.pending_text.push(Text::from(" \""));
-                    self.pending_text.push(Text::new(link.title.clone(), TextStyle::default().link_title()));
-                    self.pending_text.push(Text::from("\""));
+                LinkRender::InlineUrl => {
+                    let has_label = node.first_child().is_some();
+                    if has_label {
+                        self.process_children(node, TextStyle::default().link_label())?;
+                        self.pending_text.push(Text::from(" ("));
+                    }
+                    self.pending_text.push(Text::new(link.url.clone(), TextStyle::default().link_url()));
+                    if !link.title.is_empty() {
+                        self.pending_text.push(Text::from(" \""));
+                        self.pending_text.push(Text::new(link.title.clone(), TextStyle::default().link_title()));
+                        self.pending_text.push(Text::from("\""));
+                    }
+                    if has_label {
+                        self.pending_text.push(Text::from(")"));
+                    }
                 }
-                if has_label {
-                    self.pending_text.push(Text::from(")"));
-                }
-            }
+            },
             NodeValue::WikiLink(link) => {
                 self.pending_text.push(Text::new(link.url.clone(), TextStyle::default().link_url()));
             }
@@ -719,6 +783,14 @@ mod test {
         MarkdownParser::new(&arena).parse(input)
     }
 
+    fn parse_single_inline_urls(input: &str) -> MarkdownElement {
+        let arena = Arena::new();
+        let elements =
+            MarkdownParser::new(&arena).with_link_render(LinkRender::InlineUrl).parse(input).expect("failed to parse");
+        assert_eq!(elements.len(), 1, "more than one element: {elements:?}");
+        elements.into_iter().next().unwrap()
+    }
+
     fn parse_single(input: &str) -> MarkdownElement {
         let elements = try_parse(input).expect("failed to parse");
         assert_eq!(elements.len(), 1, "more than one element: {elements:?}");
@@ -799,8 +871,11 @@ boop
     fn link_wo_label_wo_title() {
         let parsed = parse_single("my [](https://example.com)");
         let MarkdownElement::Paragraph(elements) = parsed else { panic!("not a paragraph: {parsed:?}") };
-        let expected_chunks =
-            vec![Text::from("my "), Text::new("https://example.com", TextStyle::default().link_url())];
+        // Without a label the URL is shown as text and made clickable.
+        let expected_chunks = vec![
+            Text::from("my "),
+            Text::new("https://example.com", TextStyle::default().link_url().link("https://example.com")),
+        ];
 
         let expected_elements = &[Line(expected_chunks)];
         assert_eq!(elements, expected_elements);
@@ -810,12 +885,10 @@ boop
     fn link_w_label_wo_title() {
         let parsed = parse_single("my [website](https://example.com)");
         let MarkdownElement::Paragraph(elements) = parsed else { panic!("not a paragraph: {parsed:?}") };
+        // The label becomes a clickable hyperlink and the raw URL is hidden.
         let expected_chunks = vec![
             Text::from("my "),
-            Text::new("website", TextStyle::default().link_label()),
-            Text::from(" ("),
-            Text::new("https://example.com", TextStyle::default().link_url()),
-            Text::from(")"),
+            Text::new("website", TextStyle::default().link_label().link("https://example.com")),
         ];
 
         let expected_elements = &[Line(expected_chunks)];
@@ -826,12 +899,10 @@ boop
     fn link_wo_label_w_title() {
         let parsed = parse_single("my [](https://example.com \"Example\")");
         let MarkdownElement::Paragraph(elements) = parsed else { panic!("not a paragraph: {parsed:?}") };
+        // The title is not rendered; the URL itself is the clickable link.
         let expected_chunks = vec![
             Text::from("my "),
-            Text::new("https://example.com", TextStyle::default().link_url()),
-            Text::from(" \""),
-            Text::new("Example", TextStyle::default().link_title()),
-            Text::from("\""),
+            Text::new("https://example.com", TextStyle::default().link_url().link("https://example.com")),
         ];
 
         let expected_elements = &[Line(expected_chunks)];
@@ -841,6 +912,37 @@ boop
     #[test]
     fn link_w_label_w_title() {
         let parsed = parse_single("my [website](https://example.com \"Example\")");
+        let MarkdownElement::Paragraph(elements) = parsed else { panic!("not a paragraph: {parsed:?}") };
+        // Only the clickable label is shown; both the URL and the title are hidden.
+        let expected_chunks = vec![
+            Text::from("my "),
+            Text::new("website", TextStyle::default().link_label().link("https://example.com")),
+        ];
+
+        let expected_elements = &[Line(expected_chunks)];
+        assert_eq!(elements, expected_elements);
+    }
+
+    #[test]
+    fn link_w_label_wo_title_inline_urls() {
+        let parsed = parse_single_inline_urls("my [website](https://example.com)");
+        let MarkdownElement::Paragraph(elements) = parsed else { panic!("not a paragraph: {parsed:?}") };
+        // The pre-hyperlink rendering: label followed by the visible URL.
+        let expected_chunks = vec![
+            Text::from("my "),
+            Text::new("website", TextStyle::default().link_label()),
+            Text::from(" ("),
+            Text::new("https://example.com", TextStyle::default().link_url()),
+            Text::from(")"),
+        ];
+
+        let expected_elements = &[Line(expected_chunks)];
+        assert_eq!(elements, expected_elements);
+    }
+
+    #[test]
+    fn link_w_label_w_title_inline_urls() {
+        let parsed = parse_single_inline_urls("my [website](https://example.com \"Example\")");
         let MarkdownElement::Paragraph(elements) = parsed else { panic!("not a paragraph: {parsed:?}") };
         let expected_chunks = vec![
             Text::from("my "),
@@ -852,6 +954,17 @@ boop
             Text::from("\""),
             Text::from(")"),
         ];
+
+        let expected_elements = &[Line(expected_chunks)];
+        assert_eq!(elements, expected_elements);
+    }
+
+    #[test]
+    fn link_wo_label_inline_urls() {
+        let parsed = parse_single_inline_urls("my [](https://example.com)");
+        let MarkdownElement::Paragraph(elements) = parsed else { panic!("not a paragraph: {parsed:?}") };
+        let expected_chunks =
+            vec![Text::from("my "), Text::new("https://example.com", TextStyle::default().link_url())];
 
         let expected_elements = &[Line(expected_chunks)];
         assert_eq!(elements, expected_elements);

--- a/src/markdown/parse.rs
+++ b/src/markdown/parse.rs
@@ -79,6 +79,24 @@ impl LinkRender {
     }
 }
 
+/// Whether a URL can safely be used as a hyperlink target.
+///
+/// Only absolute http/https/mailto URLs qualify: OSC 8 leaves the meaning of relative URIs
+/// unspecified (so `./notes.md` or `#anchor` would silently become dead links with their target
+/// hidden), and other schemes such as `javascript:` must never become live links in HTML exports.
+/// Everything else falls back to being rendered inline next to its label.
+fn is_hyperlink_target(url: &str) -> bool {
+    let has_scheme = |scheme: &str| {
+        url.as_bytes().get(..scheme.len()).is_some_and(|prefix| prefix.eq_ignore_ascii_case(scheme.as_bytes()))
+    };
+    has_scheme("http://") || has_scheme("https://") || has_scheme("mailto:")
+}
+
+/// Whether this node contains an image anywhere in its descendants.
+fn contains_image<'a>(node: &'a AstNode<'a>) -> bool {
+    node.descendants().any(|child| matches!(child.data.borrow().value, NodeValue::Image(_)))
+}
+
 /// A markdown parser.
 ///
 /// This takes the contents of a markdown file and parses it into a list of [MarkdownElement].
@@ -471,7 +489,11 @@ impl<'a> InlinesParser<'a> {
                 self.pending_text.push(Text::new(text.clone(), style));
             }
             NodeValue::Code(code) => {
-                self.pending_text.push(Text::new(code.literal.clone(), TextStyle::default().code()));
+                // Carry over a potential enclosing link so labels like [`code`](url) stay
+                // clickable, but no other styling since code spans use their own style.
+                let mut code_style = TextStyle::default().code();
+                code_style.link = style.link;
+                self.pending_text.push(Text::new(code.literal.clone(), code_style));
             }
             NodeValue::Strong => self.process_children(node, style.bold())?,
             NodeValue::Emph => self.process_children(node, style.italics())?,
@@ -485,19 +507,29 @@ impl<'a> InlinesParser<'a> {
                     SoftBreak::Space => self.pending_text.push(Text::new(" ", style)),
                 };
             }
-            NodeValue::Link(link) => match self.link_render {
-                LinkRender::Hyperlink => {
+            NodeValue::Link(link) => {
+                // Only use a hyperlink if the URL can safely be a hyperlink target and the label
+                // can carry it: labels containing images can't, since images aren't rendered as
+                // styled text and the URL would be lost entirely.
+                let hyperlink = matches!(self.link_render, LinkRender::Hyperlink)
+                    && is_hyperlink_target(&link.url)
+                    && !contains_image(node);
+                if hyperlink {
                     if node.first_child().is_some() {
                         // Render the label as a clickable hyperlink (OSC 8), hiding the raw URL
                         // just like a GitHub markdown preview does.
-                        self.process_children(node, TextStyle::default().link_label().link(link.url.clone()))?;
+                        self.process_children(
+                            node,
+                            TextStyle::default().link_label().link_with_title(&link.url, &link.title),
+                        )?;
                     } else {
                         // No label: show the URL itself, made clickable.
-                        self.pending_text
-                            .push(Text::new(link.url.clone(), TextStyle::default().link_url().link(link.url.clone())));
+                        self.pending_text.push(Text::new(
+                            link.url.clone(),
+                            TextStyle::default().link_url().link_with_title(&link.url, &link.title),
+                        ));
                     }
-                }
-                LinkRender::InlineUrl => {
+                } else {
                     let has_label = node.first_child().is_some();
                     if has_label {
                         self.process_children(node, TextStyle::default().link_label())?;
@@ -513,9 +545,13 @@ impl<'a> InlinesParser<'a> {
                         self.pending_text.push(Text::from(")"));
                     }
                 }
-            },
+            }
             NodeValue::WikiLink(link) => {
-                self.pending_text.push(Text::new(link.url.clone(), TextStyle::default().link_url()));
+                let mut style = TextStyle::default().link_url();
+                if matches!(self.link_render, LinkRender::Hyperlink) && is_hyperlink_target(&link.url) {
+                    style = style.link(link.url.clone());
+                }
+                self.pending_text.push(Text::new(link.url.clone(), style));
             }
             NodeValue::LineBreak => {
                 self.store_pending_text();
@@ -580,9 +616,11 @@ impl<'a> InlinesParser<'a> {
                 };
             }
             NodeValue::FootnoteReference(reference) => {
-                // Keep only colors here, we don't care about e.g. italics footnotes.
-                let style = TextStyle::colored(style.colors).superscript();
-                self.pending_text.push(Text::new(reference.name.clone(), style));
+                // Keep only colors and a potential enclosing link here, we don't care about e.g.
+                // italics footnotes.
+                let mut footnote_style = TextStyle::colored(style.colors).superscript();
+                footnote_style.link = style.link;
+                self.pending_text.push(Text::new(reference.name.clone(), footnote_style));
             }
             other => {
                 return Err(ParseErrorKind::UnsupportedStructure { container: "text", element: other.identifier() }
@@ -780,7 +818,8 @@ mod test {
 
     fn try_parse(input: &str) -> Result<Vec<MarkdownElement>, ParseError> {
         let arena = Arena::new();
-        MarkdownParser::new(&arena).parse(input)
+        // Pin the link render mode so these tests don't depend on the process-wide default.
+        MarkdownParser::new(&arena).with_link_render(LinkRender::Hyperlink).parse(input)
     }
 
     fn parse_single_inline_urls(input: &str) -> MarkdownElement {
@@ -902,7 +941,10 @@ boop
         // The title is not rendered; the URL itself is the clickable link.
         let expected_chunks = vec![
             Text::from("my "),
-            Text::new("https://example.com", TextStyle::default().link_url().link("https://example.com")),
+            Text::new(
+                "https://example.com",
+                TextStyle::default().link_url().link_with_title("https://example.com", "Example"),
+            ),
         ];
 
         let expected_elements = &[Line(expected_chunks)];
@@ -913,10 +955,11 @@ boop
     fn link_w_label_w_title() {
         let parsed = parse_single("my [website](https://example.com \"Example\")");
         let MarkdownElement::Paragraph(elements) = parsed else { panic!("not a paragraph: {parsed:?}") };
-        // Only the clickable label is shown; both the URL and the title are hidden.
+        // Only the clickable label is shown; both the URL and the title are hidden from the
+        // rendered text (the title is still carried on the link's target).
         let expected_chunks = vec![
             Text::from("my "),
-            Text::new("website", TextStyle::default().link_label().link("https://example.com")),
+            Text::new("website", TextStyle::default().link_label().link_with_title("https://example.com", "Example")),
         ];
 
         let expected_elements = &[Line(expected_chunks)];
@@ -974,10 +1017,79 @@ boop
     fn wikilink_wo_title() {
         let parsed = parse_single("[[https://example.com]]");
         let MarkdownElement::Paragraph(elements) = parsed else { panic!("not a paragraph: {parsed:?}") };
-        let expected_chunks = vec![Text::new("https://example.com", TextStyle::default().link_url())];
+        let expected_chunks =
+            vec![Text::new("https://example.com", TextStyle::default().link_url().link("https://example.com"))];
 
         let expected_elements = &[Line(expected_chunks)];
         assert_eq!(elements, expected_elements);
+    }
+
+    #[test]
+    fn link_code_label_stays_clickable() {
+        let parsed = parse_single("[`serde`](https://serde.rs)");
+        let MarkdownElement::Paragraph(elements) = parsed else { panic!("not a paragraph: {parsed:?}") };
+        let expected_chunks = vec![Text::new("serde", TextStyle::default().code().link("https://serde.rs"))];
+
+        let expected_elements = &[Line(expected_chunks)];
+        assert_eq!(elements, expected_elements);
+    }
+
+    #[test]
+    fn link_relative_url_falls_back_to_inline() {
+        // Relative URLs aren't valid OSC 8 targets so the URL must stay visible.
+        let parsed = parse_single("[notes](./notes.md)");
+        let MarkdownElement::Paragraph(elements) = parsed else { panic!("not a paragraph: {parsed:?}") };
+        let expected_chunks = vec![
+            Text::new("notes", TextStyle::default().link_label()),
+            Text::from(" ("),
+            Text::new("./notes.md", TextStyle::default().link_url()),
+            Text::from(")"),
+        ];
+
+        let expected_elements = &[Line(expected_chunks)];
+        assert_eq!(elements, expected_elements);
+    }
+
+    #[test]
+    fn link_unsafe_scheme_falls_back_to_inline() {
+        // javascript: and friends must never become hyperlink targets (e.g. HTML export anchors).
+        let parsed = parse_single("[click](javascript:alert(1))");
+        let MarkdownElement::Paragraph(elements) = parsed else { panic!("not a paragraph: {parsed:?}") };
+        let expected_chunks = vec![
+            Text::new("click", TextStyle::default().link_label()),
+            Text::from(" ("),
+            Text::new("javascript:alert(1)", TextStyle::default().link_url()),
+            Text::from(")"),
+        ];
+
+        let expected_elements = &[Line(expected_chunks)];
+        assert_eq!(elements, expected_elements);
+    }
+
+    #[test]
+    fn link_image_label_falls_back_to_inline() {
+        // An image can't carry a hyperlink so the URL must stay visible.
+        let elements = try_parse("[![](potato.png)](https://example.com)").expect("failed to parse");
+        let mut found_url = false;
+        let mut found_image = false;
+        for element in &elements {
+            match element {
+                MarkdownElement::Image { path, .. } => found_image = path.as_os_str() == "potato.png",
+                MarkdownElement::Paragraph(lines) => {
+                    for Line(chunks) in lines {
+                        for chunk in chunks {
+                            if chunk.content.contains("https://example.com") {
+                                found_url = true;
+                                assert_eq!(chunk.style.link, None, "URL itself must not carry a hyperlink");
+                            }
+                        }
+                    }
+                }
+                _ => (),
+            }
+        }
+        assert!(found_image, "image not found: {elements:?}");
+        assert!(found_url, "url not visible: {elements:?}");
     }
 
     #[test]

--- a/src/markdown/text_style.rs
+++ b/src/markdown/text_style.rs
@@ -3,10 +3,13 @@ use crate::{
     theme::{ColorPalette, raw::RawColor},
 };
 use crossterm::style::{ContentStyle, StyledContent, Stylize};
+use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use std::{
     borrow::Cow,
+    collections::HashMap,
     fmt::{self, Display},
+    sync::{Arc, RwLock},
 };
 
 /// The style of a piece of text.
@@ -15,11 +18,17 @@ pub(crate) struct TextStyle<C = Color> {
     flags: u8,
     pub(crate) colors: Colors<C>,
     pub(crate) size: u8,
+    /// The target of a hyperlink, if this text is a link.
+    ///
+    /// When set, the text is emitted as an OSC 8 terminal hyperlink (and an `<a href>` when
+    /// exporting to HTML), making the text itself clickable rather than showing the raw URL. The
+    /// URL is interned (see [`LinkId`]) so that this style stays cheap to copy.
+    pub(crate) link: Option<LinkId>,
 }
 
 impl<C> Default for TextStyle<C> {
     fn default() -> Self {
-        Self { flags: Default::default(), colors: Default::default(), size: 1 }
+        Self { flags: Default::default(), colors: Default::default(), size: 1, link: None }
     }
 }
 
@@ -76,6 +85,19 @@ where
         self.italics().underlined()
     }
 
+    /// Set the hyperlink target for this text.
+    ///
+    /// This turns the text into a clickable link pointing at `url`.
+    pub(crate) fn link<U: AsRef<str>>(mut self, url: U) -> Self {
+        self.link = Some(intern_link(url.as_ref()));
+        self
+    }
+
+    /// Get this style's hyperlink target, if any.
+    pub(crate) fn link_target(&self) -> Option<Arc<str>> {
+        self.link.map(resolve_link)
+    }
+
     /// Indicate this is a superscript.
     pub(crate) fn superscript(self) -> Self {
         self.add_flag(TextFormatFlags::Superscript)
@@ -120,6 +142,9 @@ where
         self.size = self.size.max(other.size);
         self.colors.background = self.colors.background.clone().or(other.colors.background.clone());
         self.colors.foreground = self.colors.foreground.clone().or(other.colors.foreground.clone());
+        if self.link.is_none() {
+            self.link = other.link;
+        }
     }
 
     /// Return a new style merged with the one passed in.
@@ -166,7 +191,7 @@ impl TextStyle<Color> {
                 TextAttribute::BackgroundColor(color) => style.on(color.into()),
             }
         }
-        let text = FontSizedStr { contents, font_size };
+        let text = FontSizedStr { contents, font_size, link_target: self.link_target() };
         StyledContent::new(style, text)
     }
 
@@ -175,7 +200,7 @@ impl TextStyle<Color> {
             background: self.colors.background.map(Into::into),
             foreground: self.colors.foreground.map(Into::into),
         };
-        TextStyle { flags: self.flags, colors, size: self.size }
+        TextStyle { flags: self.flags, colors, size: self.size, link: self.link }
     }
 
     /// Iterate all attributes in this style.
@@ -192,7 +217,7 @@ impl TextStyle<Color> {
 impl TextStyle<RawColor> {
     pub(crate) fn resolve(&self, palette: &ColorPalette) -> Result<TextStyle, UndefinedPaletteColorError> {
         let colors = self.colors.resolve(palette)?;
-        Ok(TextStyle { flags: self.flags, colors, size: self.size })
+        Ok(TextStyle { flags: self.flags, colors, size: self.size, link: self.link })
     }
 }
 
@@ -250,22 +275,69 @@ pub(crate) enum TextAttribute {
     BackgroundColor(Color),
 }
 
+/// An interned hyperlink target.
+///
+/// Links are stored in a global table and referenced by id so that [`TextStyle`] stays `Copy` and
+/// cheap to pass around while still supporting arbitrary URLs.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct LinkId(u32);
+
+static LINK_TABLE: Lazy<RwLock<LinkTable>> = Lazy::new(|| RwLock::new(LinkTable::default()));
+
+#[derive(Default)]
+struct LinkTable {
+    urls: Vec<Arc<str>>,
+    ids: HashMap<Arc<str>, LinkId>,
+}
+
+/// Intern a URL, returning a stable id. Identical URLs always map to the same id.
+fn intern_link(url: &str) -> LinkId {
+    if let Some(id) = LINK_TABLE.read().expect("link table poisoned").ids.get(url) {
+        return *id;
+    }
+    let mut table = LINK_TABLE.write().expect("link table poisoned");
+    // Re-check in case another thread inserted while we were waiting for the write lock.
+    if let Some(id) = table.ids.get(url) {
+        return *id;
+    }
+    let id = LinkId(table.urls.len() as u32);
+    let url: Arc<str> = Arc::from(url);
+    table.urls.push(url.clone());
+    table.ids.insert(url, id);
+    id
+}
+
+/// Resolve an interned link id back into its URL.
+fn resolve_link(id: LinkId) -> Arc<str> {
+    LINK_TABLE.read().expect("link table poisoned").urls[id.0 as usize].clone()
+}
+
 #[derive(Clone, Debug)]
 struct FontSizedStr<'a> {
     contents: Cow<'a, str>,
     font_size: FontSize,
+    link_target: Option<Arc<str>>,
 }
 
 impl fmt::Display for FontSizedStr<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Open an OSC 8 hyperlink so the text below is clickable. Terminals that don't support
+        // OSC 8 ignore these sequences and simply render the text as-is.
+        if let Some(url) = &self.link_target {
+            write!(f, "\x1b]8;;{url}\x1b\\")?;
+        }
         let contents = &self.contents;
         match self.font_size {
-            FontSize::Scaled(0 | 1) => write!(f, "{contents}"),
-            FontSize::Scaled(size) => write!(f, "\x1b]66;s={size};{contents}\x1b\\"),
+            FontSize::Scaled(0 | 1) => write!(f, "{contents}")?,
+            FontSize::Scaled(size) => write!(f, "\x1b]66;s={size};{contents}\x1b\\")?,
             FontSize::Fractional { numerator, denominator } => {
-                write!(f, "\x1b]66;n={numerator}:d={denominator};{contents}\x1b\\")
+                write!(f, "\x1b]66;n={numerator}:d={denominator};{contents}\x1b\\")?
             }
         }
+        if self.link_target.is_some() {
+            write!(f, "\x1b]8;;\x1b\\")?;
+        }
+        Ok(())
     }
 }
 
@@ -517,5 +589,28 @@ mod tests {
     fn iterate_attributes(#[case] style: TextStyle, #[case] expected: &[TextAttribute]) {
         let attrs: Vec<_> = style.iter_attributes().collect();
         assert_eq!(attrs, expected);
+    }
+
+    #[test]
+    fn apply_wraps_link_in_osc8() {
+        let style = TextStyle::default().link_label().link("https://example.com");
+        let rendered = style.apply("website", &Default::default()).to_string();
+        assert!(rendered.contains("\x1b]8;;https://example.com\x1b\\website"), "no OSC 8 open: {rendered:?}");
+        assert!(rendered.contains("website\x1b]8;;\x1b\\"), "no OSC 8 close: {rendered:?}");
+    }
+
+    #[test]
+    fn no_link_emits_no_osc8() {
+        let rendered = TextStyle::default().bold().apply("plain", &Default::default()).to_string();
+        assert!(!rendered.contains("\x1b]8"), "unexpected OSC 8: {rendered:?}");
+    }
+
+    #[test]
+    fn identical_urls_share_a_link_id() {
+        let a = TextStyle::<Color>::default().link("https://dup.example");
+        let b = TextStyle::<Color>::default().link("https://dup.example");
+        let c = TextStyle::<Color>::default().link("https://other.example");
+        assert_eq!(a.link, b.link);
+        assert_ne!(a.link, c.link);
     }
 }

--- a/src/markdown/text_style.rs
+++ b/src/markdown/text_style.rs
@@ -88,13 +88,18 @@ where
     /// Set the hyperlink target for this text.
     ///
     /// This turns the text into a clickable link pointing at `url`.
-    pub(crate) fn link<U: AsRef<str>>(mut self, url: U) -> Self {
-        self.link = Some(intern_link(url.as_ref()));
+    pub(crate) fn link<U: AsRef<str>>(self, url: U) -> Self {
+        self.link_with_title(url, "")
+    }
+
+    /// Set the hyperlink target for this text, along with the link's title.
+    pub(crate) fn link_with_title<U: AsRef<str>, T: AsRef<str>>(mut self, url: U, title: T) -> Self {
+        self.link = Some(intern_link(url.as_ref(), title.as_ref()));
         self
     }
 
     /// Get this style's hyperlink target, if any.
-    pub(crate) fn link_target(&self) -> Option<Arc<str>> {
+    pub(crate) fn link_target(&self) -> Option<LinkTarget> {
         self.link.map(resolve_link)
     }
 
@@ -191,7 +196,7 @@ impl TextStyle<Color> {
                 TextAttribute::BackgroundColor(color) => style.on(color.into()),
             }
         }
-        let text = FontSizedStr { contents, font_size, link_target: self.link_target() };
+        let text = FontSizedStr { contents, font_size, link_target: self.link_target().map(|target| target.url) };
         StyledContent::new(style, text)
     }
 
@@ -282,34 +287,59 @@ pub(crate) enum TextAttribute {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct LinkId(u32);
 
+/// A hyperlink target: its URL plus the link's title, if any.
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub(crate) struct LinkTarget {
+    pub(crate) url: Arc<str>,
+    pub(crate) title: Arc<str>,
+}
+
 static LINK_TABLE: Lazy<RwLock<LinkTable>> = Lazy::new(|| RwLock::new(LinkTable::default()));
 
 #[derive(Default)]
 struct LinkTable {
-    urls: Vec<Arc<str>>,
-    ids: HashMap<Arc<str>, LinkId>,
+    targets: Vec<LinkTarget>,
+    ids: HashMap<LinkTarget, LinkId>,
 }
 
-/// Intern a URL, returning a stable id. Identical URLs always map to the same id.
-fn intern_link(url: &str) -> LinkId {
-    if let Some(id) = LINK_TABLE.read().expect("link table poisoned").ids.get(url) {
-        return *id;
+/// Percent-encode any URL byte outside of the printable ASCII range.
+///
+/// URLs end up interpolated in OSC 8 escape sequences, where a raw ESC/BEL byte would terminate
+/// the sequence early and let the rest of the URL be interpreted as arbitrary terminal escape
+/// sequences. Markdown allows such bytes in link destinations (e.g. via `[label](<...>)`) so
+/// encode them, which is both safe and semantically equivalent for well-behaved consumers.
+fn sanitize_url(url: &str) -> Cow<'_, str> {
+    let is_safe = |byte: u8| (33..=126).contains(&byte);
+    if url.bytes().all(is_safe) {
+        return Cow::Borrowed(url);
     }
+    let mut sanitized = String::with_capacity(url.len());
+    for byte in url.bytes() {
+        if is_safe(byte) {
+            sanitized.push(byte as char);
+        } else {
+            sanitized.push_str(&format!("%{byte:02X}"));
+        }
+    }
+    Cow::Owned(sanitized)
+}
+
+/// Intern a link, returning a stable id. Identical links always map to the same id.
+fn intern_link(url: &str, title: &str) -> LinkId {
+    let target = LinkTarget { url: Arc::from(sanitize_url(url).as_ref()), title: Arc::from(title) };
     let mut table = LINK_TABLE.write().expect("link table poisoned");
-    // Re-check in case another thread inserted while we were waiting for the write lock.
-    if let Some(id) = table.ids.get(url) {
+    if let Some(id) = table.ids.get(&target) {
         return *id;
     }
-    let id = LinkId(table.urls.len() as u32);
-    let url: Arc<str> = Arc::from(url);
-    table.urls.push(url.clone());
-    table.ids.insert(url, id);
+    let id = LinkId(table.targets.len() as u32);
+    table.targets.push(target.clone());
+    table.ids.insert(target, id);
     id
 }
 
-/// Resolve an interned link id back into its URL.
-fn resolve_link(id: LinkId) -> Arc<str> {
-    LINK_TABLE.read().expect("link table poisoned").urls[id.0 as usize].clone()
+/// Resolve an interned link id back into its target.
+fn resolve_link(id: LinkId) -> LinkTarget {
+    LINK_TABLE.read().expect("link table poisoned").targets[id.0 as usize].clone()
 }
 
 #[derive(Clone, Debug)]
@@ -612,5 +642,27 @@ mod tests {
         let c = TextStyle::<Color>::default().link("https://other.example");
         assert_eq!(a.link, b.link);
         assert_ne!(a.link, c.link);
+    }
+
+    #[test]
+    fn url_control_bytes_are_percent_encoded() {
+        // An embedded ESC byte must not be emitted raw inside the OSC 8 sequence, as it would
+        // terminate it early and allow terminal escape sequence injection.
+        let style = TextStyle::<Color>::default().link("https://x.example/\x1b\\evil\x07 end");
+        let target = style.link_target().expect("no link");
+        assert_eq!(&*target.url, "https://x.example/%1B\\evil%07%20end");
+        let rendered = style.apply("x", &Default::default()).to_string();
+        assert!(!rendered.contains("\x1b\\evil"), "raw ESC leaked: {rendered:?}");
+    }
+
+    #[test]
+    fn link_titles_are_interned() {
+        let styled = TextStyle::<Color>::default().link_with_title("https://t.example", "My title");
+        let target = styled.link_target().expect("no link");
+        assert_eq!(&*target.url, "https://t.example");
+        assert_eq!(&*target.title, "My title");
+        // Same URL with a different title is a different link target.
+        let other = TextStyle::<Color>::default().link("https://t.example");
+        assert_ne!(styled.link, other.link);
     }
 }

--- a/src/terminal/capabilities.rs
+++ b/src/terminal/capabilities.rs
@@ -27,6 +27,7 @@ pub(crate) struct TerminalCapabilities {
     pub(crate) tmux: bool,
     pub(crate) font_size: bool,
     pub(crate) fractional_font_size: bool,
+    pub(crate) hyperlinks: bool,
 }
 
 impl TerminalCapabilities {
@@ -68,7 +69,55 @@ impl TerminalCapabilities {
 
         let mut response = response?;
         response.tmux = tmux;
+        response.hyperlinks = Self::hyperlinks_supported(|name| env::var(name).ok());
         Ok(response)
+    }
+
+    /// Whether the terminal emulator supports OSC 8 hyperlinks.
+    ///
+    /// There is no escape sequence to query hyperlink support so, like the rest of the ecosystem,
+    /// this relies on environment variable heuristics. The heuristic errs on the side of "no": a
+    /// false negative merely causes URLs to be displayed inline next to their label, whereas a
+    /// false positive would cause them to be silently dropped by the terminal.
+    fn hyperlinks_supported<F: Fn(&str) -> Option<String>>(var: F) -> bool {
+        // Allow forcing hyperlinks on/off, following the convention used by other tools.
+        if let Some(force) = var("FORCE_HYPERLINK") {
+            return !matches!(force.trim(), "" | "0");
+        }
+        // Multiplexers swallow OSC 8 sequences: GNU screen entirely, and tmux only passes them
+        // through on >= 3.4 when the outer terminal supports them, which we can't detect from in
+        // here. Note that these must be checked first since environment variables set by the
+        // terminal that hosts the multiplexer (e.g. `VTE_VERSION`) leak into its sessions.
+        if var("TMUX").is_some() || var("TERM_PROGRAM").as_deref() == Some("tmux") {
+            return false;
+        }
+        let term = var("TERM").unwrap_or_default();
+        if term == "screen" || term.starts_with("screen-") || term.starts_with("screen.") {
+            return false;
+        }
+        // Terminals that advertise themselves via $TERM.
+        if ["xterm-kitty", "alacritty", "foot", "foot-extra", "xterm-ghostty", "contour", "rio"]
+            .contains(&term.as_str())
+        {
+            return true;
+        }
+        // Terminals that advertise themselves via $TERM_PROGRAM, falling back to $LC_TERMINAL
+        // which iTerm2 propagates over ssh.
+        let program = var("TERM_PROGRAM").or_else(|| var("LC_TERMINAL")).unwrap_or_default();
+        if ["iTerm.app", "iTerm2", "WezTerm", "ghostty", "vscode", "Hyper", "mintty", "terminology", "rio", "Tabby"]
+            .contains(&program.as_str())
+        {
+            return true;
+        }
+        // VTE based terminals (GNOME terminal, xfce4-terminal, tilix, etc) support these since 0.50.
+        if var("VTE_VERSION").and_then(|version| version.parse::<u32>().ok()).is_some_and(|version| version >= 5000) {
+            return true;
+        }
+        // Konsole, Windows Terminal, DomTerm, and jetbrains IDE terminals.
+        var("KONSOLE_VERSION").is_some()
+            || var("WT_SESSION").is_some()
+            || var("DOMTERM").is_some()
+            || var("TERMINAL_EMULATOR").as_deref() == Some("JetBrains-JediTerm")
     }
 
     fn build_capabilities(ids: KittyImageIds) -> io::Result<TerminalCapabilities> {
@@ -305,5 +354,30 @@ mod tests {
         assert_eq!(capabilities.kitty_local, kitty_local);
         assert_eq!(capabilities.kitty_remote, kitty_remote);
         assert_eq!(capabilities.sixel, sixel);
+    }
+
+    #[rstest]
+    #[case::nothing(&[], false)]
+    #[case::dumb_xterm(&[("TERM", "xterm-256color")], false)]
+    #[case::apple_terminal(&[("TERM", "xterm-256color"), ("TERM_PROGRAM", "Apple_Terminal")], false)]
+    #[case::iterm(&[("TERM", "xterm-256color"), ("TERM_PROGRAM", "iTerm.app")], true)]
+    #[case::iterm_over_ssh(&[("TERM", "xterm-256color"), ("LC_TERMINAL", "iTerm2")], true)]
+    #[case::kitty(&[("TERM", "xterm-kitty")], true)]
+    #[case::alacritty(&[("TERM", "alacritty")], true)]
+    #[case::wezterm(&[("TERM_PROGRAM", "WezTerm")], true)]
+    #[case::ghostty(&[("TERM", "xterm-ghostty"), ("TERM_PROGRAM", "ghostty")], true)]
+    #[case::vte(&[("TERM", "xterm-256color"), ("VTE_VERSION", "7802")], true)]
+    #[case::old_vte(&[("TERM", "xterm-256color"), ("VTE_VERSION", "4999")], false)]
+    #[case::konsole(&[("KONSOLE_VERSION", "230800")], true)]
+    #[case::windows_terminal(&[("WT_SESSION", "some-guid")], true)]
+    #[case::jetbrains(&[("TERMINAL_EMULATOR", "JetBrains-JediTerm")], true)]
+    #[case::tmux(&[("TMUX", "/tmp/tmux-1/default,42,0"), ("TERM_PROGRAM", "tmux"), ("VTE_VERSION", "7802")], false)]
+    #[case::screen(&[("TERM", "screen-256color"), ("LC_TERMINAL", "iTerm2")], false)]
+    #[case::force_on(&[("FORCE_HYPERLINK", "1"), ("TERM", "xterm-256color")], true)]
+    #[case::force_on_beats_tmux(&[("FORCE_HYPERLINK", "1"), ("TMUX", "/tmp/tmux-1/default,42,0")], true)]
+    #[case::force_off(&[("FORCE_HYPERLINK", "0"), ("TERM_PROGRAM", "iTerm.app")], false)]
+    fn hyperlink_detection(#[case] vars: &[(&str, &str)], #[case] expected: bool) {
+        let lookup = |name: &str| vars.iter().find(|(key, _)| *key == name).map(|(_, value)| value.to_string());
+        assert_eq!(TerminalCapabilities::hyperlinks_supported(lookup), expected);
     }
 }

--- a/src/terminal/capabilities.rs
+++ b/src/terminal/capabilities.rs
@@ -69,8 +69,22 @@ impl TerminalCapabilities {
 
         let mut response = response?;
         response.tmux = tmux;
-        response.hyperlinks = Self::hyperlinks_supported(|name| env::var(name).ok());
         Ok(response)
+    }
+
+    /// Detect OSC 8 hyperlink support from the environment.
+    pub(crate) fn hyperlinks_supported_from_env() -> bool {
+        Self::hyperlinks_supported(|name| env::var(name).ok())
+    }
+
+    /// The hyperlink support override requested via `FORCE_HYPERLINK`, if any.
+    pub(crate) fn hyperlink_force_override() -> Option<bool> {
+        Self::parse_force_hyperlink(env::var("FORCE_HYPERLINK").ok())
+    }
+
+    fn parse_force_hyperlink(value: Option<String>) -> Option<bool> {
+        let value = value?;
+        Some(!matches!(value.trim().to_ascii_lowercase().as_str(), "" | "0" | "false" | "no" | "off"))
     }
 
     /// Whether the terminal emulator supports OSC 8 hyperlinks.
@@ -81,18 +95,20 @@ impl TerminalCapabilities {
     /// false positive would cause them to be silently dropped by the terminal.
     fn hyperlinks_supported<F: Fn(&str) -> Option<String>>(var: F) -> bool {
         // Allow forcing hyperlinks on/off, following the convention used by other tools.
-        if let Some(force) = var("FORCE_HYPERLINK") {
-            return !matches!(force.trim(), "" | "0");
+        if let Some(force) = Self::parse_force_hyperlink(var("FORCE_HYPERLINK")) {
+            return force;
         }
         // Multiplexers swallow OSC 8 sequences: GNU screen entirely, and tmux only passes them
         // through on >= 3.4 when the outer terminal supports them, which we can't detect from in
         // here. Note that these must be checked first since environment variables set by the
-        // terminal that hosts the multiplexer (e.g. `VTE_VERSION`) leak into its sessions.
+        // terminal that hosts the multiplexer (e.g. `VTE_VERSION`) leak into its sessions, and
+        // `TERM` must be checked too since only it survives into ssh sessions.
         if var("TMUX").is_some() || var("TERM_PROGRAM").as_deref() == Some("tmux") {
             return false;
         }
         let term = var("TERM").unwrap_or_default();
-        if term == "screen" || term.starts_with("screen-") || term.starts_with("screen.") {
+        let term_is = |name: &str, prefix: &str| term == name || term.starts_with(prefix);
+        if term_is("screen", "screen-") || term.starts_with("screen.") || term_is("tmux", "tmux-") {
             return false;
         }
         // Terminals that advertise themselves via $TERM.
@@ -373,9 +389,13 @@ mod tests {
     #[case::jetbrains(&[("TERMINAL_EMULATOR", "JetBrains-JediTerm")], true)]
     #[case::tmux(&[("TMUX", "/tmp/tmux-1/default,42,0"), ("TERM_PROGRAM", "tmux"), ("VTE_VERSION", "7802")], false)]
     #[case::screen(&[("TERM", "screen-256color"), ("LC_TERMINAL", "iTerm2")], false)]
+    #[case::ssh_from_tmux(&[("TERM", "tmux-256color"), ("LC_TERMINAL", "iTerm2")], false)]
     #[case::force_on(&[("FORCE_HYPERLINK", "1"), ("TERM", "xterm-256color")], true)]
     #[case::force_on_beats_tmux(&[("FORCE_HYPERLINK", "1"), ("TMUX", "/tmp/tmux-1/default,42,0")], true)]
     #[case::force_off(&[("FORCE_HYPERLINK", "0"), ("TERM_PROGRAM", "iTerm.app")], false)]
+    #[case::force_off_false(&[("FORCE_HYPERLINK", "false"), ("TERM_PROGRAM", "iTerm.app")], false)]
+    #[case::force_off_no(&[("FORCE_HYPERLINK", "No"), ("TERM_PROGRAM", "iTerm.app")], false)]
+    #[case::force_off_off(&[("FORCE_HYPERLINK", "off"), ("TERM_PROGRAM", "iTerm.app")], false)]
     fn hyperlink_detection(#[case] vars: &[(&str, &str)], #[case] expected: bool) {
         let lookup = |name: &str| vars.iter().find(|(key, _)| *key == name).map(|(_, value)| value.to_string());
         assert_eq!(TerminalCapabilities::hyperlinks_supported(lookup), expected);

--- a/src/terminal/emulator.rs
+++ b/src/terminal/emulator.rs
@@ -33,7 +33,15 @@ impl TerminalEmulator {
     }
 
     pub(crate) fn capabilities() -> TerminalCapabilities {
-        CAPABILITIES.get_or_init(|| TerminalCapabilities::query().unwrap_or_default()).clone()
+        CAPABILITIES
+            .get_or_init(|| {
+                let mut capabilities = TerminalCapabilities::query().unwrap_or_default();
+                // Hyperlink detection is purely environment based, so run it even if the terminal
+                // query above failed.
+                capabilities.hyperlinks = TerminalCapabilities::hyperlinks_supported_from_env();
+                capabilities
+            })
+            .clone()
     }
 
     pub(crate) fn disable_capability_detection() {


### PR DESCRIPTION
## Summary

Render markdown links as clickable terminal hyperlinks using the OSC 8 escape sequence, showing only the link's label — the same way a GitHub markdown preview renders them — instead of always printing `label (url)` inline.

Support is detected per terminal; when a terminal doesn't support OSC 8 the previous inline rendering is kept unchanged, so URLs are never lost.

## Behavior

| Context | Before | After |
|---|---|---|
| Terminal with OSC 8 support (iTerm2, kitty, WezTerm, Ghostty, Alacritty, VTE ≥ 0.50, Konsole, Windows Terminal, ...) | `label (https://url)` as plain text | `label` only, clickable via OSC 8 |
| Terminal without OSC 8 support (Apple Terminal, xterm, GNU screen, tmux, ...) | `label (https://url)` | unchanged: `label (https://url)` |
| Relative / fragment / non-http(s)/mailto destinations | `label (./notes.md)` | unchanged: rendered inline (OSC 8 leaves relative URIs unspecified, and schemes like `javascript:` must never become live links) |
| HTML / PDF export | `label (https://url)` as plain text | `label` as a real `<a href>` anchor (see below) |

## Export behavior (changed)

Exports previously rendered links as visible inline text. They now emit real anchors:

- `<a href="...">` with `target="_blank" rel="noopener"` so clicking a link doesn't unload the presentation, `style="color: inherit; text-decoration: inherit"` so anchors match the slide styling, and a `title` attribute when the markdown link has a title.
- The export's click-to-advance handler ignores clicks on anchors.
- Setting `FORCE_HYPERLINK=0` restores the previous inline `label (url)` rendering in exports, for cases where URLs must stay visible (e.g. printable handouts).

## Detection

There is no escape sequence to query OSC 8 support, so detection uses environment variable heuristics (the same approach as the `supports-hyperlinks` crate): an allowlist over `TERM`, `TERM_PROGRAM`/`LC_TERMINAL`, `VTE_VERSION`, `KONSOLE_VERSION`, `WT_SESSION`, etc. It errs on the side of "no": a false negative just keeps URLs visible inline, while a false positive would silently drop them. Multiplexers (tmux, GNU screen) are conservatively treated as unsupported, including `TERM=tmux*`/`screen*` seen over ssh. `FORCE_HYPERLINK=1`/`0` (also `false`/`no`/`off`) overrides the heuristic in both directions.

## Hardening

- Only absolute `http://`, `https://`, and `mailto:` URLs become hyperlink targets; everything else falls back to inline rendering.
- URL bytes outside printable ASCII are percent-encoded before being embedded in OSC 8 sequences, preventing terminal escape-sequence injection through crafted link destinations.
- `href`/`title` attributes in HTML exports are properly escaped (`&`, `<`, `>`, `"`).

## Implementation notes

- `TextStyle` stays `Copy`: link targets (URL + title) are interned in a global table and referenced by a `LinkId(u32)`.
- The render mode (`LinkRender::Hyperlink` vs `InlineUrl`) is decided once at startup and set process-wide, so every parsing path (slide body, footer templates, intro slide fields) renders links consistently. Labels that can't carry a hyperlink (e.g. image labels) fall back to inline rendering; inline code labels like ``[`code`](url)`` keep the link.
- Link titles are not rendered in the terminal (matching how a GitHub preview shows only the label); they're preserved as `title` attributes in HTML exports.

## Testing

- 522 unit tests pass; this PR adds coverage for parsing modes, scheme gating, label edge cases (code spans, images), OSC 8 emission, URL sanitization, HTML anchor rendering/escaping, and the detection heuristic (19 environment cases).
- End-to-end verified through a scripted pseudo-terminal (pty) that answers capability queries: an iTerm2-like environment renders OSC 8 sequences with correct targets, a plain `TERM=xterm-256color` environment renders byte-identical pre-change output, and `--export-html` output was checked for anchor attributes, scheme filtering, and the `FORCE_HYPERLINK=0` opt-out.
- Manually verified in iTerm2 and kitty (labels clickable, hidden URLs; fallback rendering in a plain-TERM environment).

## Screenshots

Test on macOS 26.4 iterm2 Build 3.6.10

<!-- drag test screenshots here: before (label (url) inline) / after (clickable label) -->

given: 
```
### Books:

* ["A Philosophy of Software Design" (2nd Ed.)](https://www.amazon.com/Philosophy-Software-Design-2nd/dp/173210221X) - John Ousterhout
* ["The Mythical Man-Month"](https://www.amazon.com/Mythical-Man-Month-Software-Engineering-Anniversary/dp/0201835959) - Frederick P. Brooks Jr.
* ["Peopleware"](https://www.amazon.com/Peopleware-Productive-Projects-Teams-3rd/dp/0321934113) - Tom DeMarco & Timothy Lister
```

before: 
<img width="1112" height="263" alt="presenterm-test-proof-issue-before" src="https://github.com/user-attachments/assets/471287e4-b870-4805-b418-2d2168763f24" />

after (clickable) : 

<img width="692" height="183" alt="presenterm-test-proof-after" src="https://github.com/user-attachments/assets/9e163901-cdd2-4bc3-8e4e-e021cfb94f4e" />


---
_🤖 On behalf of @grimmerk — generated with [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01Lo58cqwatU6v7RxxaVKqxn
