### PR TITLE
feat: load local syntaxes from bat's config directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,6 +617,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1511,6 +1517,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.17",
  "walkdir",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -1962,6 +1969,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ schemars = { version = "0.8", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 serde_json = "1.0"
-syntect = { version = "5.2", features = ["parsing", "default-themes", "regex-onig", "plist-load"], default-features = false }
+syntect = { version = "5.2", features = ["parsing", "default-themes", "regex-onig", "plist-load", "yaml-load"], default-features = false }
 socket2 = "0.6"
 strum = { version = "0.27", features = ["derive"] }
 tempfile = { version = "3.10", default-features =  false }

--- a/docs/src/features/code/highlighting.md
+++ b/docs/src/features/code/highlighting.md
@@ -75,6 +75,10 @@ Other languages that are supported are:
 
 * nushell, for which highlighting isn't supported but execution is.
 
+Besides these, any other syntax that's bundled with [bat](https://github.com/sharkdp/bat) can be used by naming it in the 
+code block, even if it's not in the list above. For example ```` ```nim ```` will use _bat_'s _Nim_ syntax. See 
+[below](#adding-highlighting-syntaxes-for-new-languages) if you'd like to use a syntax that _bat_ doesn't ship with.
+
 If there's a language that is not in this list and you would like it to be supported, please [create an 
 issue](https://github.com/mfontanini/presenterm/issues/new). If you'd also like code execution support, provide details 
 on how to compile (if necessary) and run snippets for that language. You can also configure how to run code snippet for 
@@ -173,16 +177,31 @@ languages supported by _bat_ natively can be added to _presenterm_ easily. Pleas
 [this](https://github.com/mfontanini/presenterm/pull/385) as a reference to submit a pull request to make a syntax 
 officially supported by _presenterm_ as well.
 
-If a language isn't natively supported by _bat_ but you'd like to use it, you can follow
-[this guide in the bat docs](https://github.com/sharkdp/bat#adding-new-syntaxes--language-definitions) and
-invoke _bat_ directly in a presentation:
+If a language isn't natively supported by _bat_ but you'd like to use it, drop the syntax definition for it in _bat_'s 
+syntaxes directory and _presenterm_ will load it on startup, in addition to the ones it ships with:
+
+```bash
+mkdir -p "$(bat --config-dir)/syntaxes"
+cp /path/to/MyLanguage.sublime-syntax "$(bat --config-dir)/syntaxes"
+```
+
+Syntax definitions must be [Sublime Text](https://www.sublimetext.com/docs/syntax.html) `.sublime-syntax` files and are 
+looked up recursively, so you can organize them in subdirectories or check out entire repositories in there. See
+[this guide in the bat docs](https://github.com/sharkdp/bat#adding-new-syntaxes--language-definitions) for pointers on 
+where to find syntax definitions. Note that unlike _bat_, _presenterm_ reads these files directly so there's no need to 
+run `bat cache --build` after adding one.
+
+Once a syntax is in there, use its name or any of the file extensions it claims as the language in a code block:
 
 ~~~markdown
-```bash +exec_replace
-bat --color always script.py
+```mylanguage
+this will be highlighted using MyLanguage.sublime-syntax
 ```
 ~~~
 
+Locally installed syntaxes take precedence over the bundled ones, so you can also use this to override the syntax used 
+for any of the languages listed above.
+
 > [!note]
-> Check the [code execution docs](execution.md#executing-and-replacing) for more details on how to allow the tool to run 
-> `exec_replace` blocks.
+> _presenterm_ looks up _bat_'s config directory the same way _bat_ does: `$BAT_CONFIG_DIR` if set, otherwise
+> `$XDG_CONFIG_HOME/bat`, defaulting to `~/.config/bat`. Run `bat --config-dir` to see which one it is on your system.

--- a/src/code/highlighting.rs
+++ b/src/code/highlighting.rs
@@ -9,18 +9,63 @@ use crate::{
 use flate2::read::ZlibDecoder;
 use once_cell::sync::Lazy;
 use serde::Deserialize;
-use std::{cell::RefCell, collections::BTreeMap, fs, path::Path, rc::Rc};
+use std::{cell::RefCell, collections::BTreeMap, fs, path::Path, rc::Rc, sync::OnceLock};
 use syntect::{
     LoadingError,
     easy::HighlightLines,
     highlighting::{Style, Theme, ThemeSet},
-    parsing::SyntaxSet,
+    parsing::{SyntaxReference, SyntaxSet},
 };
 
-static SYNTAX_SET: Lazy<SyntaxSet> = Lazy::new(|| {
+static SYNTAX_SET: OnceLock<SyntaxSet> = OnceLock::new();
+
+/// The syntaxes that are used to highlight code snippets.
+///
+/// Unless [register_syntaxes_from_directory] was called beforehand, this only contains the
+/// syntaxes that are shipped with the binary.
+fn syntax_set() -> &'static SyntaxSet {
+    SYNTAX_SET.get_or_init(bundled_syntaxes)
+}
+
+fn bundled_syntaxes() -> SyntaxSet {
     let contents = include_bytes!("../../bat/syntaxes.bin");
     bincode::deserialize(contents).expect("syntaxes are broken")
-});
+}
+
+/// Register all `.sublime-syntax` syntaxes in the given directory, in addition to the ones that are
+/// shipped with the binary.
+///
+/// Syntaxes are looked up recursively and take precedence over the bundled ones, meaning a syntax
+/// that claims an extension that's already claimed by a bundled one will be used instead of it.
+/// This is a no-op if the directory doesn't exist or contains no syntaxes.
+///
+/// This must be invoked before any code is highlighted, as otherwise the syntaxes will be ignored.
+pub fn register_syntaxes_from_directory<P: AsRef<Path>>(path: P) -> Result<(), LoadingError> {
+    let Some(syntaxes) = load_syntaxes(path)? else {
+        return Ok(());
+    };
+    // This can only fail if we already started highlighting code, in which case there's nothing we
+    // can do about it.
+    let _ = SYNTAX_SET.set(syntaxes);
+    Ok(())
+}
+
+/// Build a syntax set that contains the bundled syntaxes plus the ones in the given directory.
+///
+/// This returns `None` if there's no syntax to be loaded from that directory, as building a syntax
+/// set is not cheap and there's no point in doing it if it would be identical to the bundled one.
+fn load_syntaxes<P: AsRef<Path>>(path: P) -> Result<Option<SyntaxSet>, LoadingError> {
+    let path = path.as_ref();
+    if !fs::metadata(path).map(|metadata| metadata.is_dir()).unwrap_or(false) {
+        return Ok(None);
+    }
+    let mut builder = bundled_syntaxes().into_builder();
+    let bundled_count = builder.syntaxes().len();
+    // Snippet lines are fed to the highlighter including their trailing newline, which is also how
+    // bat builds the syntaxes we bundle.
+    builder.add_from_folder(path, /* lines_include_newline */ true)?;
+    if builder.syntaxes().len() == bundled_count { Ok(None) } else { Ok(Some(builder.build())) }
+}
 
 static BAT_THEMES: Lazy<LazyThemeSet> = Lazy::new(|| {
     let contents = include_bytes!("../../bat/themes.bin");
@@ -94,10 +139,24 @@ pub(crate) struct SnippetHighlighter {
 impl SnippetHighlighter {
     /// Create a highlighter for a specific language.
     pub(crate) fn language_highlighter(&self, language: &SnippetLanguage) -> LanguageHighlighter<'_> {
-        let extension = Self::language_extension(language);
-        let syntax = SYNTAX_SET.find_syntax_by_extension(extension).unwrap();
+        let syntax = Self::language_syntax(syntax_set(), language);
         let highlighter = HighlightLines::new(syntax, &self.theme);
         LanguageHighlighter::new(language.clone(), highlighter)
+    }
+
+    fn language_syntax<'a>(syntax_set: &'a SyntaxSet, language: &SnippetLanguage) -> &'a SyntaxReference {
+        match language {
+            // Languages we don't know about are looked up by name so that syntaxes we don't
+            // support natively, including any locally registered ones, can still be used by simply
+            // naming them in the code block.
+            SnippetLanguage::Unknown(token) => {
+                syntax_set.find_syntax_by_token(token).unwrap_or_else(|| syntax_set.find_syntax_plain_text())
+            }
+            _ => {
+                let extension = Self::language_extension(language);
+                syntax_set.find_syntax_by_extension(extension).unwrap_or_else(|| syntax_set.find_syntax_plain_text())
+            }
+        }
     }
 
     fn language_extension(language: &SnippetLanguage) -> &'static str {
@@ -207,13 +266,13 @@ impl<'a> LanguageHighlighter<'a> {
                 // Parse a fake "<?php" line if PHP code doesn't start with one so highlighting
                 // looks good.
                 if matches!(self.language, SnippetLanguage::Php) && !line.starts_with("<?php") {
-                    self.highlighter.highlight_line("<?php\n", &SYNTAX_SET).unwrap();
+                    self.highlighter.highlight_line("<?php\n", syntax_set()).unwrap();
                 }
             }
         }
         let texts: Vec<_> = self
             .highlighter
-            .highlight_line(line, &SYNTAX_SET)
+            .highlight_line(line, syntax_set())
             .unwrap()
             .into_iter()
             .map(|(style, tokens)| StyledTokens::new(style, tokens, block_style).apply_style())
@@ -283,7 +342,7 @@ mod test {
     fn language_extensions_exist() {
         for language in SnippetLanguage::iter() {
             let extension = SnippetHighlighter::language_extension(&language);
-            let syntax = SYNTAX_SET.find_syntax_by_extension(extension);
+            let syntax = syntax_set().find_syntax_by_extension(extension);
             assert!(syntax.is_some(), "extension {extension} for {language:?} not found");
         }
     }
@@ -291,6 +350,86 @@ mod test {
     #[test]
     fn default_highlighter() {
         SnippetHighlighter::default();
+    }
+
+    fn write_syntax(directory: &Path, name: &str, extension: &str) {
+        let syntax = format!(
+            r#"%YAML 1.2
+---
+name: {name}
+file_extensions: [{extension}]
+scope: source.{extension}
+contexts:
+  main:
+    - match: potato
+      scope: keyword.other
+"#
+        );
+        fs::write(directory.join(format!("{name}.sublime-syntax")), syntax).expect("writing syntax");
+    }
+
+    #[test]
+    fn load_custom_syntaxes() {
+        let directory = tempdir().expect("creating tempdir");
+        // Use a nested directory to ensure we look up syntaxes recursively.
+        let nested = directory.path().join("nested");
+        fs::create_dir(&nested).expect("creating directory");
+        write_syntax(&nested, "Potato", "potato");
+
+        let syntaxes = load_syntaxes(directory.path()).expect("loading syntaxes").expect("no syntaxes loaded");
+        assert!(syntaxes.find_syntax_by_name("Potato").is_some());
+        // Bundled syntaxes must still be there.
+        assert!(syntaxes.find_syntax_by_extension("rs").is_some());
+    }
+
+    #[test]
+    fn custom_syntaxes_take_precedence() {
+        let directory = tempdir().expect("creating tempdir");
+        write_syntax(directory.path(), "Not rust", "rs");
+
+        let syntaxes = load_syntaxes(directory.path()).expect("loading syntaxes").expect("no syntaxes loaded");
+        let syntax = SnippetHighlighter::language_syntax(&syntaxes, &SnippetLanguage::Rust);
+        assert_eq!(syntax.name, "Not rust");
+    }
+
+    #[test]
+    fn load_syntaxes_from_empty_directory() {
+        let directory = tempdir().expect("creating tempdir");
+        let syntaxes = load_syntaxes(directory.path()).expect("loading syntaxes");
+        assert!(syntaxes.is_none());
+    }
+
+    #[test]
+    fn load_syntaxes_from_missing_directory() {
+        let syntaxes =
+            load_syntaxes("/tmp/presenterm/8ee2027983915ec78acc45027d874316").expect("loading syntaxes failed");
+        assert!(syntaxes.is_none());
+    }
+
+    #[test]
+    fn load_invalid_syntax() {
+        let directory = tempdir().expect("creating tempdir");
+        fs::write(directory.path().join("potato.sublime-syntax"), "this is not a syntax").expect("writing syntax");
+        load_syntaxes(directory.path()).expect_err("loading syntaxes succeeded");
+    }
+
+    #[test]
+    fn unknown_language_syntax_lookup() {
+        let directory = tempdir().expect("creating tempdir");
+        write_syntax(directory.path(), "Potato", "potato");
+        let syntaxes = load_syntaxes(directory.path()).expect("loading syntaxes").expect("no syntaxes loaded");
+
+        let lookup = |name: &str| {
+            SnippetHighlighter::language_syntax(&syntaxes, &SnippetLanguage::Unknown(name.to_string())).name.clone()
+        };
+        // Custom syntaxes can be looked up by name and by extension.
+        assert_eq!(lookup("Potato"), "Potato");
+        assert_eq!(lookup("potato"), "Potato");
+        // As can bundled ones that we don't support natively.
+        assert_eq!(lookup("nim"), "Nim");
+        // Anything else falls back to plain text.
+        assert_eq!(lookup("something we don't know about"), "Plain Text");
+        assert_eq!(lookup(""), "Plain Text");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,8 @@
 use crate::{
-    code::{execute::SnippetExecutor, highlighting::HighlightThemeSet},
+    code::{
+        execute::SnippetExecutor,
+        highlighting::{self, HighlightThemeSet},
+    },
     commands::listener::CommandListener,
     config::{Config, ImageProtocol, ValidateOverflows},
     demo::ThemesDemo,
@@ -24,7 +27,7 @@ use crossterm::{
     execute,
     style::{PrintStyledContent, Stylize},
 };
-use directories::ProjectDirs;
+use directories::{BaseDirs, ProjectDirs};
 use export::exporter::OutputDirectory;
 use render::{engine::MaxSize, properties::WindowSize};
 use std::{
@@ -182,6 +185,7 @@ impl Customizations {
         };
         let themes_path = configs_path.join("themes");
         let themes = Self::load_themes(&themes_path)?;
+        Self::load_syntaxes()?;
         let require_config_file = config_file_path.is_some();
         let config_file_path = config_file_path.unwrap_or_else(|| configs_path.join("config.yaml"));
         let config = match Config::load(&config_file_path) {
@@ -202,6 +206,32 @@ impl Customizations {
 
         let themes = Themes { presentation: presentation_themes, highlight: highlight_themes };
         Ok(themes)
+    }
+
+    /// Load any syntaxes the user dropped in `bat`'s config directory, on top of the ones we bundle.
+    fn load_syntaxes() -> Result<(), Box<dyn std::error::Error>> {
+        let Some(bat_config_path) = Self::bat_config_path() else {
+            return Ok(());
+        };
+        highlighting::register_syntaxes_from_directory(bat_config_path.join("syntaxes"))?;
+        Ok(())
+    }
+
+    /// Find `bat`'s config directory, mimicking the way `bat --config-dir` resolves it.
+    fn bat_config_path() -> Option<PathBuf> {
+        if let Some(path) = env::var_os("BAT_CONFIG_DIR").filter(|path| !path.is_empty()) {
+            return Some(path.into());
+        }
+        // bat follows the XDG spec everywhere except on Windows, so we can't blindly use the config
+        // directory the `directories` crate hands us as that one uses macOS specific paths there.
+        if cfg!(windows) {
+            BaseDirs::new().map(|dirs| dirs.config_dir().join("bat"))
+        } else {
+            match env::var_os("XDG_CONFIG_HOME").map(PathBuf::from).filter(|path| path.is_absolute()) {
+                Some(path) => Some(path.join("bat")),
+                None => BaseDirs::new().map(|dirs| dirs.home_dir().join(".config").join("bat")),
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Any `.sublime-syntax` file under `$(bat --config-dir)/syntaxes` is now loaded on startup, in addition to the syntaxes we bundle. Syntaxes are looked up recursively and take precedence over the bundled ones, and unlike bat there's no need to run `bat cache --build` first.

Languages we don't know about are now looked up by name/extension in the syntax set rather than defaulting to plain text, which is what makes locally installed syntaxes usable. As a side effect, syntaxes bat bundles but presenterm doesn't support natively can now be used as well.